### PR TITLE
feat: Add display column to `Record_ID` as button reference.

### DIFF
--- a/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
@@ -35,6 +35,7 @@ import org.adempiere.core.domains.models.I_AD_Message;
 import org.adempiere.core.domains.models.I_AD_Process;
 import org.adempiere.core.domains.models.I_AD_Reference;
 import org.adempiere.core.domains.models.I_AD_Tab;
+import org.adempiere.core.domains.models.I_AD_Table;
 import org.adempiere.core.domains.models.I_AD_Val_Rule;
 import org.adempiere.core.domains.models.I_AD_Window;
 import org.compiere.model.MColumn;
@@ -1492,8 +1493,12 @@ public class DictionaryServiceImplementation extends DictionaryImplBase {
 			} else {
 				builder.setDisplayType(DisplayType.String);
 			}
+		} else if (DisplayType.Button == displayTypeId) {
+			if (column.getColumnName().equals("Record_ID")) {
+				builder.addContextColumnNames(I_AD_Table.COLUMNNAME_AD_Table_ID);
+			}
 		}
-		
+
 		//	Field Definition
 		if(field.getAD_FieldDefinition_ID() > 0) {
 			FieldDefinition.Builder fieldDefinitionBuilder = convertFieldDefinition(context, field.getAD_FieldDefinition_ID());

--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -2483,7 +2483,7 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 				// log.warning(e.getLocalizedMessage());
 			}
 		}
-		if (ReferenceUtil.validateReference(referenceId)) {
+		if (ReferenceUtil.validateReference(referenceId) || DisplayType.Button == referenceId) {
 			if(referenceId == DisplayType.List) {
 				// (') (text) (') or (") (text) (")
 				String singleQuotesPattern = "('|\")(\\w+)('|\")";
@@ -2500,6 +2500,20 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 				MRefList referenceList = MRefList.get(Env.getCtx(), referenceValueId, defaultValueList, null);
 				builder = convertDefaultValueFromResult(referenceList.getValue(), referenceList.getUUID(), referenceList.getValue(), referenceList.get_Translation(MRefList.COLUMNNAME_Name));
 			} else {
+				if (DisplayType.Button == referenceId) {
+					if (columnName.equals("Record_ID")) {
+						defaultValueAsObject = Integer.valueOf(defaultValueAsObject.toString());
+						int tableId = Env.getContextAsInt(Env.getCtx(), windowNo, I_AD_Table.COLUMNNAME_AD_Table_ID);
+						MTable table = MTable.get(Env.getCtx(), tableId);
+						String tableKeyColumn = table.getTableName() + "_ID";
+						referenceId = DisplayType.TableDir;
+						columnName = tableKeyColumn;
+					} else {
+						builder.putValues(columnName, ValueUtil.getValueFromObject(defaultValueAsObject).build());
+						return builder;
+					}
+				}
+
 				MLookupInfo lookupInfo = ReferenceUtil.getReferenceLookupInfo(referenceId, referenceValueId, columnName, validationRuleId);
 				if(!Util.isEmpty(lookupInfo.QueryDirect)) {
 					String sql = MRole.getDefault(Env.getCtx(), false).addAccessSQL(lookupInfo.QueryDirect,

--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -66,6 +66,7 @@ import org.adempiere.core.domains.models.I_AD_Record_Access;
 import org.adempiere.core.domains.models.I_AD_ReportView;
 import org.adempiere.core.domains.models.I_AD_Role;
 import org.adempiere.core.domains.models.I_AD_Tab;
+import org.adempiere.core.domains.models.I_AD_Table;
 import org.adempiere.core.domains.models.I_AD_User;
 import org.adempiere.core.domains.models.I_AD_Window;
 import org.adempiere.core.domains.models.I_CM_Chat;


### PR DESCRIPTION

![imagen](https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/4605e2da-5b06-481c-9950-b2b1051c8c49)


#### Request

```bash
curl --location --globoff 'http://localhost:8085/api/adempiere/user-interface/window/default-value?context_attributes[]=%7B%22key%22%3A%22AD_Table_ID%22%2C%22value%22%3A318%7D&field_uuid=8d56bba8-fb40-11e8-a479-7a0060f0aa01&id=3890&value=100&ts=1687806196918' \
--header 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIxMDAxNDg0IiwiQURfQ2xpZW50X0lEIjoxMSwiQURfT3JnX0lEIjoxMSwiQURfUm9sZV9JRCI6MTAyLCJBRF9Vc2VyX0lEIjoxMDEsIk1fV2FyZWhvdXNlX0lEIjowLCJBRF9MYW5ndWFnZSI6ImVuX1VTIiwiaWF0IjoxNjg3Nzg5Nzk3LCJleHAiOjE2ODc4NzYxOTd9.KxLqQo_xjLezK0yyMncs80GEFUXlFUZDf11xWH5hL6U'
```

#### Response
```json
{
	"code": 200,
	"result": {
		"id": 100,
		"uuid": "3880ea1a-35c7-4e62-b450-755ac24c4817",
		"attributes": [
			{
				"key": "DisplayColumn",
				"value": "2002-02-22 USD"
			},
			{
				"key": "KeyColumn",
				"value": 100
			},
			{
				"key": "UUID",
				"value": "3880ea1a-35c7-4e62-b450-755ac24c4817"
			}
		]
	}
}
```
