### PR TITLE
fix: `Bank Statement Match` form, matches/unmatches records.

### DIFF
--- a/src/main/java/org/spin/form/bank_statement_match/BankStatementMatchConvertUtil.java
+++ b/src/main/java/org/spin/form/bank_statement_match/BankStatementMatchConvertUtil.java
@@ -385,6 +385,11 @@ public class BankStatementMatchConvertUtil {
 					bankStatemet.getTrxAmt()
 				)
 			)
+			.setIsAutomatic(
+				ValueUtil.stringToBoolean(
+					bankStatemet.getEftMemo()
+				)
+			)
 		;
 
 		if (bankStatemet.getC_Payment_ID() > 0) {
@@ -393,6 +398,11 @@ public class BankStatementMatchConvertUtil {
 				.setDocumentNo(
 					ValueUtil.validateNull(
 						payment.getDocumentNo()
+					)
+				)
+				.setPaymentAmount(
+					ValueUtil.getDecimalFromBigDecimal(
+						payment.getPayAmt()
 					)
 				)
 			;
@@ -493,6 +503,11 @@ public class BankStatementMatchConvertUtil {
 				.setDocumentNo(
 					ValueUtil.validateNull(
 						payment.getDocumentNo()
+					)
+				)
+				.setPaymentAmount(
+					ValueUtil.getDecimalFromBigDecimal(
+						payment.getPayAmt()
 					)
 				)
 			;

--- a/src/main/java/org/spin/form/bank_statement_match/BankStatementMatchServiceLogic.java
+++ b/src/main/java/org/spin/form/bank_statement_match/BankStatementMatchServiceLogic.java
@@ -373,8 +373,9 @@ public abstract class BankStatementMatchServiceLogic {
 			X_I_BankStatement currentBankStatementImport = new X_I_BankStatement(context, bankStatementId, null);
 			
 			if(currentBankStatementImport.getC_Payment_ID() != 0
-					|| currentBankStatementImport.getC_BPartner_ID() != 0
-					|| currentBankStatementImport.getC_Invoice_ID() != 0) {
+				// || currentBankStatementImport.getC_BPartner_ID() != 0
+				// || currentBankStatementImport.getC_Invoice_ID() != 0
+			) {
 				//	put on hash
 				matchedPaymentHashMap.put(currentBankStatementImport.getC_Payment_ID(), currentBankStatementImport);
 				matched++;

--- a/src/main/java/org/spin/form/bank_statement_match/BankStatementMatchUtil.java
+++ b/src/main/java/org/spin/form/bank_statement_match/BankStatementMatchUtil.java
@@ -78,13 +78,13 @@ public class BankStatementMatchUtil {
 		paymentFilters.add(bankAccountId);
 
 		//	Match
-		if(isMatchedMode) {
-			whereClasuePayment += "AND EXISTS(SELECT 1 FROM I_BankStatement ibs "
-				+ "WHERE ibs.C_Payment_ID = C_Payment.C_Payment_ID) ";
-		} else {
-			whereClasuePayment += "AND NOT EXISTS(SELECT 1 FROM I_BankStatement ibs "
-				+ "WHERE ibs.C_Payment_ID = C_Payment.C_Payment_ID) ";
-		}
+		// if(isMatchedMode) {
+		// 	whereClasuePayment += "AND EXISTS(SELECT 1 FROM I_BankStatement ibs "
+		// 		+ "WHERE ibs.C_Payment_ID = C_Payment.C_Payment_ID) ";
+		// } else {
+		// 	whereClasuePayment += "AND NOT EXISTS(SELECT 1 FROM I_BankStatement ibs "
+		// 		+ "WHERE ibs.C_Payment_ID = C_Payment.C_Payment_ID) ";
+		// }
 
 		//	Date Trx
 		if (dateFrom != null) {
@@ -142,15 +142,15 @@ public class BankStatementMatchUtil {
 		filterParameters.add(bankAccountId);
 
 		//	Match
-		if(isMatchedMode) {
-			whereClasueBankStatement += "AND (C_Payment_ID IS NOT NULL "
-				+ "OR C_BPartner_ID IS NOT NULL "
-				+ "OR C_Invoice_ID IS NOT NULL) ";
-		} else {
-			whereClasueBankStatement += "AND (C_Payment_ID IS NULL "
-				+ "AND C_BPartner_ID IS NULL "
-				+ "AND C_Invoice_ID IS NULL) ";
-		}
+		// if(isMatchedMode) {
+		// 	whereClasueBankStatement += "AND (C_Payment_ID IS NOT NULL "
+		// 		+ "OR C_BPartner_ID IS NOT NULL "
+		// 		+ "OR C_Invoice_ID IS NOT NULL) ";
+		// } else {
+		// 	whereClasueBankStatement += "AND (C_Payment_ID IS NULL "
+		// 		+ "AND C_BPartner_ID IS NULL "
+		// 		+ "AND C_Invoice_ID IS NULL) ";
+		// }
 
 		//	Date Trx
 		if (dateFrom != null) {

--- a/src/main/proto/bank_statement_match.proto
+++ b/src/main/proto/bank_statement_match.proto
@@ -238,6 +238,8 @@ message MatchingMovement {
 	string reference_no = 11;
 	string memo = 12;
 	int32 payment_id = 13;
+	bool is_automatic = 14;
+	data.Decimal payment_amount = 15;
 }
 
 message ListMatchingMovementsResponse {
@@ -262,6 +264,8 @@ message ResultMovement {
 	string reference_no = 11;
 	string memo = 12;
 	int32 payment_id = 13;
+	bool is_automatic = 14;
+	data.Decimal payment_amount = 15;
 }
 
 message ListResultMovementsRequest {


### PR DESCRIPTION

- List Imported Payments, regardless if it is matches.
- List Payments, regardless if it is matches.
- Add `isAutomatic` matches.
- Add `PaymentAmount`.

