### PR TITLE
fix: `Bank Statement Match` empty name.

### DIFF
--- a/src/main/java/org/spin/form/bank_statement_match/BankStatementMatchConvertUtil.java
+++ b/src/main/java/org/spin/form/bank_statement_match/BankStatementMatchConvertUtil.java
@@ -68,6 +68,11 @@ public class BankStatementMatchConvertUtil {
 					bankStatement.getDocumentNo()
 				)
 			)
+			.setName(
+				ValueUtil.validateNull(
+					bankStatement.getName()
+				)
+			)
 			.setDescription(
 				ValueUtil.validateNull(
 					bankStatement.getDescription()


### PR DESCRIPTION
Set Bank Statement name.

fixes https://github.com/solop-develop/frontend-core/issues/1297
fixes https://github.com/solop-develop/frontend-core/issues/1298