### PR TITLE
fix: Unused import on bank statement march proto.

### DIFF
--- a/src/main/proto/bank_statement_match.proto
+++ b/src/main/proto/bank_statement_match.proto
@@ -20,7 +20,6 @@ option java_outer_classname = "ADempiereBankStatementMatch";
 
 import "base_data_type.proto";
 import "business.proto";
-import "core_functionality.proto";
 
 package bank_statement_match;
 


### PR DESCRIPTION
The import `core_functionality.proto` is unused on `src/main/proto/bank_statement_match.proto` file.