### PR TITLE
fix: Workflow Actions list error if exists wokflow activity.

### DIFF
--- a/src/main/java/org/spin/grpc/service/WorkflowServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/WorkflowServiceImplementation.java
@@ -601,14 +601,6 @@ public class WorkflowServiceImplementation extends WorkflowImplBase {
 		String[] options = new String[valueList.size()];
 		int index = 0;
 
-		/**
-		 * 	Check Existence of Workflow Activities
-		 */
-		String workflowStatus = MWFActivity.getActiveInfo(Env.getCtx(), entity.get_Table_ID(), entity.get_ID()); 
-		if (workflowStatus != null) {
-			throw new AdempiereException("@WFActiveForRecord@");
-		}
-		
 		/*******************
 		 *  General Actions
 		 */
@@ -725,6 +717,12 @@ public class WorkflowServiceImplementation extends WorkflowImplBase {
 		//	Validate as document
 		if (!DocAction.class.isAssignableFrom(entity.getClass())) {
 			throw new AdempiereException("@Invalid@ @Document@");
+		}
+
+		// Check Existence of Workflow Activities
+		String workflowStatus = MWFActivity.getActiveInfo(Env.getCtx(), entity.get_Table_ID(), entity.get_ID());
+		if (!Util.isEmpty(workflowStatus, true)) {
+			throw new AdempiereException("@WFActiveForRecord@");
 		}
 
 		//	Status Change

--- a/src/main/java/org/spin/grpc/service/WorkflowServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/WorkflowServiceImplementation.java
@@ -722,7 +722,7 @@ public class WorkflowServiceImplementation extends WorkflowImplBase {
 		// Check Existence of Workflow Activities
 		String workflowStatus = MWFActivity.getActiveInfo(Env.getCtx(), entity.get_Table_ID(), entity.get_ID());
 		if (!Util.isEmpty(workflowStatus, true)) {
-			throw new AdempiereException("@WFActiveForRecord@");
+			throw new AdempiereException("@WFActiveForRecord@ " + workflowStatus);
 		}
 
 		//	Status Change


### PR DESCRIPTION
When listing the actions on a document that has active workflows, this will generate the error `Active Workflow for this Record exists (complete first): Status`, however to list the document actions this validation should not exist.

This validation was moved to `runDocumentAction` to avoid executing multiple workflows simultaneously on the same document.