### PR TITLE
fix: Callout context, return clear empty values.

### DIFF
--- a/src/main/java/org/spin/base/util/ContextManager.java
+++ b/src/main/java/org/spin/base/util/ContextManager.java
@@ -59,21 +59,7 @@ public class ContextManager {
 
 		//	Fill context
 		attributes.entrySet().forEach(attribute -> {
-			if(attribute.getValue() instanceof Integer) {
-				Env.setContext(context, windowNo, attribute.getKey(), (Integer) attribute.getValue());
-			} else if(attribute.getValue() instanceof BigDecimal) {
-				String value = null;
-				if (attribute.getValue() != null) {
-					value = attribute.getValue().toString();
-				}
-				Env.setContext(context, windowNo, attribute.getKey(), value);
-			} else if(attribute.getValue() instanceof Timestamp) {
-				Env.setContext(context, windowNo, attribute.getKey(), (Timestamp) attribute.getValue());
-			} else if(attribute.getValue() instanceof Boolean) {
-				Env.setContext(context, windowNo, attribute.getKey(), (Boolean) attribute.getValue());
-			} else if(attribute.getValue() instanceof String) {
-				Env.setContext(context, windowNo, attribute.getKey(), (String) attribute.getValue());
-			}
+			setWindowContextByObject(context, windowNo, attribute.getKey(), attribute.getValue());
 		});
 		
 		return context;
@@ -86,7 +72,66 @@ public class ContextManager {
 		Map<String, Object> attributes = ValueUtil.convertValuesToObjects(values);
 		return setContextWithAttributes(windowNo, context, attributes, isClearWindow);
 	}
-	
+
+
+	/**
+	 * Set context on window by object value
+	 * @param windowNo
+	 * @param context
+	 * @param windowNo
+	 * @param key
+	 * @param value
+	 * @return {Properties} context with new values
+	 */
+	public static void setWindowContextByObject(Properties context, int windowNo, String key, Object value) {
+		if (value instanceof Integer) {
+			Env.setContext(context, windowNo, key, (Integer) value);
+		} else if(value instanceof BigDecimal) {
+			String currentValue = null;
+			if (value != null) {
+				currentValue = value.toString();
+			}
+			Env.setContext(context, windowNo, key, currentValue);
+		} else if(value instanceof Timestamp) {
+			Env.setContext(context, windowNo, key, (Timestamp) value);
+		} else if(value instanceof Boolean) {
+			Env.setContext(context, windowNo, key, (Boolean) value);
+		} else if(value instanceof String) {
+			Env.setContext(context, windowNo, key, (String) value);
+		}
+	}
+
+	/**
+	 * Set context on tab by object value
+	 * @param windowNo
+	 * @param context
+	 * @param windowNo
+	 * @param tabNo
+	 * @param key
+	 * @param value
+	 * @return {Properties} context with new values
+	 */
+	public static void setTabContextByObject(Properties context, int windowNo, int tabNo, String key, Object value) {
+		if (value instanceof Integer) {
+			Integer currentValue = (Integer) value;
+			Env.setContext(context, windowNo, tabNo, key, currentValue.toString());
+		} else if(value instanceof BigDecimal) {
+			String currentValue = null;
+			if (value != null) {
+				currentValue = value.toString();
+			}
+			Env.setContext(context, windowNo, tabNo, key, currentValue);
+		} else if(value instanceof Timestamp) {
+			Timestamp currentValue = (Timestamp) value;
+			Env.setContext(context, windowNo, tabNo, key, currentValue.toString());
+		} else if(value instanceof Boolean) {
+			Env.setContext(context, windowNo, tabNo, key, (Boolean) value);
+		} else if(value instanceof String) {
+			Env.setContext(context, windowNo, tabNo, key, (String) value);
+		}
+	}
+
+
 	/**
 	 * Get Default Country
 	 * @return

--- a/src/main/java/org/spin/base/util/ContextManager.java
+++ b/src/main/java/org/spin/base/util/ContextManager.java
@@ -61,7 +61,7 @@ public class ContextManager {
 		attributes.entrySet().forEach(attribute -> {
 			setWindowContextByObject(context, windowNo, attribute.getKey(), attribute.getValue());
 		});
-		
+
 		return context;
 	}
 
@@ -86,17 +86,17 @@ public class ContextManager {
 	public static void setWindowContextByObject(Properties context, int windowNo, String key, Object value) {
 		if (value instanceof Integer) {
 			Env.setContext(context, windowNo, key, (Integer) value);
-		} else if(value instanceof BigDecimal) {
+		} else if (value instanceof BigDecimal) {
 			String currentValue = null;
 			if (value != null) {
 				currentValue = value.toString();
 			}
 			Env.setContext(context, windowNo, key, currentValue);
-		} else if(value instanceof Timestamp) {
+		} else if (value instanceof Timestamp) {
 			Env.setContext(context, windowNo, key, (Timestamp) value);
-		} else if(value instanceof Boolean) {
+		} else if (value instanceof Boolean) {
 			Env.setContext(context, windowNo, key, (Boolean) value);
-		} else if(value instanceof String) {
+		} else if (value instanceof String) {
 			Env.setContext(context, windowNo, key, (String) value);
 		}
 	}
@@ -115,18 +115,18 @@ public class ContextManager {
 		if (value instanceof Integer) {
 			Integer currentValue = (Integer) value;
 			Env.setContext(context, windowNo, tabNo, key, currentValue.toString());
-		} else if(value instanceof BigDecimal) {
+		}else if (value instanceof BigDecimal) {
 			String currentValue = null;
 			if (value != null) {
 				currentValue = value.toString();
 			}
 			Env.setContext(context, windowNo, tabNo, key, currentValue);
-		} else if(value instanceof Timestamp) {
+		} else if (value instanceof Timestamp) {
 			Timestamp currentValue = (Timestamp) value;
 			Env.setContext(context, windowNo, tabNo, key, currentValue.toString());
-		} else if(value instanceof Boolean) {
+		} else if (value instanceof Boolean) {
 			Env.setContext(context, windowNo, tabNo, key, (Boolean) value);
-		} else if(value instanceof String) {
+		} else if (value instanceof String) {
 			Env.setContext(context, windowNo, tabNo, key, (String) value);
 		}
 	}

--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -3308,7 +3308,7 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 			for (Entry<String, Object> attribute : attributes.entrySet()) {
 				gridTab.setValue(attribute.getKey(), attribute.getValue());
 			}
-			gridTab.setValue(request.getColumnName(), value.toString());
+			gridTab.setValue(request.getColumnName(), value);
 
 			//	Load value for field
 			gridField.setValue(oldValue, false);

--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -3255,6 +3255,9 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 	private org.spin.backend.grpc.common.Callout.Builder runcallout(RunCalloutRequest request) {
 		org.spin.backend.grpc.common.Callout.Builder calloutBuilder = org.spin.backend.grpc.common.Callout.newBuilder();
 		Trx.run(transactionName -> {
+			if (Util.isEmpty(request.getTabUuid(), true)) {
+				throw new AdempiereException("@FillMandatory@ @AD_Tab_ID@");
+			}
 			MTab tab = tabRequested.get(request.getTabUuid());
 			if (tab == null) {
 				tab = MTab.get(Env.getCtx(), RecordUtil.getIdFromUuid(I_AD_Tab.Table_Name, request.getTabUuid(), transactionName));
@@ -3284,6 +3287,11 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 			Map<String, Object> attributes = ValueUtil.convertValuesToObjects(request.getContextAttributesList());
 			ContextManager.setContextWithAttributes(windowNo, Env.getCtx(), attributes);
 
+			//
+			Object oldValue = ValueUtil.getObjectFromValue(request.getOldValue());
+			Object value = ValueUtil.getObjectFromValue(request.getValue());
+			ContextManager.setTabContextByObject(Env.getCtx(), windowNo, tabNo, request.getColumnName(), value);
+
 			//	Initial load for callout wrapper
 			GridWindowVO gridWindowVo = GridWindowVO.create(Env.getCtx(), windowNo, tab.getAD_Window_ID());
 			GridWindow gridWindow = new GridWindow(gridWindowVo, true);
@@ -3300,10 +3308,12 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 			for (Entry<String, Object> attribute : attributes.entrySet()) {
 				gridTab.setValue(attribute.getKey(), attribute.getValue());
 			}
+			gridTab.setValue(request.getColumnName(), value.toString());
 
 			//	Load value for field
-			gridField.setValue(ValueUtil.getObjectFromValue(request.getOldValue()), false);
-			gridField.setValue(ValueUtil.getObjectFromValue(request.getValue()), false);
+			gridField.setValue(oldValue, false);
+			gridField.setValue(value, false);
+
 			//	Run it
 			String result = processCallout(windowNo, gridTab, gridField);
 			Arrays.asList(gridTab.getFields()).stream()
@@ -3398,11 +3408,7 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 		if(gridField.isKey()) {
 			return false;
 		}
-		//	new value like null
-		if(gridField.getValue() == null
-				&& gridField.getOldValue() == null) {
-			return false;
-		}
+
 		//	validate with old value
 		if(gridField.getOldValue() != null
 				&& gridField.getValue() != null


### PR DESCRIPTION
If the column that triggers the callout is `C_BPartner_ID`, whose value is 10000, but it is sent in the context attributes `C_BPartner_ID = 5000`, in the return context it will still have the value 5000 when it should be 1000.

It also does not take into account the context that is emptied, which may be necessary for fields that depend on another for their value such as `C_BPartner_Location_ID`.

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/636
