### PR TITLE
fix: Exists attachment error with role zero.

### DIFF
--- a/src/main/java/org/spin/grpc/service/FileManagementServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/FileManagementServiceImplementation.java
@@ -626,13 +626,11 @@ public class FileManagementServiceImplementation extends FileManagementImplBase 
 
 		// validate record
 		int recordId = request.getRecordId();
-		if (recordId <= 0) {
-			if (!Util.isEmpty(request.getRecordUuid(), true)) {
-				recordId = RecordUtil.getIdFromUuid(table.getTableName(), request.getRecordUuid(), null);
-			}
-			if (RecordUtil.isValidId(recordId, table.getAccessLevel())) {
-				throw new AdempiereException("@Record_ID@ / @UUID@ @NotFound@");
-			}
+		if (recordId <= 0 && !Util.isEmpty(request.getRecordUuid(), true)) {
+			recordId = RecordUtil.getIdFromUuid(table.getTableName(), request.getRecordUuid(), null);
+		}
+		if (!RecordUtil.isValidId(recordId, table.getAccessLevel())) {
+			throw new AdempiereException("@Record_ID@ / @UUID@ @NotFound@");
 		}
 
 		MAttachment attachment = MAttachment.get(Env.getCtx(), table.getAD_Table_ID(), recordId);

--- a/src/main/java/org/spin/grpc/service/FileManagementServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/FileManagementServiceImplementation.java
@@ -318,6 +318,7 @@ public class FileManagementServiceImplementation extends FileManagementImplBase 
 	 * @return
 	 */
 	private Attachment.Builder getAttachmentFromEntity(GetAttachmentRequest request) {
+		// validate and get table
 		MTable table = validateAndGetTable(request.getTableName());
 
 		int recordId = request.getRecordId();

--- a/src/main/java/org/spin/grpc/service/FileManagementServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/FileManagementServiceImplementation.java
@@ -318,22 +318,18 @@ public class FileManagementServiceImplementation extends FileManagementImplBase 
 	 * @return
 	 */
 	private Attachment.Builder getAttachmentFromEntity(GetAttachmentRequest request) {
-		int tableId = 0;
-		if (!Util.isEmpty(request.getTableName(), true)) {
-			MTable table = MTable.get(Env.getCtx(), request.getTableName());
-			if (table != null && table.getAD_Table_ID() > 0) {
-				tableId = table.getAD_Table_ID();
-			}
-		}
+		MTable table = validateAndGetTable(request.getTableName());
+
 		int recordId = request.getRecordId();
-		if (recordId <= 0) {
-			recordId = RecordUtil.getIdFromUuid(request.getTableName(), request.getRecordUuid(), null);
+		if (recordId <= 0 && !Util.isEmpty(request.getRecordUuid(), true)) {
+			recordId = RecordUtil.getIdFromUuid(table.getTableName(), request.getRecordUuid(), null);
 		}
-		if (tableId > 0 && recordId > 0) {
-			MAttachment attachment = MAttachment.get(Env.getCtx(), tableId, recordId);
-			return convertAttachment(attachment);
+		if (!RecordUtil.isValidId(recordId, table.getAccessLevel())) {
+			return Attachment.newBuilder();
 		}
-		return Attachment.newBuilder();
+
+		MAttachment attachment = MAttachment.get(Env.getCtx(), table.getAD_Table_ID(), recordId);
+		return convertAttachment(attachment);
 	}
 
 
@@ -440,13 +436,11 @@ public class FileManagementServiceImplementation extends FileManagementImplBase 
 
 		// validate record
 		int recordId = request.getRecordId();
-		if (recordId <= 0) {
-			if (Util.isEmpty(request.getRecordUuid(), true)) {
-				recordId = RecordUtil.getIdFromUuid(request.getTableName(), request.getRecordUuid(), null);
-			}
-			if (recordId <= 0) {
-				throw new AdempiereException("@Record_ID@ / @UUID@ @NotFound@");
-			}
+		if (recordId <= 0 && !Util.isEmpty(request.getRecordUuid(), true)) {
+			recordId = RecordUtil.getIdFromUuid(request.getTableName(), request.getRecordUuid(), null);
+		}
+		if (!RecordUtil.isValidId(recordId, table.getAccessLevel())) {
+			throw new AdempiereException("@Record_ID@ / @UUID@ @NotFound@");
 		}
 		final int recordIdentifier = recordId;
 
@@ -520,7 +514,7 @@ public class FileManagementServiceImplementation extends FileManagementImplBase 
 		}
 
 		if (resourceReference == null || resourceReference.getAD_AttachmentReference_ID() <= 0) {
-			throw new AdempiereException("@AD_AttachmentReference_ID@ Null");
+			throw new AdempiereException("@AD_AttachmentReference_ID@ @NotFound@");
 		}
 		
 		resourceReference.setDescription(request.getDescription());


### PR DESCRIPTION
when querying for attachments in the role window with the `System` record having the id `0`, an error is generated.

#### Request
```bash
curl 'https://api-develop.solopcloud.com/api/adempiere/user-interface/component/resource/exists-attachment?table_name=AD_Role&record_id=0&record_uuid=a48d2596-fb40-11e8-a479-7a0060f0aa01&ts=1689910629327' -H 'Accept: application/json, text/plain, */*'  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIxMDAxNzMwIiwiQURfQ2xpZW50X0lEIjoxMSwiQURfT3JnX0lEIjoxMDAwMDA0LCJBRF9Sb2xlX0lEIjoxMDIsIkFEX1VzZXJfSUQiOjEwMSwiTV9XYXJlaG91c2VfSUQiOjAsIkFEX0xhbmd1YWdlIjoiZXNfTVgiLCJpYXQiOjE2ODk4OTE0MzIsImV4cCI6MTY4OTk3NzgzMn0.FfUizGkjbZh3pbi695EGwXir0_HPxHSlgGd57Ybp62I''
```

#### Before this changes

https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/792978fe-fcdf-4fa3-a2ba-655533aa5e36

```json
{
	"code": 500,
	"result": "ID de Registro / Immutable Universally Unique Identifier * No encontrado *"
}
```


#### After this changes

https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/ea4ace22-2ab6-46b6-bc96-dfa8fdf88041

```json
{
	"code": 200,
	"result": 1
}
```

