### PR TITLE
fix: `Null Pointer Execption` when save attachment.

### DIFF
--- a/src/main/java/org/spin/grpc/service/FileManagementServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/FileManagementServiceImplementation.java
@@ -454,6 +454,12 @@ public class FileManagementServiceImplementation extends FileManagementImplBase 
 		Trx.run(transactionName -> {
 			MAttachment attachment = new MAttachment(Env.getCtx(), table.getAD_Table_ID(), recordIdentifier, transactionName);
 			if (attachment.getAD_Attachment_ID() <= 0) {
+				/**
+				 * TODO: this disables the `MAttachment.afterSave` which calls the `MAttachment.saveLOBData`
+				 * method but generates an error (Null Pointer Exception) since items is initialized to null,
+				 * when it should be initialized with a `items = new ArrayList<MAttachmentEntry>()`.
+				 */
+				attachment.setIsDirectLoad(true); 
 				attachment.saveEx();
 			}
 			MADAttachmentReference attachmentReference = new MADAttachmentReference(Env.getCtx(), 0, transactionName);


### PR DESCRIPTION
#### Before this changes:

https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/59ff60dc-00f4-4216-bf89-296a7083ea43


```log
FileManagementServiceImplementation.setResourceReference: SaveError [915]
org.adempiere.exceptions.AdempiereException: SaveError
        at org.compiere.model.PO.saveEx(PO.java:2320)
        at org.spin.grpc.service.FileManagementServiceImplementation.lambda$1(FileManagementServiceImplementation.java:457)
        at org.compiere.util.Trx.run(Trx.java:529)
        at org.compiere.util.Trx.run(Trx.java:497)
        at org.spin.grpc.service.FileManagementServiceImplementation.setResourceReference(FileManagementServiceImplementation.java:454)
        at org.spin.grpc.service.FileManagementServiceImplementation.setResourceReference(FileManagementServiceImplementation.java:411)
        at org.spin.backend.grpc.file_management.FileManagementGrpc$MethodHandlers.invoke(FileManagementGrpc.java:808)
        at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
        at io.grpc.Contexts$ContextualizedServerCallListener.onHalfClose(Contexts.java:86)
        at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:346)
        at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:860)
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
```
#### After this changes

https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/d96a4705-024b-4a50-82cf-9d1539b3f6c8



