### PR TITLE
fix: Run Process/DocAction empty error message.

### DIFF
--- a/src/main/java/org/spin/grpc/service/BusinessDataServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/BusinessDataServiceImplementation.java
@@ -339,11 +339,18 @@ public class BusinessDataServiceImplementation extends BusinessDataImplBase {
 		try {
 			result = builder.execute();
 		} catch (Exception e) {
+			e.printStackTrace();
+			// log.severe(e.getLocalizedMessage());
+
 			result = builder.getProcessInfo();
 			//	Set error message
-			if(Util.isEmpty(result.getSummary())) {
-				result.setSummary(e.getLocalizedMessage());
+			String summary = Msg.parseTranslation(Env.getCtx(), result.getSummary());
+			if(Util.isEmpty(summary, true)) {
+				summary = e.getLocalizedMessage();
 			}
+			result.setSummary(
+				ValueUtil.validateNull(summary)
+			);
 		}
 		String reportViewUuid = null;
 		String printFormatUuid = request.getPrintFormatUuid();
@@ -438,7 +445,22 @@ public class BusinessDataServiceImplementation extends BusinessDataImplBase {
 					reportType = getExtension(validFileName);
 				}
 				output.setReportType(request.getReportType());
-				ByteString resultFile = ByteString.readFrom(new FileInputStream(reportFile));
+
+				ByteString resultFile = ByteString.empty();
+				try {
+					resultFile = ByteString.readFrom(new FileInputStream(reportFile));
+				} catch (IOException e) {
+					e.printStackTrace();
+					// log.severe(e.getLocalizedMessage());
+
+					if (Util.isEmpty(response.getSummary(), true)) {
+						response.setSummary(
+							ValueUtil.validateNull(
+								e.getLocalizedMessage()
+							)
+						);
+					}
+				}
 				if(reportType.endsWith("html") || reportType.endsWith("txt")) {
 					output.setOutputBytes(resultFile);
 				}

--- a/src/main/java/org/spin/grpc/service/WorkflowServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/WorkflowServiceImplementation.java
@@ -690,8 +690,8 @@ public class WorkflowServiceImplementation extends WorkflowImplBase {
 	 * Run a process from request
 	 * @param context
 	 * @param request
-	 * @throws IOException 
-	 * @throws FileNotFoundException 
+	 * @throws IOException
+	 * @throws FileNotFoundException
 	 */
 	private ProcessLog.Builder runDocumentAction(Properties context, RunDocumentActionRequest request) throws FileNotFoundException, IOException {
 		if (Util.isEmpty(request.getTableName(), true)) {
@@ -760,7 +760,16 @@ public class WorkflowServiceImplementation extends WorkflowImplBase {
 				}
 			}
 		} catch (Exception e) {
-			response.setSummary(Msg.parseTranslation(context, document.getProcessMsg()));
+			e.printStackTrace();
+			log.severe(e.getLocalizedMessage());
+
+			String summary = Msg.parseTranslation(context, document.getProcessMsg());
+			if (Util.isEmpty(summary, true)) {
+				summary = e.getLocalizedMessage();
+			}
+			response.setSummary(
+				ValueUtil.validateNull(summary)
+			);
 			response.setIsError(true);
 		}
 		response.setResultTableName(ValueUtil.validateNull(table.getTableName()));


### PR DESCRIPTION
Sometimes when executing a process or a document action, and it generates an error that is not captured, it may arrive empty so the cause of the error is not identified.

If the error is handled and I return its corresponding message, it is the one that is sent to the client, otherwise it takes the error of the catch.