### PR TITLE
Fix not found column

### DIFF
--- a/src/main/java/org/spin/base/db/WhereClauseUtil.java
+++ b/src/main/java/org/spin/base/db/WhereClauseUtil.java
@@ -526,11 +526,13 @@ public class WhereClauseUtil {
 					mainColumnName = childColumn;
 				}
 
-				whereClause.append(table.getTableName()).append(".").append(childColumn);
-				if (mainColumnName != null && mainColumnName.endsWith("_ID")) {
-					whereClause.append(" = ").append("@").append(mainColumnName).append("@");
-				} else {
-					whereClause.append(" = ").append("'@").append(mainColumnName).append("@'");
+				if (table.getColumn(childColumn) != null) {
+					whereClause.append(table.getTableName()).append(".").append(childColumn);
+					if (mainColumnName != null && mainColumnName.endsWith("_ID")) {
+						whereClause.append(" = ").append("@").append(mainColumnName).append("@");
+					} else {
+						whereClause.append(" = ").append("'@").append(mainColumnName).append("@'");
+					}
 				}
 				if(optionalTab.isPresent()) {
 					parentTabUuid = optionalTab.get().getUUID();


### PR DESCRIPTION
Cuando hay 2 pestañas que no comparten campos en comun, zk permitia "joinearlas" mediante la clausula SQL del AD_Tab.
Ahora en VUE, a lo que tenga la clausula le agrega el ID de la ventana de nivel 0
Esto causa que se intente hacer un join con la tabla lvl1 con la superior lvl0 por su campo ID, siendo que no tienen campos en comun.
Esto causa un error SQL de campo no encontrado que hace que no se carguen registros en la pestaña