### PR TITLE
fix: Fill Mandatory Table on general info fields.

### DIFF
--- a/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
@@ -1802,7 +1802,7 @@ public class DictionaryServiceImplementation extends DictionaryImplBase {
 	}
 
 	private ListFieldsResponse.Builder getIdentifierFields(ListFieldsRequest request) {
-		if (request.getTableId() <= 0 ||Util.isEmpty(request.getTableUuid(), true) && Util.isEmpty(request.getTableName(), true)) {
+		if (request.getTableId() <= 0 && Util.isEmpty(request.getTableUuid(), true) && Util.isEmpty(request.getTableName(), true)) {
 			throw new AdempiereException("@FillMandatory@ @AD_Table_ID@");
 		}
 
@@ -1889,7 +1889,7 @@ public class DictionaryServiceImplementation extends DictionaryImplBase {
 	}
 
 	private ListFieldsResponse.Builder getTableSearchFields(ListFieldsRequest request) {
-		if (request.getTableId() <= 0 || Util.isEmpty(request.getTableUuid(), true)) {
+		if (request.getTableId() <= 0 && Util.isEmpty(request.getTableUuid(), true) && Util.isEmpty(request.getTableName(), true)) {
 			throw new AdempiereException("@FillMandatory@ @AD_Table_ID@");
 		}
 


### PR DESCRIPTION
Although the table name is sent, it is not considered for the `MTable` instance.


### Request

http://localhost:8085/api/adempiere/dashboard/window/exists-dashboards?tab_id=347&window_id=204&ts=1686794671262


### Response
```json
{
	"code": 500,
	"result": "Llenar campos obligatorios:  Tabla"
}
```
