### PR TITLE
fix: Gradle CI with base group id.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,10 @@ jobs:
 
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
+        env:
+          GITHUB_DEPLOY_USER: ${{ github.actor }}
+          GITHUB_DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+          GITHUB_DEPLOY_REPOSITORY: ${{ secrets.DEPLOY_REPOSITORY }}
         with:
           gradle-version: 8.0.2
           arguments: build

--- a/build.gradle
+++ b/build.gradle
@@ -82,11 +82,11 @@ dependencies {
 
 	// ADempiere Projects with additional features
 	// Dashboard Improvements
-	implementation "${baseGroupId}::adempiere-dashboard-improvements:1.0.7"
+	implementation "${baseGroupId}:adempiere-dashboard-improvements:1.0.7"
 	// Point Of Sales Improvements
-	implementation "${baseGroupId}::adempiere-pos-improvements:1.0.0"
+	implementation "${baseGroupId}:adempiere-pos-improvements:1.0.0"
 	// Business Processors (To Task's and Schedulers)
-	implementation "${baseGroupId}::adempiere-business-processors:1.0.5"
+	implementation "${baseGroupId}:adempiere-business-processors:1.0.5"
 }
 
 configurations.all {


### PR DESCRIPTION
![imagen](https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/d9794d78-e5c6-4c3d-a58f-c7f6902c2984)
