### PR TITLE
fix: Error adding recent items when different from window.

### DIFF
--- a/src/main/java/org/spin/base/dictionary/DictionaryUtil.java
+++ b/src/main/java/org/spin/base/dictionary/DictionaryUtil.java
@@ -87,6 +87,9 @@ public class DictionaryUtil {
 		if (menuId <= 0) {
 			return;
 		}
+		if (!action.equals(MMenu.ACTION_Window)) {
+			optionId = 0;
+		}
 		MRecentItem.addMenuOption(Env.getCtx(), menuId, optionId);
 	}
 

--- a/src/main/java/org/spin/grpc/service/BusinessDataServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/BusinessDataServiceImplementation.java
@@ -274,11 +274,6 @@ public class BusinessDataServiceImplementation extends BusinessDataImplBase {
 			parametersList.add(0, recordParameter.build());
 		}
 
-		//	Add to recent Item
-		DictionaryUtil.addToRecentItem(
-			MMenu.ACTION_Process,
-			process.getAD_Process_ID()
-		);
 		//	Call process builder
 		ProcessBuilder builder = ProcessBuilder.create(Env.getCtx())
 				.process(process.getAD_Process_ID())

--- a/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
@@ -763,6 +763,20 @@ public class DictionaryServiceImplementation extends DictionaryImplBase {
 				builder.addParameters(fieldBuilder.build());
 			}
 		}
+
+		//	Add to recent Item
+		if (process.isReport()) {
+			org.spin.base.dictionary.DictionaryUtil.addToRecentItem(
+				MMenu.ACTION_Report,
+				process.getAD_Process_ID()
+			);
+		} else {
+			org.spin.base.dictionary.DictionaryUtil.addToRecentItem(
+				MMenu.ACTION_Process,
+				process.getAD_Process_ID()
+			);
+		}
+
 		return builder;
 	}
 	

--- a/src/main/java/org/spin/grpc/service/WorkflowServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/WorkflowServiceImplementation.java
@@ -143,7 +143,10 @@ public class WorkflowServiceImplementation extends WorkflowImplBase {
 		;
 
 		//	Add to recent Item
-		DictionaryUtil.addToRecentItem(MMenu.ACTION_WorkFlow, workflow.getAD_Workflow_ID());
+		DictionaryUtil.addToRecentItem(
+			MMenu.ACTION_WorkFlow,
+			workflow.getAD_Workflow_ID()
+		);
 
 		return WorkflowUtil.convertWorkflowDefinition(workflow);
 	}


### PR DESCRIPTION

#### Before this changes:

![imagen](https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/9f80fa37-1b96-45de-b1c7-0d414dd70a08)


#### After this changes:
```log
===========> Trx.commit: POSave_298520ab-b473-4efc-bd6e-bb62b6d84b75 [79]
org.postgresql.util.PSQLException: ERROR: insert or update on table "ad_recentitem" violates foreign key constraint "adwindow_adrecentitem"
  Detail: Key (ad_window_id)=(50075) is not present in table "ad_window".; State=23503; ErrorCode=0
        at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2675)
        at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2365)
        at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:355)
        at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:315)
        at org.postgresql.jdbc.PgConnection.executeTransactionCommand(PgConnection.java:855)
        at org.postgresql.jdbc.PgConnection.commit(PgConnection.java:877)
        at com.zaxxer.hikari.pool.ProxyConnection.commit(ProxyConnection.java:377)
        at com.zaxxer.hikari.pool.HikariProxyConnection.commit(HikariProxyConnection.java)
        at org.compiere.util.Trx.commit(Trx.java:338)
        at org.compiere.model.PO.save(PO.java:2238)
        at org.compiere.model.MRecentItem.addChange(MRecentItem.java:250)
        at org.compiere.model.MRecentItem.addMenuOption(MRecentItem.java:295)
        at org.compiere.model.MRecentItem.addMenuOption(MRecentItem.java:310)
        at org.spin.base.dictionary.DictionaryUtil.addToRecentItem(DictionaryUtil.java:93)
        at org.spin.grpc.service.DictionaryServiceImplementation.convertBrowser(DictionaryServiceImplementation.java:837)
        at org.spin.grpc.service.DictionaryServiceImplementation.convertBrowser(DictionaryServiceImplementation.java:513)
        at org.spin.grpc.service.DictionaryServiceImplementation.getBrowser(DictionaryServiceImplementation.java:211)
        at org.spin.backend.grpc.dictionary.DictionaryGrpc$MethodHandlers.invoke(DictionaryGrpc.java:1054)
        at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)

===========> MRecentItem.saveError: Error - ERROR: insert or update on table "ad_recentitem" violates foreign key constraint "adwindow_adrecentitem"
  Detail: Key (ad_window_id)=(50075) is not present in table "ad_window". [79]
```


#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/1205
