### PR TITLE
fix: Session Not Found before restart server.

### DIFF
--- a/src/main/java/org/spin/base/util/SessionManager.java
+++ b/src/main/java/org/spin/base/util/SessionManager.java
@@ -109,7 +109,7 @@ public class SessionManager {
 					throw new AdempiereException("@AD_User_ID@ / @AD_Role_ID@ / @AD_Org_ID@ @NotFound@");
 				}
 				Env.setContext (context, "#Date", TimeUtil.getDay(System.currentTimeMillis()));
-				Env.setContext(Env.getCtx(), "#AD_Session_ID", Integer.parseInt(claims.getBody().getId()));
+				Env.setContext(context, "#AD_Session_ID", Integer.parseInt(claims.getBody().getId()));
 				MRole role = MRole.get(context, roleId);
 				//	Warehouse / Org
 				Env.setContext (context, "#M_Warehouse_ID", warehouseId);


### PR DESCRIPTION
When the server is restarted the first request associated with a token never gets the session, however when the same request is sent again it receives a successful response because it does get the session.


#### Before this changes
```json
{
    "code": 500,
    "result": "@AD_Session_ID@ @NotFound@"
}
```


fixes https://github.com/solop-develop/frontend-core/issues/928
