### PR TITLE
fix: Empty values with `IN` and `NOT IN` operator.

### DIFF
--- a/src/main/java/org/spin/base/db/ParameterUtil.java
+++ b/src/main/java/org/spin/base/db/ParameterUtil.java
@@ -76,6 +76,8 @@ public class ParameterUtil {
 			pstmt.setDate(index, (Date) value);
 		} else if(value instanceof Boolean) {
 			pstmt.setString(index, ((Boolean) value) ? "Y" : "N");
+		} else {
+			pstmt.setObject(index, null);
 		}
 	}
 


### PR DESCRIPTION
When is `NULL` value on list to `IN` or `NOT IN` operator, the search is empty.

With the values `CO`, `NULL`, `CL` generates sql:

### Before this changes

```sql
o.DocStatus IN (
  'CO',
  NULL,
  'CL'
)
```

### After this changes:

```sql
(UPPER(o.DocumentNo) IN (
  UPPER('CO'),
  UPPER(''),
  UPPER('CL')
)
OR UPPER(o.DocumentNo) IN (SELECT o.DocumentNo WHERE o.DocumentNo IS NULL))
```

### Add on sql

Is add restriction:
```sql
OR `columnName` IN (SELECT `columnName` WHERE `columnName` IS NULL)
```

If column is value type string the 
```sql
UPPER(`columnName`)

UPPER(`value`)
```
is added on column name and value.



