### PR TITLE
fix: POS Set Price List Version on Sales Order.

### DIFF
--- a/src/main/java/org/spin/grpc/service/PointOfSalesServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/PointOfSalesServiceImplementation.java
@@ -5269,7 +5269,7 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 		MPriceList priceList = MPriceList.get(Env.getCtx(), salesOrder.getM_PriceList_ID(), transactionName);
 		//
 		MPriceListVersion priceListVersion = priceList.getPriceListVersion (RecordUtil.getDate());
-		List<MProductPrice> productPrices = Arrays.asList(priceListVersion.getProductPrice("AND EXISTS("
+		List<MProductPrice> productPrices = Arrays.asList(priceListVersion.getProductPrice(" AND EXISTS("
 				+ "SELECT 1 "
 				+ "FROM C_OrderLine ol "
 				+ "WHERE ol.C_Order_ID = " + salesOrder.getC_Order_ID() + " "


### PR DESCRIPTION

```log
PointOfSalesServiceImplementation.createOrder: org.postgresql.util.PSQLException: ERROR: trailing junk after parameter at or near "$1A"
  Position: 215, SQL=SELECT AD_Client_ID,AD_Org_ID,Created,CreatedBy,IsActive,M_PriceList_Version_ID,M_ProductPrice_ID,M_Product_ID,PriceLimit,PriceList,PriceStd,UUID,Updated,UpdatedBy FROM M_ProductPrice WHERE (M_PriceList_Version_ID=?AND EXISTS(SELECT 1 FROM C_OrderLine ol WHERE ol.C_Order_ID = 1000035 AND ol.M_Product_ID = M_ProductPrice.M_Product_ID) AND EXISTS(SELECT 1 FROM C_OrderLine ol WHERE ol.C_Order_ID = 1000035 AND ol.M_Product_ID = M_ProductPrice.M_Product_ID)) [45]
```

fixes https://github.com/solop-develop/frontend-core/issues/961


Adempiere related changes to fixes https://github.com/adempiere/adempiere/pull/4094

