### PR TITLE
fix: Default value starts with ' and ends with ".

### DIFF
--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -2520,12 +2520,14 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 		if (ReferenceUtil.validateReference(referenceId)) {
 			if(referenceId == DisplayType.List) {
 				// (') (text) (') or (") (text) (")
-				String singleQuotesPattern = "('|\")(\\w+)(\\1)";
-				Matcher matcherSingleQuotes = Pattern.compile(
+				String singleQuotesPattern = "('|\")(\\w+)('|\")";
+				// columnName = value
+				Pattern pattern = Pattern.compile(
 					singleQuotesPattern,
 					Pattern.CASE_INSENSITIVE | Pattern.DOTALL
-				)
-				.matcher(String.valueOf(defaultValueAsObject));
+				);
+				Matcher matcherSingleQuotes = pattern
+					.matcher(String.valueOf(defaultValueAsObject));
 				// remove single quotation mark 'DR' -> DR, "DR" -> DR
 				String defaultValueList = matcherSingleQuotes.replaceAll("$2");
 


### PR DESCRIPTION

![imagen](https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/9cdc3728-37a3-485c-863c-80a30eb44c5d)


#### Request
```bash
curl --location 'http://localhost:8085/api/adempiere/user-interface/window/default-value?field_uuid=8d8b5bba-fb40-11e8-a479-7a0060f0aa01&id=59390&value=%27DR%22&token=23b81174-fa45-40dc-8583-b176673f85eb&language=en&ts=1675265155138' \
--header 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIxMDAxMjk5IiwiQURfQ2xpZW50X0lEIjoxMSwiQURfT3JnX0lEIjoxMDAwMDA1LCJBRF9Sb2xlX0lEIjoxMDIsIkFEX1VzZXJfSUQiOjEwMSwiTV9XYXJlaG91c2VfSUQiOjAsIkFEX0xhbmd1YWdlIjoiZW5fVVMiLCJpYXQiOjE2ODU2Mzc0NjIsImV4cCI6MTY4NTcyMzg2Mn0.N1phU7FvJHLeTlVHClMFXMEiX3Z1fd_OBPQ2r0xzfrc'
```

#### Response

Before this changes

```log
===========> UserInterfaceServiceImplementation.getDefaultValue: null [338]
```

```json
{
    "code": 500,
    "result": ""
}
```

After this changes:

```json
{
    "code": 200,
    "result": {
        "id": 0,
        "uuid": "a459d506-fb40-11e8-a479-7a0060f0aa01",
        "attributes": [
            {
                "key": "DisplayColumn",
                "value": "Drafted"
            },
            {
                "key": "KeyColumn",
                "value": "DR"
            },
            {
                "key": "UUID",
                "value": "a459d506-fb40-11e8-a479-7a0060f0aa01"
            },
            {
                "key": "ValueColumn",
                "value": "DR"
            }
        ]
    }
}
```
