### PR TITLE
feat: Move order by methods to `OrderByUtil`.

### DIFF
--- a/src/main/java/org/spin/base/db/OrderByUtil.java
+++ b/src/main/java/org/spin/base/db/OrderByUtil.java
@@ -1,0 +1,46 @@
+package org.spin.base.db;
+
+import org.adempiere.model.MBrowse;
+import org.adempiere.model.MBrowseField;
+import org.adempiere.model.MViewColumn;
+import org.compiere.util.Env;
+import org.spin.util.ASPUtil;
+
+public class OrderByUtil {
+
+	/**
+	 * Get Order By
+	 * @param browser
+	 * @return
+	 */
+	public static String getBrowseOrderBy(MBrowse browser) {
+		StringBuilder sqlOrderBy = new StringBuilder();
+		for (MBrowseField field : ASPUtil.getInstance().getBrowseOrderByFields(browser.getAD_Browse_ID())) {
+			if (sqlOrderBy.length() > 0) {
+				sqlOrderBy.append(",");
+			}
+
+			MViewColumn viewColumn = MViewColumn.getById(Env.getCtx(), field.getAD_View_Column_ID(), null);
+			sqlOrderBy.append(viewColumn.getColumnSQL());
+		}
+		return sqlOrderBy.length() > 0 ? sqlOrderBy.toString(): "";
+	}
+	
+	/**
+	 * Get Order By Postirion for SB
+	 * @param BrowserField
+	 * @return
+	 */
+	public static int getBrowserFieldOrderByPosition(MBrowse browser, MBrowseField browserField) {
+		int colOffset = 1; // columns start with 1
+		int col = 0;
+		for (MBrowseField field : browser.getFields()) {
+			int sortBySqlNo = col + colOffset;
+			if (browserField.getAD_Browse_Field_ID() == field.getAD_Browse_Field_ID())
+				return sortBySqlNo;
+			col ++;
+		}
+		return -1;
+	}
+
+}

--- a/src/main/java/org/spin/base/util/DictionaryUtil.java
+++ b/src/main/java/org/spin/base/util/DictionaryUtil.java
@@ -526,39 +526,5 @@ public class DictionaryUtil {
 		queryToAdd.append(joinsToAdd);
 		return queryToAdd.toString();
 	}
-	
-	/**
-	 * Get Order By
-	 * @param browser
-	 * @return
-	 */
-	public static String getSQLOrderBy(MBrowse browser) {
-		StringBuilder sqlOrderBy = new StringBuilder();
-		for (MBrowseField field : ASPUtil.getInstance().getBrowseOrderByFields(browser.getAD_Browse_ID())) {
-			if (sqlOrderBy.length() > 0) {
-				sqlOrderBy.append(",");
-			}
 
-			MViewColumn viewColumn = MViewColumn.getById(Env.getCtx(), field.getAD_View_Column_ID(), null);
-			sqlOrderBy.append(viewColumn.getColumnSQL());
-		}
-		return sqlOrderBy.length() > 0 ? sqlOrderBy.toString(): "";
-	}
-	
-	/**
-	 * Get Order By Postirion for SB
-	 * @param BrowserField
-	 * @return
-	 */
-	public static int getOrderByPosition(MBrowse browser, MBrowseField BrowserField) {
-		int colOffset = 1; // columns start with 1
-		int col = 0;
-		for (MBrowseField field : browser.getFields()) {
-			int sortBySqlNo = col + colOffset;
-			if (BrowserField.getAD_Browse_Field_ID() == field.getAD_Browse_Field_ID())
-				return sortBySqlNo;
-			col ++;
-		}
-		return -1;
-	}
 }

--- a/src/main/java/org/spin/grpc/service/BankStatementMatchServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/BankStatementMatchServiceImplementation.java
@@ -22,7 +22,6 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-import java.util.logging.Level;
 
 import org.adempiere.core.domains.models.I_AD_Column;
 import org.adempiere.core.domains.models.I_AD_Ref_List;

--- a/src/main/java/org/spin/grpc/service/BusinessDataServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/BusinessDataServiceImplementation.java
@@ -670,12 +670,12 @@ public class BusinessDataServiceImplementation extends BusinessDataImplBase {
 			String parsedSQL = MRole.getDefault().addAccessSQL(sql.toString(),
 					null, MRole.SQL_FULLYQUALIFIED,
 					MRole.SQL_RO);
+
 			String orderByClause = criteria.getOrderByClause();
-			if(Util.isEmpty(orderByClause)) {
-				orderByClause = "";
-			} else {
+			if (!Util.isEmpty(orderByClause, true)) {
 				orderByClause = " ORDER BY " + orderByClause;
 			}
+
 			//	Count records
 			count = CountUtil.countRecords(parsedSQL, criteria.getTableName(), params);
 			//	Add Row Number

--- a/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
@@ -63,6 +63,7 @@ import org.compiere.util.Env;
 import org.compiere.util.Language;
 import org.compiere.util.Util;
 import org.compiere.wf.MWorkflow;
+import org.spin.base.db.OrderByUtil;
 import org.spin.base.dictionary.DictionaryConvertUtil;
 import org.spin.base.util.DictionaryUtil;
 import org.spin.base.util.RecordUtil;
@@ -792,7 +793,7 @@ public class DictionaryServiceImplementation extends DictionaryImplBase {
 			return Browser.newBuilder();
 		}
 		String query = DictionaryUtil.addQueryReferencesFromBrowser(browser);
-		String orderByClause = DictionaryUtil.getSQLOrderBy(browser);
+		String orderByClause = OrderByUtil.getBrowseOrderBy(browser);
 		Browser.Builder builder = Browser.newBuilder()
 				.setId(browser.getAD_Browse_ID())
 				.setUuid(ValueUtil.validateNull(browser.getUUID()))

--- a/src/main/java/org/spin/grpc/service/MatchPOReceiptInvoiceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/MatchPOReceiptInvoiceServiceImplementation.java
@@ -65,7 +65,6 @@ import org.spin.backend.grpc.form.match_po_receipt_invoice.Product;
 import org.spin.backend.grpc.form.match_po_receipt_invoice.MatchPORReceiptInvoiceGrpc.MatchPORReceiptInvoiceImplBase;
 import org.spin.base.db.LimitUtil;
 import org.spin.base.util.LookupUtil;
-import org.spin.base.util.RecordUtil;
 import org.spin.base.util.ReferenceUtil;
 import org.spin.base.util.SessionManager;
 import org.spin.base.util.ValueUtil;

--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -126,6 +126,7 @@ import org.compiere.util.Util;
 import org.spin.base.db.CountUtil;
 import org.spin.base.db.LimitUtil;
 import org.spin.base.db.OperatorUtil;
+import org.spin.base.db.OrderByUtil;
 import org.spin.base.db.ParameterUtil;
 import org.spin.base.db.WhereUtil;
 import org.spin.base.ui.UserInterfaceConvertUtil;
@@ -2970,7 +2971,7 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 			sqlWithRoleAccess += whereClause;
 		}
 
-		String orderByClause = DictionaryUtil.getSQLOrderBy(browser);
+		String orderByClause = OrderByUtil.getBrowseOrderBy(browser);
 		if (!Util.isEmpty(orderByClause, true)) {
 			orderByClause = " ORDER BY " + orderByClause;
 		}


### PR DESCRIPTION
Move `getBrowseOrderBy`, and `getBrowserFieldOrderByPosition` methods, from `src/main/java/org/spin/base/util/DictionaryUtil.java` to `src/main/java/org/spin/base/db/OrderByUtil.java`