### PR TITLE
feat: Change `getWhereClauseFromCriteria` and remove duplicated `convertOperator`.

### DIFF
--- a/src/main/java/org/spin/base/db/OperatorUtil.java
+++ b/src/main/java/org/spin/base/db/OperatorUtil.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License                *
  * along with this program. If not, see <https://www.gnu.org/licenses/>.            *
  ************************************************************************************/
-package org.spin.base.util;
+package org.spin.base.db;
 
 import org.compiere.model.MQuery;
 import org.compiere.util.DisplayType;
@@ -21,7 +21,7 @@ import org.spin.backend.grpc.common.Operator;
 import org.spin.backend.grpc.common.Value.ValueType;
 
 /**
- * Class for handle Operators
+ * Class for handle SQL Operators
  * @author Edwin Betancourt, EdwinBetanc0urt@outlook.com, https://github.com/EdwinBetanc0urt
  */
 public class OperatorUtil {
@@ -82,7 +82,7 @@ public class OperatorUtil {
 			}
 		return operator;
 	}
-	
+
 	/**
 	 * Get default operator by display type
 	 * @param displayTypeId

--- a/src/main/java/org/spin/base/db/WhereUtil.java
+++ b/src/main/java/org/spin/base/db/WhereUtil.java
@@ -12,17 +12,19 @@
  * You should have received a copy of the GNU General Public License                *
  * along with this program. If not, see <https://www.gnu.org/licenses/>.            *
  ************************************************************************************/
-package org.spin.base.util;
+package org.spin.base.db;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.MBrowse;
 import org.adempiere.model.MBrowseField;
 import org.adempiere.model.MView;
 import org.adempiere.model.MViewColumn;
+import org.compiere.model.MTable;
 import org.compiere.util.DisplayType;
 import org.compiere.util.Env;
 import org.compiere.util.Util;
@@ -30,13 +32,14 @@ import org.spin.backend.grpc.common.Criteria;
 import org.spin.backend.grpc.common.KeyValue;
 import org.spin.backend.grpc.common.Operator;
 import org.spin.backend.grpc.common.Value;
+import org.spin.base.util.ValueUtil;
 import org.spin.util.ASPUtil;
 
 /**
- * Class for handle SQL Queries
+ * Class for handle SQL Where Clause
  * @author Edwin Betancourt, EdwinBetanc0urt@outlook.com, https://github.com/EdwinBetanc0urt
  */
-public class QueryUtil {
+public class WhereUtil {
 
 	/**
 	 * Get sql restriction by operator
@@ -64,7 +67,8 @@ public class QueryUtil {
 				if (parameterValues.length() > 0) {
 					parameterValues.append(", ");
 				}
-				parameterValues.append("?");
+				String sqlItemValue = "?";
+				parameterValues.append(sqlItemValue);
 				params.add(ValueUtil.getObjectFromValue(itemValue));
 			});
 			sqlValue = "(" + parameterValues.toString() + ")";
@@ -116,6 +120,69 @@ public class QueryUtil {
 
 		return rescriction;
 	}
+
+
+
+	/**
+	 * Get Where Clause from criteria and dynamic condition
+	 * @param criteria
+	 * @param params
+	 * @return
+	 */
+	public static String getWhereClauseFromCriteria(Criteria criteria, List<Object> params) {
+		return getWhereClauseFromCriteria(criteria, null, params);
+	}
+
+	/**
+	 * Get Where Clause from criteria and dynamic condition
+	 * @param criteria
+	 * @param tableName optional table name
+	 * @param params
+	 * @return
+	 */
+	public static String getWhereClauseFromCriteria(Criteria criteria, String tableName, List<Object> params) {
+		StringBuffer whereClause = new StringBuffer();
+		if (!Util.isEmpty(criteria.getWhereClause(), true)) {
+			whereClause.append("(").append(criteria.getWhereClause()).append(")");
+		}
+		if (Util.isEmpty(tableName, true)) {
+			tableName = criteria.getTableName();
+		}
+		final MTable table = MTable.get(Env.getCtx(), tableName);
+		//	Validate
+		if (table == null || table.getAD_Table_ID() <= 0) {
+			throw new AdempiereException("@AD_Table_ID@ @NotFound@");
+		}
+		criteria.getConditionsList().stream()
+			.filter(condition -> !Util.isEmpty(condition.getColumnName(), true))
+			.forEach(condition -> {
+				int operatorValue = condition.getOperatorValue();
+				if (whereClause.length() > 0) {
+					whereClause.append(" AND ");
+				}
+				String columnName = table.getTableName() + "." + condition.getColumnName();
+				if (operatorValue < 0 || operatorValue == Operator.VOID_VALUE) {
+					operatorValue = OperatorUtil.getDefaultOperatorByConditionValue(
+						condition
+					);
+				}
+
+				String restriction = WhereUtil.getRestrictionByOperator(
+					columnName,
+					operatorValue,
+					condition.getValue(),
+					condition.getValueTo(),
+					condition.getValuesList(),
+					params
+				);
+
+				whereClause.append(restriction);
+		});
+		//	Return where clause
+		return whereClause.toString();
+	}
+
+
 
 	/**
 	 * Get Where clause for Smart Browse
@@ -305,7 +372,7 @@ public class QueryUtil {
 						);
 					}
 
-					String restriction = QueryUtil.getRestrictionByOperator(
+					String restriction = WhereUtil.getRestrictionByOperator(
 						columnName,
 						operatorValue,
 						condition.getValue(),
@@ -392,7 +459,7 @@ public class QueryUtil {
 						);
 					}
 
-					String restriction = QueryUtil.getRestrictionByOperator(
+					String restriction = WhereUtil.getRestrictionByOperator(
 						columnName,
 						operatorValue,
 						condition.getValue(),

--- a/src/main/java/org/spin/base/db/WhereUtil.java
+++ b/src/main/java/org/spin/base/db/WhereUtil.java
@@ -355,34 +355,34 @@ public class WhereUtil {
 		}
 
 		criteria.getConditionsList().stream()
-				.filter(condition -> !Util.isEmpty(condition.getColumnName(), true))
-				.forEach(condition -> {
-					MBrowseField browseField = browseFields.get(condition.getColumnName());
-					MViewColumn viewColumn = browseField.getAD_View_Column();
+			.filter(condition -> !Util.isEmpty(condition.getColumnName(), true))
+			.forEach(condition -> {
+				MBrowseField browseField = browseFields.get(condition.getColumnName());
+				MViewColumn viewColumn = browseField.getAD_View_Column();
 
-					int operatorValue = condition.getOperatorValue();
-					if (whereClause.length() > 0) {
-						whereClause.append(" AND ");
-					}
+				int operatorValue = condition.getOperatorValue();
+				if (whereClause.length() > 0) {
+					whereClause.append(" AND ");
+				}
 
-					String columnName = viewColumn.getColumnSQL();
-					if (operatorValue < 0 || operatorValue == Operator.VOID_VALUE) {
-						operatorValue = OperatorUtil.getDefaultOperatorByConditionValue(
-							condition
-						);
-					}
-
-					String restriction = WhereUtil.getRestrictionByOperator(
-						columnName,
-						operatorValue,
-						condition.getValue(),
-						condition.getValueTo(),
-						condition.getValuesList(),
-						filterValues
+				String columnName = viewColumn.getColumnSQL();
+				if (operatorValue < 0 || operatorValue == Operator.VOID_VALUE) {
+					operatorValue = OperatorUtil.getDefaultOperatorByConditionValue(
+						condition
 					);
+				}
 
-					whereClause.append(restriction);
-				});
+				String restriction = WhereUtil.getRestrictionByOperator(
+					columnName,
+					operatorValue,
+					condition.getValue(),
+					condition.getValueTo(),
+					condition.getValuesList(),
+					filterValues
+				);
+
+				whereClause.append(restriction);
+			});
 
 		return whereClause.toString();
 	}
@@ -440,36 +440,36 @@ public class WhereUtil {
 		}
 
 		criteria.getConditionsList().stream()
-				.filter(condition -> !Util.isEmpty(condition.getColumnName(), true))
-				.forEach(condition -> {
-					MViewColumn viewColumn = viewColummns.get(condition.getColumnName());
-					if (viewColumn == null || viewColumn.getAD_View_Column_ID() <= 0) {
-						return;
-					}
+			.filter(condition -> !Util.isEmpty(condition.getColumnName(), true))
+			.forEach(condition -> {
+				MViewColumn viewColumn = viewColummns.get(condition.getColumnName());
+				if (viewColumn == null || viewColumn.getAD_View_Column_ID() <= 0) {
+					return;
+				}
 
-					int operatorValue = condition.getOperatorValue();
-					if (whereClause.length() > 0) {
-						whereClause.append(" AND ");
-					}
+				int operatorValue = condition.getOperatorValue();
+				if (whereClause.length() > 0) {
+					whereClause.append(" AND ");
+				}
 
-					String columnName = viewColumn.getColumnSQL();
-					if (operatorValue < 0 || operatorValue == Operator.VOID_VALUE) {
-						operatorValue = OperatorUtil.getDefaultOperatorByConditionValue(
-							condition
-						);
-					}
-
-					String restriction = WhereUtil.getRestrictionByOperator(
-						columnName,
-						operatorValue,
-						condition.getValue(),
-						condition.getValueTo(),
-						condition.getValuesList(),
-						filterValues
+				String columnName = viewColumn.getColumnSQL();
+				if (operatorValue < 0 || operatorValue == Operator.VOID_VALUE) {
+					operatorValue = OperatorUtil.getDefaultOperatorByConditionValue(
+						condition
 					);
+				}
 
-					whereClause.append(restriction);
-				});
+				String restriction = WhereUtil.getRestrictionByOperator(
+					columnName,
+					operatorValue,
+					condition.getValue(),
+					condition.getValueTo(),
+					condition.getValuesList(),
+					filterValues
+				);
+
+				whereClause.append(restriction);
+			});
 
 		return whereClause.toString();
 	}

--- a/src/main/java/org/spin/base/util/RecordUtil.java
+++ b/src/main/java/org/spin/base/util/RecordUtil.java
@@ -423,7 +423,7 @@ public class RecordUtil {
 					.append(column.getColumnName())
 					.append(")")
 					.append(" LIKE ")
-					.append("'%'|| UPPER(?) || '%'");
+					.append("'%' || UPPER(?) || '%'");
 				parameters.add(searchValue);
 			});
 

--- a/src/main/java/org/spin/grpc/service/BusinessDataServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/BusinessDataServiceImplementation.java
@@ -55,6 +55,7 @@ import org.compiere.util.Msg;
 import org.compiere.util.Trx;
 import org.compiere.util.Util;
 import org.eevolution.services.dsl.ProcessBuilder;
+import org.spin.base.db.WhereUtil;
 import org.spin.base.dictionary.DictionaryUtil;
 import org.spin.base.util.ConvertUtil;
 import org.spin.base.util.RecordUtil;
@@ -497,7 +498,7 @@ public class BusinessDataServiceImplementation extends BusinessDataImplBase {
 			entity = RecordUtil.getEntity(Env.getCtx(), tableName, request.getUuid(), request.getId(), null);
 		} else if(request.getCriteria() != null) {
 			List<Object> parameters = new ArrayList<Object>();
-			String whereClause = ValueUtil.getWhereClauseFromCriteria(request.getCriteria(), parameters);
+			String whereClause = WhereUtil.getWhereClauseFromCriteria(request.getCriteria(), parameters);
 			entity = RecordUtil.getEntity(Env.getCtx(), tableName, whereClause, parameters, null);
 		}
 		//	Return
@@ -614,7 +615,7 @@ public class BusinessDataServiceImplementation extends BusinessDataImplBase {
 		StringBuffer whereClause = new StringBuffer();
 		List<Object> params = new ArrayList<>();
 		//	For dynamic condition
-		String dynamicWhere = ValueUtil.getWhereClauseFromCriteria(criteria, params);
+		String dynamicWhere = WhereUtil.getWhereClauseFromCriteria(criteria, params);
 		if(!Util.isEmpty(dynamicWhere)) {
 			if(whereClause.length() > 0) {
 				whereClause.append(" AND ");

--- a/src/main/java/org/spin/grpc/service/BusinessPartnerServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/BusinessPartnerServiceImplementation.java
@@ -1,5 +1,5 @@
 /************************************************************************************
- * Copyright (C) 2012-2018 E.R.P. Consultores y Asociados, C.A.                     *
+ * Copyright (C) 2018-present E.R.P. Consultores y Asociados, C.A.                  *
  * Contributor(s): Edwin Betancourt, EdwinBetanc0urt@outlook.com                    *
  * This program is free software: you can redistribute it and/or modify             *
  * it under the terms of the GNU General Public License as published by             *
@@ -7,7 +7,7 @@
  * (at your option) any later version.                                              *
  * This program is distributed in the hope that it will be useful,                  *
  * but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
  * GNU General Public License for more details.                                     *
  * You should have received a copy of the GNU General Public License                *
  * along with this program. If not, see <https://www.gnu.org/licenses/>.            *
@@ -25,6 +25,7 @@ import org.compiere.model.MTable;
 import org.compiere.util.CLogger;
 import org.compiere.util.Env;
 import org.compiere.util.Util;
+import org.spin.base.db.WhereUtil;
 import org.spin.base.util.ContextManager;
 import org.spin.base.util.DictionaryUtil;
 import org.spin.base.util.RecordUtil;
@@ -113,7 +114,7 @@ public class BusinessPartnerServiceImplementation extends BusinessPartnerImplBas
 
 		//	For dynamic condition
 		List<Object> params = new ArrayList<>(); // includes on filters criteria
-		String dynamicWhere = ValueUtil.getWhereClauseFromCriteria(request.getFilters(), this.tableName, params);
+		String dynamicWhere = WhereUtil.getWhereClauseFromCriteria(request.getFilters(), this.tableName, params);
 		if (!Util.isEmpty(dynamicWhere, true)) {
 			//	Add includes first AND
 			whereClause.append(" AND ")

--- a/src/main/java/org/spin/grpc/service/CoreFunctionalityImplementation.java
+++ b/src/main/java/org/spin/grpc/service/CoreFunctionalityImplementation.java
@@ -53,6 +53,7 @@ import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
 import org.compiere.util.Trx;
 import org.compiere.util.Util;
+import org.spin.base.db.WhereUtil;
 import org.spin.base.util.ContextManager;
 import org.spin.base.util.ConvertUtil;
 import org.spin.base.util.RecordUtil;
@@ -374,7 +375,7 @@ public class CoreFunctionalityImplementation extends CoreFunctionalityImplBase {
 			parameters.add(request.getPostalCode());
 		}
 		//	
-		String criteriaWhereClause = ValueUtil.getWhereClauseFromCriteria(request.getCriteria(), I_C_BPartner.Table_Name, parameters);
+		String criteriaWhereClause = WhereUtil.getWhereClauseFromCriteria(request.getCriteria(), I_C_BPartner.Table_Name, parameters);
 		if(whereClause.length() > 0
 				&& !Util.isEmpty(criteriaWhereClause)) {
 			whereClause.append(" AND (").append(criteriaWhereClause).append(")");
@@ -631,7 +632,7 @@ public class CoreFunctionalityImplementation extends CoreFunctionalityImplBase {
 			parameters.add(request.getPostalCode());
 		}
 		//	
-		String criteriaWhereClause = ValueUtil.getWhereClauseFromCriteria(request.getCriteria(), parameters);
+		String criteriaWhereClause = WhereUtil.getWhereClauseFromCriteria(request.getCriteria(), parameters);
 		if(whereClause.length() > 0
 				&& !Util.isEmpty(criteriaWhereClause)) {
 			whereClause.append(" AND (").append(criteriaWhereClause).append(")");

--- a/src/main/java/org/spin/grpc/service/GeneralLedgerServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/GeneralLedgerServiceImplementation.java
@@ -1,5 +1,5 @@
 /************************************************************************************
- * Copyright (C) 2012-2018 E.R.P. Consultores y Asociados, C.A.                     *
+ * Copyright (C) 2018-present E.R.P. Consultores y Asociados, C.A.                  *
  * Contributor(s): Edwin Betancourt, EdwinBetanc0urt@outlook.com                    *
  * This program is free software: you can redistribute it and/or modify             *
  * it under the terms of the GNU General Public License as published by             *
@@ -38,6 +38,7 @@ import org.compiere.util.CLogger;
 import org.compiere.util.DB;
 import org.compiere.util.Env;
 import org.compiere.util.Util;
+import org.spin.base.db.WhereUtil;
 import org.spin.base.util.ContextManager;
 import org.spin.base.util.ConvertUtil;
 import org.spin.base.util.DictionaryUtil;
@@ -176,7 +177,7 @@ public class GeneralLedgerServiceImplementation extends GeneralLedgerImplBase {
 
 		//	For dynamic condition
 		List<Object> params = new ArrayList<>(); // includes on filters criteria
-		String dynamicWhere = ValueUtil.getWhereClauseFromCriteria(request.getFilters(), this.tableName, params);
+		String dynamicWhere = WhereUtil.getWhereClauseFromCriteria(request.getFilters(), this.tableName, params);
 		if (!Util.isEmpty(dynamicWhere, true)) {
 			// includes first AND
 			sqlWithRoleAccess += " AND " + dynamicWhere; 
@@ -603,7 +604,7 @@ public class GeneralLedgerServiceImplementation extends GeneralLedgerImplBase {
 
 		// For dynamic condition
 		List<Object> params = new ArrayList<>(); // includes on filters criteria
-		String dynamicWhere = ValueUtil.getWhereClauseFromCriteria(filter.build(), table.getTableName(), params);
+		String dynamicWhere = WhereUtil.getWhereClauseFromCriteria(filter.build(), table.getTableName(), params);
 		if (!Util.isEmpty(dynamicWhere, true)) {
 			//  Add includes first AND
 			whereClause.append(" AND ")

--- a/src/main/java/org/spin/grpc/service/InOutServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/InOutServiceImplementation.java
@@ -1,5 +1,5 @@
 /************************************************************************************
- * Copyright (C) 2012-2018 E.R.P. Consultores y Asociados, C.A.                     *
+ * Copyright (C) 2018-present E.R.P. Consultores y Asociados, C.A.                  *
  * Contributor(s): Edwin Betancourt, EdwinBetanc0urt@outlook.com                    *
  * This program is free software: you can redistribute it and/or modify             *
  * it under the terms of the GNU General Public License as published by             *
@@ -25,6 +25,7 @@ import org.compiere.model.MTable;
 import org.compiere.util.CLogger;
 import org.compiere.util.Env;
 import org.compiere.util.Util;
+import org.spin.base.db.WhereUtil;
 import org.spin.base.util.ContextManager;
 import org.spin.base.util.DictionaryUtil;
 import org.spin.base.util.RecordUtil;
@@ -113,7 +114,7 @@ public class InOutServiceImplementation extends InOutImplBase {
 
 		//	For dynamic condition
 		List<Object> params = new ArrayList<>(); // includes on filters criteria
-		String dynamicWhere = ValueUtil.getWhereClauseFromCriteria(request.getFilters(), this.tableName, params);
+		String dynamicWhere = WhereUtil.getWhereClauseFromCriteria(request.getFilters(), this.tableName, params);
 		if (!Util.isEmpty(dynamicWhere, true)) {
 			//	Add includes first AND
 			whereClause.append(" AND ")

--- a/src/main/java/org/spin/grpc/service/InvoiceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/InvoiceServiceImplementation.java
@@ -1,5 +1,5 @@
 /************************************************************************************
- * Copyright (C) 2012-2018 E.R.P. Consultores y Asociados, C.A.                     *
+ * Copyright (C) 2018-present E.R.P. Consultores y Asociados, C.A.                     *
  * Contributor(s): Edwin Betancourt, EdwinBetanc0urt@outlook.com                    *
  * This program is free software: you can redistribute it and/or modify             *
  * it under the terms of the GNU General Public License as published by             *
@@ -25,6 +25,7 @@ import org.compiere.model.MTable;
 import org.compiere.util.CLogger;
 import org.compiere.util.Env;
 import org.compiere.util.Util;
+import org.spin.base.db.WhereUtil;
 import org.spin.base.util.ContextManager;
 import org.spin.base.util.DictionaryUtil;
 import org.spin.base.util.RecordUtil;
@@ -113,7 +114,7 @@ public class InvoiceServiceImplementation extends InvoiceImplBase {
 
 		//	For dynamic condition
 		List<Object> params = new ArrayList<>(); // includes on filters criteria
-		String dynamicWhere = ValueUtil.getWhereClauseFromCriteria(request.getFilters(), this.tableName, params);
+		String dynamicWhere = WhereUtil.getWhereClauseFromCriteria(request.getFilters(), this.tableName, params);
 		if (!Util.isEmpty(dynamicWhere, true)) {
 			//	Add includes first AND
 			whereClause.append(" AND ")

--- a/src/main/java/org/spin/grpc/service/OrderServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/OrderServiceImplementation.java
@@ -25,6 +25,7 @@ import org.compiere.model.MTable;
 import org.compiere.util.CLogger;
 import org.compiere.util.Env;
 import org.compiere.util.Util;
+import org.spin.base.db.WhereUtil;
 import org.spin.base.util.ContextManager;
 import org.spin.base.util.DictionaryUtil;
 import org.spin.base.util.RecordUtil;
@@ -113,7 +114,7 @@ public class OrderServiceImplementation extends OrderImplBase {
 
 		//	For dynamic condition
 		List<Object> params = new ArrayList<>(); // includes on filters criteria
-		String dynamicWhere = ValueUtil.getWhereClauseFromCriteria(request.getFilters(), this.tableName, params);
+		String dynamicWhere = WhereUtil.getWhereClauseFromCriteria(request.getFilters(), this.tableName, params);
 		if (!Util.isEmpty(dynamicWhere, true)) {
 			//	Add includes first AND
 			whereClause.append(" AND ")

--- a/src/main/java/org/spin/grpc/service/PaymentServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/PaymentServiceImplementation.java
@@ -1,5 +1,5 @@
 /************************************************************************************
- * Copyright (C) 2012-2018 E.R.P. Consultores y Asociados, C.A.                     *
+ * Copyright (C) 2018-present E.R.P. Consultores y Asociados, C.A.                  *
  * Contributor(s): Edwin Betancourt, EdwinBetanc0urt@outlook.com                    *
  * This program is free software: you can redistribute it and/or modify             *
  * it under the terms of the GNU General Public License as published by             *
@@ -7,7 +7,7 @@
  * (at your option) any later version.                                              *
  * This program is distributed in the hope that it will be useful,                  *
  * but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
  * GNU General Public License for more details.                                     *
  * You should have received a copy of the GNU General Public License                *
  * along with this program. If not, see <https://www.gnu.org/licenses/>.            *
@@ -25,6 +25,7 @@ import org.compiere.model.MTable;
 import org.compiere.util.CLogger;
 import org.compiere.util.Env;
 import org.compiere.util.Util;
+import org.spin.base.db.WhereUtil;
 import org.spin.base.util.ContextManager;
 import org.spin.base.util.DictionaryUtil;
 import org.spin.base.util.RecordUtil;
@@ -113,7 +114,7 @@ public class PaymentServiceImplementation extends PaymentImplBase {
 
 		//	For dynamic condition
 		List<Object> params = new ArrayList<>(); // includes on filters criteria
-		String dynamicWhere = ValueUtil.getWhereClauseFromCriteria(request.getFilters(), this.tableName, params);
+		String dynamicWhere = WhereUtil.getWhereClauseFromCriteria(request.getFilters(), this.tableName, params);
 		if (!Util.isEmpty(dynamicWhere, true)) {
 			//	Add includes first AND
 			whereClause.append(" AND ")

--- a/src/main/java/org/spin/grpc/service/ProductServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/ProductServiceImplementation.java
@@ -25,6 +25,7 @@ import org.compiere.model.MTable;
 import org.compiere.util.CLogger;
 import org.compiere.util.Env;
 import org.compiere.util.Util;
+import org.spin.base.db.WhereUtil;
 import org.spin.base.util.ContextManager;
 import org.spin.base.util.DictionaryUtil;
 import org.spin.base.util.RecordUtil;
@@ -60,6 +61,7 @@ public class ProductServiceImplementation extends ProductImplBase {
 			responseObserver.onCompleted();
 		} catch (Exception e) {
 			log.severe(e.getLocalizedMessage());
+			e.printStackTrace();
 			responseObserver.onError(Status.INTERNAL
 				.withDescription(e.getLocalizedMessage())
 				.withCause(e)
@@ -113,7 +115,7 @@ public class ProductServiceImplementation extends ProductImplBase {
 
 		//	For dynamic condition
 		List<Object> params = new ArrayList<>(); // includes on filters criteria
-		String dynamicWhere = ValueUtil.getWhereClauseFromCriteria(request.getFilters(), this.tableName, params);
+		String dynamicWhere = WhereUtil.getWhereClauseFromCriteria(request.getFilters(), this.tableName, params);
 		if (!Util.isEmpty(dynamicWhere, true)) {
 			//	Add includes first AND
 			whereClause.append(" AND ")


### PR DESCRIPTION
- Move `src/main/java/org/spin/base/util/OperatorUtil.java` to `src/main/java/org/spin/base/db/OperatorUtil.java`

- Rename and move `src/main/java/org/spin/base/util/QueryUtil.java` to `src/main/java/org/spin/base/db/WhereUtil.java`

- Remove duplicated `convertOperator` method on `src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java` and `src/main/java/org/spin/base/util/ValueUtil.java`, by `src/main/java/org/spin/base/db/OperatorUtil.java`.

- Move `getWhereClauseFromCriteria` method from `src/main/java/org/spin/base/util/ValueUtil.java` to `src/main/java/org/spin/base/db/WhereUtil.java`.