### PR TITLE
fix: List Tab Entities with ASP Where Clause.

### DIFF
--- a/src/main/java/org/spin/base/dictionary/DictionaryUtil.java
+++ b/src/main/java/org/spin/base/dictionary/DictionaryUtil.java
@@ -101,11 +101,15 @@ public class DictionaryUtil {
 	 */
 	public static String getWhereClauseFromTab(int tabId) {
 		MTab tab = MTab.get(Env.getCtx(), tabId);
-		if (tab == null) {
+		if (tab == null || tab.getAD_Tab_ID() <= 0) {
 			return null;
 		}
-		MTab aspTab = ASPUtil.getInstance(Env.getCtx()).getWindowTab(tab.getAD_Window_ID(), tabId);
-		if (aspTab == null) {
+		return getWhereClauseFromTab(tab.getAD_Window_ID(), tabId);
+	}
+
+	public static String getWhereClauseFromTab(int windowId, int tabId) {
+		MTab aspTab = ASPUtil.getInstance(Env.getCtx()).getWindowTab(windowId, tabId);
+		if (aspTab == null || aspTab.getAD_Tab_ID() <= 0) {
 			return null;
 		}
 		return aspTab.getWhereClause();

--- a/src/main/java/org/spin/base/util/DictionaryUtil.java
+++ b/src/main/java/org/spin/base/util/DictionaryUtil.java
@@ -437,10 +437,11 @@ public class DictionaryUtil {
 		}
 
 		StringBuffer where = new StringBuffer();
-		if (!Util.isEmpty(tab.getWhereClause(), true)) {
+		final String whereTab = org.spin.base.dictionary.DictionaryUtil.getWhereClauseFromTab(tab.getAD_Window_ID(), tabId);
+		if (!Util.isEmpty(whereTab, true)) {
 			String whereWithAlias = DictionaryUtil.getValidationCodeWithAlias(
 				table.getTableName(),
-				tab.getWhereClause()
+				whereTab
 			);
 			where.append(whereWithAlias);
 		}


### PR DESCRIPTION
If a tab has an ASP configured and a where closure was set, it was not taken into account, it only considered the where closure of the source tab.
