### PR TITLE
feat: CI/CD Update GitHub actions docker build.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -204,7 +204,7 @@ jobs:
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Push alpine image in Docker Hub
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: docker/alpine.Dockerfile


### PR DESCRIPTION
Update `Publish Project` workflow, github action `docker/build-push-action` from v2 to v4, to remove warning in `Push docker alpine image to Docker Hub` step.



![image](https://user-images.githubusercontent.com/20288327/233413706-d7c98777-663c-4b5d-a370-d11b3a1b78f8.png)
