### PR TITLE
feat: Move query methods to `QueryUtil` class.

### DIFF
--- a/src/main/java/org/spin/base/db/QueryUtil.java
+++ b/src/main/java/org/spin/base/db/QueryUtil.java
@@ -1,0 +1,228 @@
+package org.spin.base.db;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.adempiere.model.MBrowse;
+import org.adempiere.model.MBrowseField;
+import org.adempiere.model.MView;
+import org.adempiere.model.MViewColumn;
+import org.adempiere.model.MViewDefinition;
+import org.compiere.model.MColumn;
+import org.compiere.model.MField;
+import org.compiere.model.MTab;
+import org.compiere.model.MTable;
+import org.compiere.util.Env;
+import org.compiere.util.Language;
+import org.compiere.util.Util;
+import org.spin.base.util.LookupUtil;
+import org.spin.base.util.ReferenceInfo;
+import org.spin.base.util.ReferenceUtil;
+import org.spin.util.ASPUtil;
+
+public class QueryUtil {
+
+	/**
+	 * Add references to original query from columnsList
+	 * @param {MTable} table
+	 * @param {ArrayList<MColumn>} columns
+	 * @return
+	 */
+	public static String getQueryWithReferencesFromTable(MTable table) {
+		final String tableName = table.getTableName();
+
+		String originalQuery = "SELECT " + tableName + ".* FROM " + tableName + " AS " + tableName + " ";
+		int fromIndex = originalQuery.toUpperCase().indexOf(" FROM ");
+		StringBuffer queryToAdd = new StringBuffer(originalQuery.substring(0, fromIndex));
+		StringBuffer joinsToAdd = new StringBuffer(originalQuery.substring(fromIndex, originalQuery.length() - 1));
+		Language language = Language.getLanguage(Env.getAD_Language(Env.getCtx()));
+		List<MColumn> columnsList = table.getColumnsAsList();
+
+		for (MColumn column : columnsList) {
+			int displayTypeId = column.getAD_Reference_ID();
+
+			if (ReferenceUtil.validateReference(displayTypeId)) {
+				//	Reference Value
+				int referenceValueId = column.getAD_Reference_Value_ID();
+
+				String columnName = column.getColumnName();
+
+				//	Validation Code
+				ReferenceInfo referenceInfo = ReferenceUtil.getInstance(Env.getCtx())
+					.getReferenceInfo(
+						displayTypeId,
+						referenceValueId,
+						columnName,
+						language.getAD_Language(),
+						tableName
+					);
+				if(referenceInfo != null) {
+					queryToAdd.append(", ");
+					queryToAdd.append(referenceInfo.getDisplayValue(columnName));
+					joinsToAdd.append(referenceInfo.getJoinValue(columnName, tableName));
+				}
+			}
+		}
+		queryToAdd.append(joinsToAdd);
+		return queryToAdd.toString();
+	}
+
+
+
+	/**
+	 * Add references to original query from tab
+	 * @param originalQuery
+	 * @return
+	 */
+	public static String getQueryWithReferencesFromTab(MTab tab) {
+		MTable table = MTable.get(Env.getCtx(), tab.getAD_Table_ID());
+		final String tableName = table.getTableName();
+
+		String originalQuery = "SELECT " + tableName + ".* FROM " + tableName + " AS " + tableName + " ";
+		int fromIndex = originalQuery.toUpperCase().indexOf(" FROM ");
+		StringBuffer queryToAdd = new StringBuffer(originalQuery.substring(0, fromIndex));
+		StringBuffer joinsToAdd = new StringBuffer(originalQuery.substring(fromIndex, originalQuery.length() - 1));
+		Language language = Language.getLanguage(Env.getAD_Language(Env.getCtx()));
+		for (MField field : tab.getFields(false, null)) {
+			if (!field.isDisplayed()) {
+				// key column on table
+				if (!field.getAD_Column().isKey()) {
+					continue;
+				}
+			}
+			MColumn column = MColumn.get(Env.getCtx(), field.getAD_Column_ID());
+			String columnName = column.getColumnName();
+
+			// Add virutal column
+			String columnSQL = column.getColumnSQL();
+			if (!Util.isEmpty(columnSQL, true)) {
+				queryToAdd.append(", ")
+					.append(columnSQL)
+					.append(" AS ")
+					.append(column.getColumnName())
+				;
+			}
+
+			int displayTypeId = field.getAD_Reference_ID();
+			if (displayTypeId <= 0) {
+				displayTypeId = column.getAD_Reference_ID();
+			}
+			if (ReferenceUtil.validateReference(displayTypeId)) {
+				if (!Util.isEmpty(columnSQL, true)) {
+					StringBuffer displayColumnSQL = new StringBuffer()
+						.append(", ")
+						.append(columnSQL)
+						.append(LookupUtil.DISPLAY_COLUMN_KEY)
+						.append("_")
+						.append(column.getColumnName())
+					;
+					queryToAdd.append(displayColumnSQL);
+					continue;
+				}
+
+				//	Reference Value
+				int referenceValueId = field.getAD_Reference_Value_ID();
+				if(referenceValueId == 0) {
+					referenceValueId = column.getAD_Reference_Value_ID();
+				}
+
+				//	Validation Code
+				ReferenceInfo referenceInfo = ReferenceUtil.getInstance(
+					Env.getCtx()
+				).getReferenceInfo(
+					displayTypeId,
+					referenceValueId,
+					columnName,
+					language.getAD_Language(),
+					tableName
+				);
+				if(referenceInfo != null) {
+					queryToAdd.append(", ");
+					String displayedColumn = referenceInfo.getDisplayValue(columnName);
+					queryToAdd.append(displayedColumn);
+					String joinClause = referenceInfo.getJoinValue(columnName, tableName);
+					joinsToAdd.append(joinClause);
+				}
+			}
+		}
+		queryToAdd.append(joinsToAdd);
+		return queryToAdd.toString();
+	}
+
+
+
+	/**
+	 * Get SQL from View with a custom column as alias
+	 * @param viewId
+	 * @param columnNameForAlias
+	 * @param trxName
+	 * @return
+	 */
+	public static String getSQLFromBrowser(MBrowse browser) {
+		StringBuffer sql = new StringBuffer();
+		sql.append("SELECT DISTINCT ");
+		AtomicBoolean co = new AtomicBoolean(false);
+		ASPUtil.getInstance().getBrowseDisplayFields(browser.getAD_Browse_ID()).forEach(field -> {
+			if (co.get()) {
+				sql.append(",");
+			}
+
+			MViewColumn viewColumn = MViewColumn.getById(Env.getCtx(), field.getAD_View_Column_ID(), null);
+			if (!Util.isEmpty(viewColumn.getColumnSQL(), true)) {
+				sql.append(viewColumn.getColumnSQL());
+				co.set(true);
+			}
+
+			sql.append(" AS \"" + viewColumn.getColumnName() + "\"");
+		});
+
+		MView view = new MView(Env.getCtx(), browser.getAD_View_ID());
+		sql.append(" FROM ").append(view.getFromClause());
+		return sql.toString();
+	}
+
+	/**
+	 * Add references to original query from smart browser
+	 * @param originalQuery
+	 * @return
+	 */
+	public static String addQueryReferencesFromBrowser(MBrowse browser) {
+		String originalQuery = getSQLFromBrowser(browser);
+		int fromIndex = originalQuery.toUpperCase().indexOf(" FROM ");
+		StringBuffer queryToAdd = new StringBuffer(originalQuery.substring(0, fromIndex));
+		StringBuffer joinsToAdd = new StringBuffer(originalQuery.substring(fromIndex, originalQuery.length() - 1));
+		for (MBrowseField browseField : ASPUtil.getInstance().getBrowseDisplayFields(browser.getAD_Browse_ID())) {
+			int displayTypeId = browseField.getAD_Reference_ID();
+			if (ReferenceUtil.validateReference(displayTypeId)) {
+				//	Reference Value
+				int referenceValueId = browseField.getAD_Reference_Value_ID();
+				//	Validation Code
+
+				MViewColumn viewColumn = MViewColumn.getById(Env.getCtx(), browseField.getAD_View_Column_ID(), null);
+				MViewDefinition viewDefinition = MViewDefinition.get(Env.getCtx(), viewColumn.getAD_View_Definition_ID());
+				String tableName = viewDefinition.getTableAlias();
+
+				String columnName = browseField.getAD_Element().getColumnName();
+				if (viewColumn.getAD_Column_ID() > 0) {
+					MColumn column = MColumn.get(Env.getCtx(), viewColumn.getAD_Column_ID());
+					columnName = column.getColumnName();
+				}
+				ReferenceInfo referenceInfo = ReferenceUtil.getInstance(Env.getCtx())
+					.getReferenceInfo(
+						displayTypeId,
+						referenceValueId,
+						columnName,
+						Env.getAD_Language(Env.getCtx()), tableName
+					);
+				if(referenceInfo != null) {
+					queryToAdd.append(", ");
+					queryToAdd.append(referenceInfo.getDisplayValue(viewColumn.getColumnName()));
+					joinsToAdd.append(referenceInfo.getJoinValue(columnName, tableName));
+				}
+			}
+		}
+		queryToAdd.append(joinsToAdd);
+		return queryToAdd.toString();
+	}
+
+}

--- a/src/main/java/org/spin/base/db/QueryUtil.java
+++ b/src/main/java/org/spin/base/db/QueryUtil.java
@@ -28,7 +28,7 @@ public class QueryUtil {
 	 * @param {ArrayList<MColumn>} columns
 	 * @return
 	 */
-	public static String getQueryWithReferencesFromTable(MTable table) {
+	public static String getTableQueryWithReferences(MTable table) {
 		final String tableName = table.getTableName();
 
 		String originalQuery = "SELECT " + tableName + ".* FROM " + tableName + " AS " + tableName + " ";
@@ -74,7 +74,7 @@ public class QueryUtil {
 	 * @param originalQuery
 	 * @return
 	 */
-	public static String getQueryWithReferencesFromTab(MTab tab) {
+	public static String getTabQueryWithReferences(MTab tab) {
 		MTable table = MTable.get(Env.getCtx(), tab.getAD_Table_ID());
 		final String tableName = table.getTableName();
 
@@ -158,7 +158,7 @@ public class QueryUtil {
 	 * @param trxName
 	 * @return
 	 */
-	public static String getSQLFromBrowser(MBrowse browser) {
+	public static String getBrowserQuery(MBrowse browser) {
 		StringBuffer sql = new StringBuffer();
 		sql.append("SELECT DISTINCT ");
 		AtomicBoolean co = new AtomicBoolean(false);
@@ -186,8 +186,8 @@ public class QueryUtil {
 	 * @param originalQuery
 	 * @return
 	 */
-	public static String addQueryReferencesFromBrowser(MBrowse browser) {
-		String originalQuery = getSQLFromBrowser(browser);
+	public static String getBrowserQueryWithReferences(MBrowse browser) {
+		String originalQuery = getBrowserQuery(browser);
 		int fromIndex = originalQuery.toUpperCase().indexOf(" FROM ");
 		StringBuffer queryToAdd = new StringBuffer(originalQuery.substring(0, fromIndex));
 		StringBuffer joinsToAdd = new StringBuffer(originalQuery.substring(fromIndex, originalQuery.length() - 1));

--- a/src/main/java/org/spin/base/util/DictionaryUtil.java
+++ b/src/main/java/org/spin/base/util/DictionaryUtil.java
@@ -22,23 +22,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import org.adempiere.model.MBrowse;
-import org.adempiere.model.MBrowseField;
-import org.adempiere.model.MView;
-import org.adempiere.model.MViewColumn;
-import org.adempiere.model.MViewDefinition;
 import org.compiere.model.MColumn;
-import org.compiere.model.MField;
 import org.compiere.model.MTab;
 import org.compiere.model.MTable;
 import org.compiere.util.Env;
-import org.compiere.util.Language;
 import org.compiere.util.Util;
 import org.spin.grpc.service.DictionaryServiceImplementation;
 import org.spin.util.ASPUtil;
@@ -52,131 +44,6 @@ public class DictionaryUtil {
 	public static String ID_PREFIX = "_ID";
 	
 	public static String TRANSLATION_SUFFIX = "_Trl";
-	
-	/**
-	 * Add references to original query from tab
-	 * @param originalQuery
-	 * @return
-	 */
-	public static String getQueryWithReferencesFromTab(MTab tab) {
-		MTable table = MTable.get(Env.getCtx(), tab.getAD_Table_ID());
-		final String tableName = table.getTableName();
-
-		String originalQuery = "SELECT " + tableName + ".* FROM " + tableName + " AS " + tableName + " ";
-		int fromIndex = originalQuery.toUpperCase().indexOf(" FROM ");
-		StringBuffer queryToAdd = new StringBuffer(originalQuery.substring(0, fromIndex));
-		StringBuffer joinsToAdd = new StringBuffer(originalQuery.substring(fromIndex, originalQuery.length() - 1));
-		Language language = Language.getLanguage(Env.getAD_Language(Env.getCtx()));
-		for (MField field : tab.getFields(false, null)) {
-			if (!field.isDisplayed()) {
-				// key column on table
-				if (!field.getAD_Column().isKey()) {
-					continue;
-				}
-			}
-			MColumn column = MColumn.get(Env.getCtx(), field.getAD_Column_ID());
-			String columnName = column.getColumnName();
-
-			// Add virutal column
-			String columnSQL = column.getColumnSQL();
-			if (!Util.isEmpty(columnSQL, true)) {
-				queryToAdd.append(", ")
-					.append(columnSQL)
-					.append(" AS ")
-					.append(column.getColumnName())
-				;
-			}
-
-			int displayTypeId = field.getAD_Reference_ID();
-			if (displayTypeId <= 0) {
-				displayTypeId = column.getAD_Reference_ID();
-			}
-			if (ReferenceUtil.validateReference(displayTypeId)) {
-				if (!Util.isEmpty(columnSQL, true)) {
-					StringBuffer displayColumnSQL = new StringBuffer()
-						.append(", ")
-						.append(columnSQL)
-						.append(LookupUtil.DISPLAY_COLUMN_KEY)
-						.append("_")
-						.append(column.getColumnName())
-					;
-					queryToAdd.append(displayColumnSQL);
-					continue;
-				}
-
-				//	Reference Value
-				int referenceValueId = field.getAD_Reference_Value_ID();
-				if(referenceValueId == 0) {
-					referenceValueId = column.getAD_Reference_Value_ID();
-				}
-
-				//	Validation Code
-				ReferenceInfo referenceInfo = ReferenceUtil.getInstance(
-					Env.getCtx()
-				).getReferenceInfo(
-					displayTypeId,
-					referenceValueId,
-					columnName,
-					language.getAD_Language(),
-					tableName
-				);
-				if(referenceInfo != null) {
-					queryToAdd.append(", ");
-					String displayedColumn = referenceInfo.getDisplayValue(columnName);
-					queryToAdd.append(displayedColumn);
-					String joinClause = referenceInfo.getJoinValue(columnName, tableName);
-					joinsToAdd.append(joinClause);
-				}
-			}
-		}
-		queryToAdd.append(joinsToAdd);
-		return queryToAdd.toString();
-	}
-
-	/**
-	 * Add references to original query from columnsList
-	 * @param {MTable} table
-	 * @param {ArrayList<MColumn>} columns
-	 * @return
-	 */
-	public static String getQueryWithReferencesFromColumns(MTable table) {
-		final String tableName = table.getTableName();
-
-		String originalQuery = "SELECT " + tableName + ".* FROM " + tableName + " AS " + tableName + " ";
-		int fromIndex = originalQuery.toUpperCase().indexOf(" FROM ");
-		StringBuffer queryToAdd = new StringBuffer(originalQuery.substring(0, fromIndex));
-		StringBuffer joinsToAdd = new StringBuffer(originalQuery.substring(fromIndex, originalQuery.length() - 1));
-		Language language = Language.getLanguage(Env.getAD_Language(Env.getCtx()));
-		List<MColumn> columnsList = table.getColumnsAsList();
-
-		for (MColumn column : columnsList) {
-			int displayTypeId = column.getAD_Reference_ID();
-
-			if (ReferenceUtil.validateReference(displayTypeId)) {
-				//	Reference Value
-				int referenceValueId = column.getAD_Reference_Value_ID();
-
-				String columnName = column.getColumnName();
-
-				//	Validation Code
-				ReferenceInfo referenceInfo = ReferenceUtil.getInstance(Env.getCtx())
-					.getReferenceInfo(
-						displayTypeId,
-						referenceValueId,
-						columnName,
-						language.getAD_Language(),
-						tableName
-					);
-				if(referenceInfo != null) {
-					queryToAdd.append(", ");
-					queryToAdd.append(referenceInfo.getDisplayValue(columnName));
-					joinsToAdd.append(referenceInfo.getJoinValue(columnName, tableName));
-				}
-			}
-		}
-		queryToAdd.append(joinsToAdd);
-		return queryToAdd.toString();
-	}
 	
 	/**
 	 * Get Context column names from context
@@ -456,75 +323,6 @@ public class DictionaryUtil {
 		// joined tab where clause with generated where clause
 		where.append(" AND ").append("(").append(whereClause).append(")");
 		return where.toString();
-	}
-
-
-	/**
-	 * Get SQL from View with a custom column as alias
-	 * @param viewId
-	 * @param columnNameForAlias
-	 * @param trxName
-	 * @return
-	 */
-	public static String getSQLFromBrowser(MBrowse browser) {
-		StringBuffer sql = new StringBuffer();
-		sql.append("SELECT DISTINCT ");
-		AtomicBoolean co = new AtomicBoolean(false);
-		ASPUtil.getInstance().getBrowseDisplayFields(browser.getAD_Browse_ID()).forEach(field -> {
-			if (co.get()) {
-				sql.append(",");
-			}
-
-			MViewColumn viewColumn = MViewColumn.getById(Env.getCtx(), field.getAD_View_Column_ID(), null);
-			if (!Util.isEmpty(viewColumn.getColumnSQL(), true)) {
-				sql.append(viewColumn.getColumnSQL());
-				co.set(true);
-			}
-			
-			sql.append(" AS \"" + viewColumn.getColumnName() + "\"");
-		});
-
-		MView view = new MView(Env.getCtx(), browser.getAD_View_ID());
-		sql.append(" FROM ").append(view.getFromClause());
-		return sql.toString();
-	}
-	
-	/**
-	 * Add references to original query from smart browser
-	 * @param originalQuery
-	 * @return
-	 */
-	public static String addQueryReferencesFromBrowser(MBrowse browser) {
-		String originalQuery = getSQLFromBrowser(browser);
-		int fromIndex = originalQuery.toUpperCase().indexOf(" FROM ");
-		StringBuffer queryToAdd = new StringBuffer(originalQuery.substring(0, fromIndex));
-		StringBuffer joinsToAdd = new StringBuffer(originalQuery.substring(fromIndex, originalQuery.length() - 1));
-		for (MBrowseField browseField : ASPUtil.getInstance().getBrowseDisplayFields(browser.getAD_Browse_ID())) {
-			int displayTypeId = browseField.getAD_Reference_ID();
-			if (ReferenceUtil.validateReference(displayTypeId)) {
-				//	Reference Value
-				int referenceValueId = browseField.getAD_Reference_Value_ID();
-				//	Validation Code
-
-				MViewColumn viewColumn = MViewColumn.getById(Env.getCtx(), browseField.getAD_View_Column_ID(), null);
-				MViewDefinition viewDefinition = MViewDefinition.get(Env.getCtx(), viewColumn.getAD_View_Definition_ID());
-				String tableName = viewDefinition.getTableAlias();
-
-				String columnName = browseField.getAD_Element().getColumnName();
-				if (viewColumn.getAD_Column_ID() > 0) {
-					MColumn column = MColumn.get(Env.getCtx(), viewColumn.getAD_Column_ID());
-					columnName = column.getColumnName();
-				}
-				ReferenceInfo referenceInfo = ReferenceUtil.getInstance(Env.getCtx()).getReferenceInfo(displayTypeId, referenceValueId, columnName, Env.getAD_Language(Env.getCtx()), tableName);
-				if(referenceInfo != null) {
-					queryToAdd.append(", ");
-					queryToAdd.append(referenceInfo.getDisplayValue(viewColumn.getColumnName()));
-					joinsToAdd.append(referenceInfo.getJoinValue(columnName, tableName));
-				}
-			}
-		}
-		queryToAdd.append(joinsToAdd);
-		return queryToAdd.toString();
 	}
 
 }

--- a/src/main/java/org/spin/grpc/service/BusinessPartnerServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/BusinessPartnerServiceImplementation.java
@@ -92,7 +92,7 @@ public class BusinessPartnerServiceImplementation extends BusinessPartnerImplBas
 
 		//
 		MTable table = MTable.get(Env.getCtx(), this.tableName);
-		StringBuilder sql = new StringBuilder(QueryUtil.getQueryWithReferencesFromTable(table));
+		StringBuilder sql = new StringBuilder(QueryUtil.getTableQueryWithReferences(table));
 
 		// add where with access restriction
 		String sqlWithRoleAccess = MRole.getDefault(Env.getCtx(), false)

--- a/src/main/java/org/spin/grpc/service/BusinessPartnerServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/BusinessPartnerServiceImplementation.java
@@ -27,6 +27,7 @@ import org.compiere.util.Env;
 import org.compiere.util.Util;
 import org.spin.base.db.CountUtil;
 import org.spin.base.db.LimitUtil;
+import org.spin.base.db.QueryUtil;
 import org.spin.base.db.WhereUtil;
 import org.spin.base.util.ContextManager;
 import org.spin.base.util.DictionaryUtil;
@@ -91,7 +92,7 @@ public class BusinessPartnerServiceImplementation extends BusinessPartnerImplBas
 
 		//
 		MTable table = MTable.get(Env.getCtx(), this.tableName);
-		StringBuilder sql = new StringBuilder(DictionaryUtil.getQueryWithReferencesFromColumns(table));
+		StringBuilder sql = new StringBuilder(QueryUtil.getQueryWithReferencesFromTable(table));
 
 		// add where with access restriction
 		String sqlWithRoleAccess = MRole.getDefault(Env.getCtx(), false)

--- a/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
@@ -64,6 +64,7 @@ import org.compiere.util.Language;
 import org.compiere.util.Util;
 import org.compiere.wf.MWorkflow;
 import org.spin.base.db.OrderByUtil;
+import org.spin.base.db.QueryUtil;
 import org.spin.base.dictionary.DictionaryConvertUtil;
 import org.spin.base.util.DictionaryUtil;
 import org.spin.base.util.RecordUtil;
@@ -792,7 +793,7 @@ public class DictionaryServiceImplementation extends DictionaryImplBase {
 		if (browser == null) {
 			return Browser.newBuilder();
 		}
-		String query = DictionaryUtil.addQueryReferencesFromBrowser(browser);
+		String query = QueryUtil.addQueryReferencesFromBrowser(browser);
 		String orderByClause = OrderByUtil.getBrowseOrderBy(browser);
 		Browser.Builder builder = Browser.newBuilder()
 				.setId(browser.getAD_Browse_ID())

--- a/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
@@ -793,7 +793,7 @@ public class DictionaryServiceImplementation extends DictionaryImplBase {
 		if (browser == null) {
 			return Browser.newBuilder();
 		}
-		String query = QueryUtil.addQueryReferencesFromBrowser(browser);
+		String query = QueryUtil.getBrowserQueryWithReferences(browser);
 		String orderByClause = OrderByUtil.getBrowseOrderBy(browser);
 		Browser.Builder builder = Browser.newBuilder()
 				.setId(browser.getAD_Browse_ID())

--- a/src/main/java/org/spin/grpc/service/GeneralLedgerServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/GeneralLedgerServiceImplementation.java
@@ -40,10 +40,10 @@ import org.compiere.util.Env;
 import org.compiere.util.Util;
 import org.spin.base.db.CountUtil;
 import org.spin.base.db.LimitUtil;
+import org.spin.base.db.QueryUtil;
 import org.spin.base.db.WhereUtil;
 import org.spin.base.util.ContextManager;
 import org.spin.base.util.ConvertUtil;
-import org.spin.base.util.DictionaryUtil;
 import org.spin.base.util.RecordUtil;
 import org.spin.base.util.SessionManager;
 import org.spin.base.util.ValueUtil;
@@ -166,7 +166,7 @@ public class GeneralLedgerServiceImplementation extends GeneralLedgerImplBase {
 		ContextManager.setContextWithAttributes(windowNo, Env.getCtx(), request.getContextAttributesList());
 
 		MTable table = MTable.get(Env.getCtx(), this.tableName);
-		StringBuilder sql = new StringBuilder(DictionaryUtil.getQueryWithReferencesFromColumns(table));
+		StringBuilder sql = new StringBuilder(QueryUtil.getQueryWithReferencesFromTable(table));
 
 		// add where with access restriction
 		String sqlWithRoleAccess = MRole.getDefault()
@@ -601,7 +601,7 @@ public class GeneralLedgerServiceImplementation extends GeneralLedgerImplBase {
 		//
 		MTable table = MTable.get(Env.getCtx(), I_Fact_Acct.Table_Name);
 
-		StringBuilder sql = new StringBuilder(DictionaryUtil.getQueryWithReferencesFromColumns(table));
+		StringBuilder sql = new StringBuilder(QueryUtil.getQueryWithReferencesFromTable(table));
 		StringBuffer whereClause = new StringBuffer(" WHERE 1=1 ");
 
 		// For dynamic condition

--- a/src/main/java/org/spin/grpc/service/GeneralLedgerServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/GeneralLedgerServiceImplementation.java
@@ -166,7 +166,7 @@ public class GeneralLedgerServiceImplementation extends GeneralLedgerImplBase {
 		ContextManager.setContextWithAttributes(windowNo, Env.getCtx(), request.getContextAttributesList());
 
 		MTable table = MTable.get(Env.getCtx(), this.tableName);
-		StringBuilder sql = new StringBuilder(QueryUtil.getQueryWithReferencesFromTable(table));
+		StringBuilder sql = new StringBuilder(QueryUtil.getTableQueryWithReferences(table));
 
 		// add where with access restriction
 		String sqlWithRoleAccess = MRole.getDefault()
@@ -601,7 +601,7 @@ public class GeneralLedgerServiceImplementation extends GeneralLedgerImplBase {
 		//
 		MTable table = MTable.get(Env.getCtx(), I_Fact_Acct.Table_Name);
 
-		StringBuilder sql = new StringBuilder(QueryUtil.getQueryWithReferencesFromTable(table));
+		StringBuilder sql = new StringBuilder(QueryUtil.getTableQueryWithReferences(table));
 		StringBuffer whereClause = new StringBuffer(" WHERE 1=1 ");
 
 		// For dynamic condition

--- a/src/main/java/org/spin/grpc/service/InOutServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/InOutServiceImplementation.java
@@ -27,6 +27,7 @@ import org.compiere.util.Env;
 import org.compiere.util.Util;
 import org.spin.base.db.CountUtil;
 import org.spin.base.db.LimitUtil;
+import org.spin.base.db.QueryUtil;
 import org.spin.base.db.WhereUtil;
 import org.spin.base.util.ContextManager;
 import org.spin.base.util.DictionaryUtil;
@@ -91,7 +92,7 @@ public class InOutServiceImplementation extends InOutImplBase {
 
 		//
 		MTable table = MTable.get(Env.getCtx(), this.tableName);
-		StringBuilder sql = new StringBuilder(DictionaryUtil.getQueryWithReferencesFromColumns(table));
+		StringBuilder sql = new StringBuilder(QueryUtil.getQueryWithReferencesFromTable(table));
 
 		// add where with access restriction
 		String sqlWithRoleAccess = MRole.getDefault(Env.getCtx(), false)

--- a/src/main/java/org/spin/grpc/service/InOutServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/InOutServiceImplementation.java
@@ -92,7 +92,7 @@ public class InOutServiceImplementation extends InOutImplBase {
 
 		//
 		MTable table = MTable.get(Env.getCtx(), this.tableName);
-		StringBuilder sql = new StringBuilder(QueryUtil.getQueryWithReferencesFromTable(table));
+		StringBuilder sql = new StringBuilder(QueryUtil.getTableQueryWithReferences(table));
 
 		// add where with access restriction
 		String sqlWithRoleAccess = MRole.getDefault(Env.getCtx(), false)

--- a/src/main/java/org/spin/grpc/service/InvoiceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/InvoiceServiceImplementation.java
@@ -92,7 +92,7 @@ public class InvoiceServiceImplementation extends InvoiceImplBase {
 
 		//
 		MTable table = MTable.get(Env.getCtx(), this.tableName);
-		StringBuilder sql = new StringBuilder(QueryUtil.getQueryWithReferencesFromTable(table));
+		StringBuilder sql = new StringBuilder(QueryUtil.getTableQueryWithReferences(table));
 
 		// add where with access restriction
 		String sqlWithRoleAccess = MRole.getDefault(Env.getCtx(), false)

--- a/src/main/java/org/spin/grpc/service/InvoiceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/InvoiceServiceImplementation.java
@@ -27,6 +27,7 @@ import org.compiere.util.Env;
 import org.compiere.util.Util;
 import org.spin.base.db.CountUtil;
 import org.spin.base.db.LimitUtil;
+import org.spin.base.db.QueryUtil;
 import org.spin.base.db.WhereUtil;
 import org.spin.base.util.ContextManager;
 import org.spin.base.util.DictionaryUtil;
@@ -91,7 +92,7 @@ public class InvoiceServiceImplementation extends InvoiceImplBase {
 
 		//
 		MTable table = MTable.get(Env.getCtx(), this.tableName);
-		StringBuilder sql = new StringBuilder(DictionaryUtil.getQueryWithReferencesFromColumns(table));
+		StringBuilder sql = new StringBuilder(QueryUtil.getQueryWithReferencesFromTable(table));
 
 		// add where with access restriction
 		String sqlWithRoleAccess = MRole.getDefault(Env.getCtx(), false)

--- a/src/main/java/org/spin/grpc/service/MaterialManagementServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/MaterialManagementServiceImplementation.java
@@ -81,6 +81,7 @@ import org.spin.backend.grpc.material_management.SaveProductAttributeSetInstance
 import org.spin.backend.grpc.material_management.Warehouse;
 import org.spin.base.db.CountUtil;
 import org.spin.base.db.LimitUtil;
+import org.spin.base.db.QueryUtil;
 import org.spin.base.util.ContextManager;
 import org.spin.base.util.DictionaryUtil;
 import org.spin.base.util.RecordUtil;
@@ -122,7 +123,7 @@ public class MaterialManagementServiceImplementation extends MaterialManagementI
 		//
 		String tableName = "RV_Storage";
 		MTable table = MTable.get(Env.getCtx(), tableName);
-		StringBuilder sql = new StringBuilder(DictionaryUtil.getQueryWithReferencesFromColumns(table));
+		StringBuilder sql = new StringBuilder(QueryUtil.getQueryWithReferencesFromTable(table));
 		StringBuffer whereClause = new StringBuffer(" WHERE 1=1 ");
 
 		//	For dynamic condition

--- a/src/main/java/org/spin/grpc/service/MaterialManagementServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/MaterialManagementServiceImplementation.java
@@ -123,7 +123,7 @@ public class MaterialManagementServiceImplementation extends MaterialManagementI
 		//
 		String tableName = "RV_Storage";
 		MTable table = MTable.get(Env.getCtx(), tableName);
-		StringBuilder sql = new StringBuilder(QueryUtil.getQueryWithReferencesFromTable(table));
+		StringBuilder sql = new StringBuilder(QueryUtil.getTableQueryWithReferences(table));
 		StringBuffer whereClause = new StringBuffer(" WHERE 1=1 ");
 
 		//	For dynamic condition

--- a/src/main/java/org/spin/grpc/service/OrderServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/OrderServiceImplementation.java
@@ -27,6 +27,7 @@ import org.compiere.util.Env;
 import org.compiere.util.Util;
 import org.spin.base.db.CountUtil;
 import org.spin.base.db.LimitUtil;
+import org.spin.base.db.QueryUtil;
 import org.spin.base.db.WhereUtil;
 import org.spin.base.util.ContextManager;
 import org.spin.base.util.DictionaryUtil;
@@ -91,7 +92,7 @@ public class OrderServiceImplementation extends OrderImplBase {
 
 		//
 		MTable table = MTable.get(Env.getCtx(), this.tableName);
-		StringBuilder sql = new StringBuilder(DictionaryUtil.getQueryWithReferencesFromColumns(table));
+		StringBuilder sql = new StringBuilder(QueryUtil.getQueryWithReferencesFromTable(table));
 
 		// add where with access restriction
 		String sqlWithRoleAccess = MRole.getDefault()

--- a/src/main/java/org/spin/grpc/service/OrderServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/OrderServiceImplementation.java
@@ -92,7 +92,7 @@ public class OrderServiceImplementation extends OrderImplBase {
 
 		//
 		MTable table = MTable.get(Env.getCtx(), this.tableName);
-		StringBuilder sql = new StringBuilder(QueryUtil.getQueryWithReferencesFromTable(table));
+		StringBuilder sql = new StringBuilder(QueryUtil.getTableQueryWithReferences(table));
 
 		// add where with access restriction
 		String sqlWithRoleAccess = MRole.getDefault()

--- a/src/main/java/org/spin/grpc/service/PaymentServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/PaymentServiceImplementation.java
@@ -27,6 +27,7 @@ import org.compiere.util.Env;
 import org.compiere.util.Util;
 import org.spin.base.db.CountUtil;
 import org.spin.base.db.LimitUtil;
+import org.spin.base.db.QueryUtil;
 import org.spin.base.db.WhereUtil;
 import org.spin.base.util.ContextManager;
 import org.spin.base.util.DictionaryUtil;
@@ -91,7 +92,7 @@ public class PaymentServiceImplementation extends PaymentImplBase {
 
 		//
 		MTable table = MTable.get(Env.getCtx(), this.tableName);
-		StringBuilder sql = new StringBuilder(DictionaryUtil.getQueryWithReferencesFromColumns(table));
+		StringBuilder sql = new StringBuilder(QueryUtil.getQueryWithReferencesFromTable(table));
 
 		// add where with access restriction
 		String sqlWithRoleAccess = MRole.getDefault(Env.getCtx(), false)

--- a/src/main/java/org/spin/grpc/service/PaymentServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/PaymentServiceImplementation.java
@@ -92,7 +92,7 @@ public class PaymentServiceImplementation extends PaymentImplBase {
 
 		//
 		MTable table = MTable.get(Env.getCtx(), this.tableName);
-		StringBuilder sql = new StringBuilder(QueryUtil.getQueryWithReferencesFromTable(table));
+		StringBuilder sql = new StringBuilder(QueryUtil.getTableQueryWithReferences(table));
 
 		// add where with access restriction
 		String sqlWithRoleAccess = MRole.getDefault(Env.getCtx(), false)

--- a/src/main/java/org/spin/grpc/service/ProductServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/ProductServiceImplementation.java
@@ -93,7 +93,7 @@ public class ProductServiceImplementation extends ProductImplBase {
 
 		//
 		MTable table = MTable.get(Env.getCtx(), this.tableName);
-		StringBuilder sql = new StringBuilder(QueryUtil.getQueryWithReferencesFromTable(table));
+		StringBuilder sql = new StringBuilder(QueryUtil.getTableQueryWithReferences(table));
 
 		// add where with access restriction
 		String sqlWithRoleAccess = MRole.getDefault(Env.getCtx(), false)

--- a/src/main/java/org/spin/grpc/service/ProductServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/ProductServiceImplementation.java
@@ -27,6 +27,7 @@ import org.compiere.util.Env;
 import org.compiere.util.Util;
 import org.spin.base.db.CountUtil;
 import org.spin.base.db.LimitUtil;
+import org.spin.base.db.QueryUtil;
 import org.spin.base.db.WhereUtil;
 import org.spin.base.util.ContextManager;
 import org.spin.base.util.DictionaryUtil;
@@ -92,7 +93,7 @@ public class ProductServiceImplementation extends ProductImplBase {
 
 		//
 		MTable table = MTable.get(Env.getCtx(), this.tableName);
-		StringBuilder sql = new StringBuilder(DictionaryUtil.getQueryWithReferencesFromColumns(table));
+		StringBuilder sql = new StringBuilder(QueryUtil.getQueryWithReferencesFromTable(table));
 
 		// add where with access restriction
 		String sqlWithRoleAccess = MRole.getDefault(Env.getCtx(), false)

--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -970,7 +970,7 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 		MTable table = MTable.get(Env.getCtx(), tab.getAD_Table_ID());
 		String tableName = table.getTableName();
 
-		String sql = QueryUtil.getQueryWithReferencesFromTab(tab);
+		String sql = QueryUtil.getTabQueryWithReferences(tab);
 		// add filter
 		StringBuffer whereClause = new StringBuffer()
 			.append(" WHERE ")
@@ -1130,7 +1130,7 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 
 		ListEntitiesResponse.Builder builder = ListEntitiesResponse.newBuilder();
 		//	
-		StringBuilder sql = new StringBuilder(QueryUtil.getQueryWithReferencesFromTab(tab));
+		StringBuilder sql = new StringBuilder(QueryUtil.getTabQueryWithReferences(tab));
 		String sqlWithRoleAccess = MRole.getDefault()
 			.addAccessSQL(
 					sql.toString(),
@@ -1357,7 +1357,7 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 		ContextManager.setContextWithAttributes(windowNo, Env.getCtx(), request.getContextAttributesList());
 
 		//
-		StringBuilder sql = new StringBuilder(QueryUtil.getQueryWithReferencesFromTable(table));
+		StringBuilder sql = new StringBuilder(QueryUtil.getTableQueryWithReferences(table));
 
 		// add where with access restriction
 		String sqlWithRoleAccess = MRole.getDefault(Env.getCtx(), false)
@@ -2922,7 +2922,7 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 		ContextManager.setContextWithAttributes(windowNo, context, parameterMap, false);
 
 		//	get query columns
-		String query = QueryUtil.addQueryReferencesFromBrowser(browser);
+		String query = QueryUtil.getBrowserQueryWithReferences(browser);
 		String sql = Env.parseContext(context, windowNo, query, false);
 		if (Util.isEmpty(sql, true)) {
 			throw new AdempiereException("@AD_Browse_ID@ @SQL@ @Unparseable@");

--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -48,26 +48,12 @@ import java.util.stream.Collectors;
 
 import javax.script.ScriptEngine;
 
-import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.core.domains.models.I_AD_Browse;
 import org.adempiere.core.domains.models.I_AD_Browse_Field;
-import org.adempiere.model.MBrowse;
-import org.adempiere.model.MBrowseField;
-import org.adempiere.model.MView;
-import org.adempiere.model.MViewColumn;
-import org.adempiere.model.MViewDefinition;
-import org.adempiere.model.ZoomInfoFactory;
-import org.compiere.model.Callout;
-import org.compiere.model.CalloutOrder;
-import org.compiere.model.GridField;
-import org.compiere.model.GridFieldVO;
-import org.compiere.model.GridTab;
-import org.compiere.model.GridTabVO;
-import org.compiere.model.GridWindow;
-import org.compiere.model.GridWindowVO;
 import org.adempiere.core.domains.models.I_AD_ChangeLog;
 import org.adempiere.core.domains.models.I_AD_Client;
 import org.adempiere.core.domains.models.I_AD_Column;
+import org.adempiere.core.domains.models.I_AD_ContextInfo;
 import org.adempiere.core.domains.models.I_AD_Element;
 import org.adempiere.core.domains.models.I_AD_Field;
 import org.adempiere.core.domains.models.I_AD_Org;
@@ -85,6 +71,21 @@ import org.adempiere.core.domains.models.I_AD_Window;
 import org.adempiere.core.domains.models.I_CM_Chat;
 import org.adempiere.core.domains.models.I_C_Element;
 import org.adempiere.core.domains.models.I_R_MailText;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.MBrowse;
+import org.adempiere.model.MBrowseField;
+import org.adempiere.model.MView;
+import org.adempiere.model.MViewColumn;
+import org.adempiere.model.MViewDefinition;
+import org.adempiere.model.ZoomInfoFactory;
+import org.compiere.model.Callout;
+import org.compiere.model.CalloutOrder;
+import org.compiere.model.GridField;
+import org.compiere.model.GridFieldVO;
+import org.compiere.model.GridTab;
+import org.compiere.model.GridTabVO;
+import org.compiere.model.GridWindow;
+import org.compiere.model.GridWindowVO;
 import org.compiere.model.MChangeLog;
 import org.compiere.model.MChat;
 import org.compiere.model.MChatEntry;
@@ -123,22 +124,6 @@ import org.compiere.util.MimeType;
 import org.compiere.util.Msg;
 import org.compiere.util.Trx;
 import org.compiere.util.Util;
-import org.spin.base.db.CountUtil;
-import org.spin.base.db.LimitUtil;
-import org.spin.base.db.OperatorUtil;
-import org.spin.base.db.OrderByUtil;
-import org.spin.base.db.ParameterUtil;
-import org.spin.base.db.WhereUtil;
-import org.spin.base.ui.UserInterfaceConvertUtil;
-import org.spin.base.util.ContextManager;
-import org.spin.base.util.ConvertUtil;
-import org.spin.base.util.DictionaryUtil;
-import org.spin.base.util.LookupUtil;
-import org.spin.base.util.RecordUtil;
-import org.spin.base.util.ReferenceInfo;
-import org.spin.base.util.ReferenceUtil;
-import org.spin.base.util.SessionManager;
-import org.spin.base.util.ValueUtil;
 import org.spin.backend.grpc.common.ChatEntry;
 import org.spin.backend.grpc.common.ContextInfoValue;
 import org.spin.backend.grpc.common.CreateChatEntryRequest;
@@ -206,7 +191,23 @@ import org.spin.backend.grpc.common.UpdateBrowserEntityRequest;
 import org.spin.backend.grpc.common.UpdateTabEntityRequest;
 import org.spin.backend.grpc.common.UserInterfaceGrpc.UserInterfaceImplBase;
 import org.spin.backend.grpc.common.Value;
-import org.adempiere.core.domains.models.I_AD_ContextInfo;
+import org.spin.base.db.CountUtil;
+import org.spin.base.db.LimitUtil;
+import org.spin.base.db.OperatorUtil;
+import org.spin.base.db.OrderByUtil;
+import org.spin.base.db.ParameterUtil;
+import org.spin.base.db.QueryUtil;
+import org.spin.base.db.WhereUtil;
+import org.spin.base.ui.UserInterfaceConvertUtil;
+import org.spin.base.util.ContextManager;
+import org.spin.base.util.ConvertUtil;
+import org.spin.base.util.DictionaryUtil;
+import org.spin.base.util.LookupUtil;
+import org.spin.base.util.RecordUtil;
+import org.spin.base.util.ReferenceInfo;
+import org.spin.base.util.ReferenceUtil;
+import org.spin.base.util.SessionManager;
+import org.spin.base.util.ValueUtil;
 import org.spin.model.MADContextInfo;
 import org.spin.util.ASPUtil;
 import org.spin.util.AbstractExportFormat;
@@ -969,7 +970,7 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 		MTable table = MTable.get(Env.getCtx(), tab.getAD_Table_ID());
 		String tableName = table.getTableName();
 
-		String sql = DictionaryUtil.getQueryWithReferencesFromTab(tab);
+		String sql = QueryUtil.getQueryWithReferencesFromTab(tab);
 		// add filter
 		StringBuffer whereClause = new StringBuffer()
 			.append(" WHERE ")
@@ -1129,7 +1130,7 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 
 		ListEntitiesResponse.Builder builder = ListEntitiesResponse.newBuilder();
 		//	
-		StringBuilder sql = new StringBuilder(DictionaryUtil.getQueryWithReferencesFromTab(tab));
+		StringBuilder sql = new StringBuilder(QueryUtil.getQueryWithReferencesFromTab(tab));
 		String sqlWithRoleAccess = MRole.getDefault()
 			.addAccessSQL(
 					sql.toString(),
@@ -1356,7 +1357,7 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 		ContextManager.setContextWithAttributes(windowNo, Env.getCtx(), request.getContextAttributesList());
 
 		//
-		StringBuilder sql = new StringBuilder(DictionaryUtil.getQueryWithReferencesFromColumns(table));
+		StringBuilder sql = new StringBuilder(QueryUtil.getQueryWithReferencesFromTable(table));
 
 		// add where with access restriction
 		String sqlWithRoleAccess = MRole.getDefault(Env.getCtx(), false)
@@ -2921,7 +2922,7 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 		ContextManager.setContextWithAttributes(windowNo, context, parameterMap, false);
 
 		//	get query columns
-		String query = DictionaryUtil.addQueryReferencesFromBrowser(browser);
+		String query = QueryUtil.addQueryReferencesFromBrowser(browser);
 		String sql = Env.parseContext(context, windowNo, query, false);
 		if (Util.isEmpty(sql, true)) {
 			throw new AdempiereException("@AD_Browse_ID@ @SQL@ @Unparseable@");


### PR DESCRIPTION
Move the next methods:

- `getTableQueryWithReferences`.
- `getTabQueryWithReferences`.
- `getBrowserQuery`.
- `getBrowserQueryWithReferences`

From `src/main/java/org/spin/base/util/DictionaryUtil.java` to `src/main/java/org/spin/base/db/QueryUtil.java` class.