### PR TITLE
fix: Show inactives Window Chart Parameters.

### DIFF
--- a/src/main/java/org/spin/grpc/service/DashboardingServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/DashboardingServiceImplementation.java
@@ -891,6 +891,7 @@ public class DashboardingServiceImplementation extends DashboardingImplBase {
 						null
 					)
 					.setParameters(windowChartAllocation.get_ValueAsInt("ECA50_WindowChart_ID"))
+					.setOnlyActiveRecords(true)
 					.list()
 					.forEach(windowChartParameter -> {
 						WindowDashboardParameter.Builder windowChartParameterBuilder = DashboardingConvertUtil.convertWindowDashboardParameter(


### PR DESCRIPTION
if the window chart parameter are deactivated, it is still considered to send them as filters in the vue client.

![imagen](https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/e9ae64c6-6052-4dd4-aa7f-0c723a4c78ac)
