### PR TITLE
fix: Parent tab uuid generates sql exeption.

### DIFF
--- a/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
@@ -533,8 +533,7 @@ public class DictionaryServiceImplementation extends DictionaryImplBase {
 		if (tab.getTabLevel() > 0) {
 			int parentTabId = WindowUtil.getDirectParentTabId(tab.getAD_Window_ID(), tabId);
 			if (parentTabId > 0) {
-				MTable table = MTable.get(context, tab.getAD_Table_ID());
-				parentTabUuid = RecordUtil.getUuidFromId(table.getTableName(), parentTabId, null);
+				parentTabUuid = RecordUtil.getUuidFromId(I_AD_Tab.Table_Name, parentTabId, null);
 			}
 		}
 


### PR DESCRIPTION
I was looking for the parent table sending the name of the table associated to the tab when it should be in `AD_Tab`.

```sql
SELECT UUID from C_InvoiceTax where C_InvoiceTax_ID = ? AND AD_Client_ID=? Order By C_InvoiceTax_ID
```


```log
===========> DB.getSQLValueString: select UUID from C_InvoiceTax where C_InvoiceTax_ID = ? and AD_Client_ID=? Order By C_InvoiceTax_ID [36]
328
org.postgresql.util.PSQLException: ERROR: column "c_invoicetax_id" does not exist
327
  Hint: Perhaps you meant to reference the column "c_invoicetax.c_invoice_id".
326
  Position: 37; State=42703; ErrorCode=0
325
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2675)
324
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2365)
323
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:355)
322
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:490)
321
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:408)
320
	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:166)
319
	at org.postgresql.jdbc.PgPreparedStatement.executeQuery(PgPreparedStatement.java:118)
318
	at com.zaxxer.hikari.pool.ProxyPreparedStatement.executeQuery(ProxyPreparedStatement.java:52)
317
	at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeQuery(HikariProxyPreparedStatement.java)
316
	at jdk.internal.reflect.GeneratedMethodAccessor1.invoke(Unknown Source)
315
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
314
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
313
	at org.compiere.db.StatementProxy.invoke(StatementProxy.java:100)
312
	at com.sun.proxy.$Proxy4.executeQuery(Unknown Source)
311
	at org.compiere.util.DB.getSQLValueStringEx(DB.java:1403)
310
	at org.compiere.util.DB.getSQLValueString(DB.java:1446)
309
	at org.compiere.util.DB.getSQLValueString(DB.java:1464)
308
	at org.adempiere.pipo.IDFinder.getUUID(IDFinder.java:321)
307
	at org.adempiere.pipo.IDFinder.getUUIDFromId(IDFinder.java:229)
306
	at org.spin.base.util.RecordUtil.getUuidFromId(RecordUtil.java:252)
305
	at org.spin.grpc.service.DictionaryServiceImplementation.convertTab(DictionaryServiceImplementation.java:533)
```