### PR TITLE
fix: Load connection file.

### DIFF
--- a/src/main/java/org/spin/base/setup/SetupLoader.java
+++ b/src/main/java/org/spin/base/setup/SetupLoader.java
@@ -1,6 +1,6 @@
 /*************************************************************************************
- * Product: ADempiere Bot                                                            *
- * Copyright (C) 2012-2019 E.R.P. Consultores y Asociados, C.A.                      *
+ * Product: ADempiere Setup Loader                                                   *
+ * Copyright (C) 2012-2023 E.R.P. Consultores y Asociados, C.A.                      *
  * Contributor(s): Yamel Senih ysenih@erpya.com                                      *
  * This program is free software: you can redistribute it and/or modify              *
  * it under the terms of the GNU General Public License as published by              *
@@ -54,12 +54,16 @@ public class SetupLoader {
 	 * @throws JsonMappingException 
 	 * @throws JsonParseException 
 	 */
-	private SetupLoader(String filePath) throws JsonParseException, JsonMappingException, IOException {
+	private SetupLoader(String filePath) throws Exception, JsonParseException, JsonMappingException, IOException {
 		File setupFile = new File(filePath);
+		if (setupFile == null || !setupFile.exists() || setupFile.isDirectory()) {
+			throw new Exception("Setup File not found");
+		}
 		ObjectMapper fileMapper = new ObjectMapper(new YAMLFactory());
 		setup = fileMapper.readValue(setupFile, SetupWrapper.class);
 	}
-	
+
+
 	/**
 	 * Verify if is loaded else throw a exception
 	 * @return
@@ -147,7 +151,8 @@ public class SetupLoader {
 	 * @throws JsonMappingException 
 	 * @throws JsonParseException 
 	 */
-	public static void loadSetup(String filePath) throws JsonParseException, JsonMappingException, IOException {
+	public static void loadSetup(String filePath) throws Exception, JsonParseException, JsonMappingException, IOException {
 		instance = new SetupLoader(filePath);
 	}
+
 }

--- a/src/main/java/org/spin/server/AllInOneServices.java
+++ b/src/main/java/org/spin/server/AllInOneServices.java
@@ -61,6 +61,9 @@ public class AllInOneServices {
 	private static final Logger logger = Logger.getLogger(AllInOneServices.class.getName());
 
 	private Server server;
+
+	private static String defaultFileConnection = "resources/standalone.yaml";
+
 	/**
 	  * Get SSL / TLS context
 	  * @return
@@ -256,11 +259,11 @@ public class AllInOneServices {
 	    }
 	  }
 
-	  /**
-	   * Main launches the server from the command line.
-	 * @throws Exception 
-	   */
-	  public static void main(String[] args) throws Exception {
+	/**
+	 * Main launches the server from the command line.
+	 * @throws Exception
+	 */
+	public static void main(String[] args) throws Exception {
 		if (args == null) {
 			throw new Exception("Arguments Not Found");
 		}
@@ -268,15 +271,18 @@ public class AllInOneServices {
 		if (args.length == 0) {
 			throw new Exception("Arguments Must Be: [property file name]");
 		}
-		  String setupFileName = args[0];
-		  if(setupFileName == null || setupFileName.trim().length() == 0) {
-			  throw new Exception("Setup File not found");
-		  }
+		String setupFileName = args[0];
+		if (setupFileName == null || setupFileName.trim().length() == 0) {
+			setupFileName = defaultFileConnection;
+			// throw new Exception("Setup File not found");
+		}
+
 		  SetupLoader.loadSetup(setupFileName);
 		  //	Validate load
 		  SetupLoader.getInstance().validateLoad();
 		  final AllInOneServices server = new AllInOneServices();
 		  server.start();
 		  server.blockUntilShutdown();
-	  }
+	}
+
 }

--- a/tools/ADempiere Backend.launch
+++ b/tools/ADempiere Backend.launch
@@ -15,6 +15,6 @@
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.spin.server.AllInOneServices"/>
     <stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="backend"/>
-    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="&quot;/opt/Development/ADempiere_Properties/ADEMPIERE.yml&quot;"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="&quot;resources/standalone.yaml&quot;"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="adempiere-grpc-server"/>
 </launchConfiguration>


### PR DESCRIPTION

- Set in the eclipse launcher the default connection file (`resources/standalone.yaml`).
- Set default connection file if argument is empty on `AllInOnseServices`.
- If the connection file is established but does not exist, throw exception on `SetupLoader`.