### PR TITLE
fix: NPE with get default value as `List` reference inexistent value.

### DIFF
--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -2490,6 +2490,10 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 				String defaultValueList = matcherSingleQuotes.replaceAll("$2");
 
 				MRefList referenceList = MRefList.get(Env.getCtx(), referenceValueId, defaultValueList, null);
+				if (referenceList == null) {
+					log.fine(Msg.parseTranslation(Env.getCtx(), "@AD_Ref_List_ID@ @NotFound@"));
+					return builder;
+				}
 				builder = convertDefaultValueFromResult(referenceList.getValue(), referenceList.getUUID(), referenceList.getValue(), referenceList.get_Translation(MRefList.COLUMNNAME_Name));
 			} else {
 				if (DisplayType.Button == referenceId) {
@@ -2507,7 +2511,7 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 				}
 
 				MLookupInfo lookupInfo = ReferenceUtil.getReferenceLookupInfo(referenceId, referenceValueId, columnName, validationRuleId);
-				if(!Util.isEmpty(lookupInfo.QueryDirect)) {
+				if(lookupInfo != null && !Util.isEmpty(lookupInfo.QueryDirect)) {
 					String sql = MRole.getDefault(Env.getCtx(), false).addAccessSQL(lookupInfo.QueryDirect,
 							lookupInfo.TableName, MRole.SQL_FULLYQUALIFIED, MRole.SQL_RO);
 					PreparedStatement pstmt = null;

--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -2491,7 +2491,7 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 
 				MRefList referenceList = MRefList.get(Env.getCtx(), referenceValueId, defaultValueList, null);
 				if (referenceList == null) {
-					log.fine(Msg.parseTranslation(Env.getCtx(), "@AD_Ref_List_ID@ @NotFound@"));
+					log.fine(Msg.parseTranslation(Env.getCtx(), "@AD_Ref_List_ID@ @NotFound@") + ": " + defaultValueList);
 					return builder;
 				}
 				builder = convertDefaultValueFromResult(referenceList.getValue(), referenceList.getUUID(), referenceList.getValue(), referenceList.get_Translation(MRefList.COLUMNNAME_Name));
@@ -2511,48 +2511,56 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 				}
 
 				MLookupInfo lookupInfo = ReferenceUtil.getReferenceLookupInfo(referenceId, referenceValueId, columnName, validationRuleId);
-				if(lookupInfo != null && !Util.isEmpty(lookupInfo.QueryDirect)) {
-					String sql = MRole.getDefault(Env.getCtx(), false).addAccessSQL(lookupInfo.QueryDirect,
-							lookupInfo.TableName, MRole.SQL_FULLYQUALIFIED, MRole.SQL_RO);
-					PreparedStatement pstmt = null;
-					ResultSet rs = null;
-					try {
-						//	SELECT Key, Value, Name FROM ...
-						pstmt = DB.prepareStatement(sql.toString(), null);
-						DB.setParameter(pstmt, 1, defaultValueAsObject);
+				if(lookupInfo == null || Util.isEmpty(lookupInfo.QueryDirect)) {
+					return builder;
+				}
+				String sql = MRole.getDefault(Env.getCtx(), false).addAccessSQL(
+					lookupInfo.QueryDirect,
+					lookupInfo.TableName,
+					MRole.SQL_FULLYQUALIFIED,
+					MRole.SQL_RO
+				);
+				PreparedStatement pstmt = null;
+				ResultSet rs = null;
+				try {
+					//	SELECT Key, Value, Name FROM ...
+					pstmt = DB.prepareStatement(sql.toString(), null);
+					DB.setParameter(pstmt, 1, defaultValueAsObject);
 
-						//	Get from Query
-						rs = pstmt.executeQuery();
-						if (rs.next()) {
-							//	1 = Key Column
-							//	2 = Optional Value
-							//	3 = Display Value
-							ResultSetMetaData metaData = rs.getMetaData();
-							int keyValueType = metaData.getColumnType(1);
-							Object keyValue = null;
-							if(keyValueType == Types.VARCHAR
-									|| keyValueType == Types.NVARCHAR
-									|| keyValueType == Types.CHAR
-									|| keyValueType == Types.NCHAR) {
-								keyValue = rs.getString(2);
-							} else {
-								keyValue = rs.getInt(1);
-							}
-							String uuid = null;
-							//	Validate if exist UUID
-							int uuidIndex = getColumnIndex(metaData, I_AD_Element.COLUMNNAME_UUID);
-							if(uuidIndex != -1) {
-								uuid = rs.getString(uuidIndex);
-							}
-							//	
-							builder = convertDefaultValueFromResult(keyValue, uuid, rs.getString(2), rs.getString(3));
+					//	Get from Query
+					rs = pstmt.executeQuery();
+					if (rs.next()) {
+						//	1 = Key Column
+						//	2 = Optional Value
+						//	3 = Display Value
+						ResultSetMetaData metaData = rs.getMetaData();
+						int keyValueType = metaData.getColumnType(1);
+						Object keyValue = null;
+						if(keyValueType == Types.VARCHAR
+								|| keyValueType == Types.NVARCHAR
+								|| keyValueType == Types.CHAR
+								|| keyValueType == Types.NCHAR) {
+							keyValue = rs.getString(2);
+						} else {
+							keyValue = rs.getInt(1);
 						}
-					} catch (Exception e) {
-						log.severe(e.getLocalizedMessage());
-						throw new AdempiereException(e);
-					} finally {
-						DB.close(rs, pstmt);
+						String uuid = null;
+						//	Validate if exist UUID
+						int uuidIndex = getColumnIndex(metaData, I_AD_Element.COLUMNNAME_UUID);
+						if(uuidIndex != -1) {
+							uuid = rs.getString(uuidIndex);
+						}
+						//	
+						builder = convertDefaultValueFromResult(keyValue, uuid, rs.getString(2), rs.getString(3));
 					}
+				} catch (Exception e) {
+					log.severe(e.getLocalizedMessage());
+					e.printStackTrace();
+					throw new AdempiereException(e);
+				} finally {
+					DB.close(rs, pstmt);
+					rs = null;
+					pstmt = null;
 				}
 			}
 		} else {

--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -2439,13 +2439,12 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 	 */
 	private DefaultValue.Builder getDefaultKeyAndValue(List<KeyValue> contextAttributes, String defaultValue, int referenceId, int referenceValueId, String columnName, int validationRuleId) {
 		DefaultValue.Builder builder = DefaultValue.newBuilder();
-		if(Util.isEmpty(defaultValue)) {
+		if(Util.isEmpty(defaultValue, true)) {
 			return builder;
 		}
 		Object defaultValueAsObject = null;
 
-		// Fill Env.getCtx()
-		
+		// Fill contex
 		int windowNo = ThreadLocalRandom.current().nextInt(1, 8996 + 1);
 		ContextManager.setContextWithAttributes(windowNo, Env.getCtx(), contextAttributes);
 
@@ -2511,7 +2510,7 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 				}
 
 				MLookupInfo lookupInfo = ReferenceUtil.getReferenceLookupInfo(referenceId, referenceValueId, columnName, validationRuleId);
-				if(lookupInfo == null || Util.isEmpty(lookupInfo.QueryDirect)) {
+				if(lookupInfo == null || Util.isEmpty(lookupInfo.QueryDirect, true)) {
 					return builder;
 				}
 				String sql = MRole.getDefault(Env.getCtx(), false).addAccessSQL(


### PR DESCRIPTION

#### Request
```bash
curl --location 'http://0.0.0.0:8085/api/adempiere/user-interface/window/default-value?field_uuid=8d06274c-fb40-11e8-a479-7a0060f0aa01&id=364&value=O&ts=1691109442189' \
--header 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIxMDAxODY3IiwiQURfQ2xpZW50X0lEIjoxMSwiQURfT3JnX0lEIjowLCJBRF9Sb2xlX0lEIjoxMDIsIkFEX1VzZXJfSUQiOjEwMSwiTV9XYXJlaG91c2VfSUQiOjAsIkFEX0xhbmd1YWdlIjoiZXNfTVgiLCJpYXQiOjE2OTEwNzUwNTIsImV4cCI6MTY5MTE2MTQ1Mn0.3tdP8oeHvdZJJDGajzBt_NO9xYGsIeTFV9cAikA_FrA'
```

#### Response
Before this changes
```json
{
    "code": 500,
    "result": ""
}
```

After this changes
```json
{
    "code": 200,
    "result": {
        "id": 0,
        "uuid": "",
        "attributes": []
    }
}
```

#### Additional context

```log
===========> UserInterfaceServiceImplementation.getDefaultValue: null [41]
java.lang.NullPointerException
        at org.spin.grpc.service.UserInterfaceServiceImplementation.getDefaultKeyAndValue(UserInterfaceServiceImplementation.java:2497)
        at org.spin.grpc.service.UserInterfaceServiceImplementation.getInfoFromDefaultValueRequest(UserInterfaceServiceImplementation.java:2425)
        at org.spin.grpc.service.UserInterfaceServiceImplementation.getDefaultValue(UserInterfaceServiceImplementation.java:602)
        at org.spin.backend.grpc.common.UserInterfaceGrpc$MethodHandlers.invoke(UserInterfaceGrpc.java:2783)
        at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
        at io.grpc.Contexts$ContextualizedServerCallListener.onHalfClose(Contexts.java:86)
        at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:346)
        at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:860)
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
```
