### PR TITLE
fix: `#ShowAcct` on session context.

### DIFF
--- a/src/main/java/org/spin/base/util/SessionManager.java
+++ b/src/main/java/org/spin/base/util/SessionManager.java
@@ -294,11 +294,13 @@ public class SessionManager {
 		//	Other
 		Env.setAutoCommit(context, Ini.isPropertyBool(Ini.P_A_COMMIT));
 		Env.setAutoNew(context, Ini.isPropertyBool(Ini.P_A_NEW));
+
+		String isShowAccounting = "N";
 		if (MRole.getDefault(context, false).isShowAcct()) {
-			Env.setContext(context, "#ShowAcct", Ini.getProperty(Ini.P_SHOW_ACCT));
-		} else {
-			Env.setContext(context, "#ShowAcct", "N");
+			isShowAccounting = "Y";
 		}
+		Env.setContext(context, "#ShowAcct", isShowAccounting);
+
 		Env.setContext(context, "#ShowTrl", Ini.getProperty(Ini.P_SHOW_TRL));
 		Env.setContext(context, "#ShowAdvanced", Ini.getProperty(Ini.P_SHOW_ADVANCED));
 


### PR DESCRIPTION
The `#ShowAcct` attribute is required to display logic on `Posted` field to accounting features.


#### Before this changes

![imagen](https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/b9f607fd-67e6-43b1-98ae-3c9a88552941)


#### After this changes

![imagen](https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/8f7263dd-9562-465f-a2c3-c5c5d607229c)
