### PR TITLE
feat: Move `getResourceFromImageId` to `FileUtil` class.

### DIFF
--- a/src/main/java/org/spin/base/util/ConvertUtil.java
+++ b/src/main/java/org/spin/base/util/ConvertUtil.java
@@ -1188,9 +1188,16 @@ public class ConvertUtil {
 				.setSubKeyLayoutUuid(ValueUtil.validateNull(RecordUtil.getUuidFromId(I_C_POSKeyLayout.Table_Name, key.getSubKeyLayout_ID())))
 				.setQuantity(ValueUtil.getDecimalFromBigDecimal(Optional.ofNullable(key.getQty()).orElse(Env.ZERO)))
 				.setProductValue(ValueUtil.validateNull(productValue))
-				.setResourceReference(FileManagementServiceImplementation.convertResourceReference(RecordUtil.getResourceFromImageId(key.getAD_Image_ID())));
+			.setResourceReference(
+				FileManagementServiceImplementation.convertResourceReference(
+					FileUtil.getResourceFromImageId(
+						key.getAD_Image_ID())
+					)
+			)
+		;
 	}
-	
+
+
 	/**
 	 * Convert Sales Representative
 	 * @param salesRepresentative

--- a/src/main/java/org/spin/base/util/FileUtil.java
+++ b/src/main/java/org/spin/base/util/FileUtil.java
@@ -57,7 +57,7 @@ public class FileUtil {
 		//	Return uuid
 		return reference.getUUID();
 	}
-	
+
 	/**
 	 * Get Attachment reference from image ID
 	 * @param imageId
@@ -77,6 +77,7 @@ public class FileUtil {
 			null
 		);
 	}
+
 
 
 	public static ByteString getByteStringByOutputStream(OutputStream outputStream) {

--- a/src/main/java/org/spin/base/util/FileUtil.java
+++ b/src/main/java/org/spin/base/util/FileUtil.java
@@ -26,6 +26,11 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import org.compiere.model.MClientInfo;
+import org.compiere.util.Env;
+import org.spin.model.MADAttachmentReference;
+import org.spin.util.AttachmentUtil;
+
 import com.google.protobuf.ByteString;
 import com.itextpdf.text.Document;
 import com.itextpdf.text.pdf.PdfContentByte;
@@ -38,6 +43,41 @@ import com.itextpdf.text.pdf.PdfWriter;
  * @author Edwin Betancourt, EdwinBetanc0urt@outlook.com, https://github.com/EdwinBetanc0urt
  */
 public class FileUtil {
+
+	/**
+	 * Get resource UUID from image id
+	 * @param imageId
+	 * @return
+	 */
+	public static String getResourceUuidFromImageId(int imageId) {
+		MADAttachmentReference reference = getResourceFromImageId(imageId);
+		if(reference == null) {
+			return null;
+		}
+		//	Return uuid
+		return reference.getUUID();
+	}
+	
+	/**
+	 * Get Attachment reference from image ID
+	 * @param imageId
+	 * @return
+	 */
+	public static MADAttachmentReference getResourceFromImageId(int imageId) {
+		int clientId = Env.getAD_Client_ID(Env.getCtx());
+		if(!AttachmentUtil.getInstance().isValidForClient(clientId)) {
+			return null;
+		}
+		//	
+		MClientInfo clientInfo = MClientInfo.get(Env.getCtx(), Env.getAD_Client_ID(Env.getCtx()));
+		return MADAttachmentReference.getByImageId(
+			Env.getCtx(),
+			clientInfo.getFileHandler_ID(),
+			imageId,
+			null
+		);
+	}
+
 
 	public static ByteString getByteStringByOutputStream(OutputStream outputStream) {
 		ByteArrayOutputStream buffer = (ByteArrayOutputStream) outputStream;

--- a/src/main/java/org/spin/base/util/RecordUtil.java
+++ b/src/main/java/org/spin/base/util/RecordUtil.java
@@ -35,7 +35,6 @@ import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.pipo.IDFinder;
 import org.adempiere.core.domains.models.I_AD_Element;
 import org.adempiere.core.domains.models.X_AD_Table;
-import org.compiere.model.MClientInfo;
 import org.compiere.model.MColumn;
 import org.compiere.model.MConversionRate;
 import org.compiere.model.MTable;
@@ -50,8 +49,6 @@ import org.compiere.util.Util;
 import org.spin.backend.grpc.common.Entity;
 import org.spin.backend.grpc.common.ListEntitiesResponse;
 import org.spin.backend.grpc.common.Value;
-import org.spin.model.MADAttachmentReference;
-import org.spin.util.AttachmentUtil;
 
 /**
  * Class for handle records utils values
@@ -283,33 +280,7 @@ public class RecordUtil {
 	}
 
 
-	/**
-	 * Get resource UUID from image id
-	 * @param imageId
-	 * @return
-	 */
-	public static String getResourceUuidFromImageId(int imageId) {
-		MADAttachmentReference reference = getResourceFromImageId(imageId);
-		if(reference == null) {
-			return null;
-		}
-		//	Return uuid
-		return reference.getUUID();
-	}
-	
-	/**
-	 * Get Attachment reference from image ID
-	 * @param imageId
-	 * @return
-	 */
-	public static MADAttachmentReference getResourceFromImageId(int imageId) {
-		if(!AttachmentUtil.getInstance().isValidForClient(Env.getAD_Client_ID(Env.getCtx()))) {
-			return null;
-		}
-		//	
-		return MADAttachmentReference.getByImageId(Env.getCtx(), MClientInfo.get(Env.getCtx(), Env.getAD_Client_ID(Env.getCtx())).getFileHandler_ID(), imageId, null);
-	}
-	
+
 	/**
 	 * Get conversion Rate from ValidFrom, Currency From, Currency To and Conversion Type
 	 * @param request

--- a/src/main/java/org/spin/grpc/service/FileManagementServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/FileManagementServiceImplementation.java
@@ -43,6 +43,7 @@ import org.spin.backend.grpc.file_management.LoadResourceRequest;
 import org.spin.backend.grpc.file_management.Resource;
 import org.spin.backend.grpc.file_management.ResourceReference;
 import org.spin.backend.grpc.file_management.SetResourceReferenceRequest;
+import org.spin.base.util.FileUtil;
 import org.spin.base.util.RecordUtil;
 import org.spin.base.util.ValueUtil;
 import org.adempiere.core.domains.models.I_AD_AttachmentReference;
@@ -180,8 +181,11 @@ public class FileManagementServiceImplementation extends FileManagementImplBase 
 	 * @return
 	 */
 	private ResourceReference.Builder getResourceReferenceFromImageId(int imageId) {
-		return convertResourceReference(RecordUtil.getResourceFromImageId(imageId));
+		return convertResourceReference(
+			FileUtil.getResourceFromImageId(imageId)
+		);
 	}
+
 
 	@Override
 	public StreamObserver<LoadResourceRequest> loadResource(StreamObserver<ResourceReference> responseObserver) {


### PR DESCRIPTION
Move `getResourceFromImageId` and `getResourceUuidFromImageId` methods, from `src/main/java/org/spin/base/util/RecordUtil.java` to `src/main/java/org/spin/base/util/FileUtil.java`