### PR TITLE
fix: CI with github action.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,7 +87,7 @@ jobs:
   publish-to-maven:
     name: Publish to Maven Repository
     needs:
-      - check-docker-secrets
+      - check-maven-secrets
     # Skip step based on secret
     if: needs.check-maven-secrets.outputs.is_have_secrets == 'true'
     runs-on: ubuntu-latest


### PR DESCRIPTION
el paso `Publish to Maven Repository` depende del paso `Check if docker hub registry information was set on secrets` cuando de `Check if maven registry information was set on secrets`.


![publish-maven](https://user-images.githubusercontent.com/20288327/233226999-38a67331-6cb5-4cbd-8077-77eaaf96813e.png)
