### PR TITLE
fix: Callout wiith `isSOTrx` context.

### DIFF
--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -3170,6 +3170,13 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 					Value.Builder valueBuilder = ValueUtil.getValueFromReference(fieldValue.getValue(), fieldValue.getDisplayType());
 					calloutBuilder.putValues(fieldValue.getColumnName(), valueBuilder.build());
 				});
+
+			// always add is sales transaction on context
+			String isSalesTransaction = Env.getContext(tab.getCtx(), windowNo, "IsSOTrx", true);
+			if (!Util.isEmpty(isSalesTransaction, true)) {
+				Value.Builder valueBuilder = ValueUtil.getValueFromBoolean(isSalesTransaction);
+				calloutBuilder.putValues("IsSOTrx", valueBuilder.build());
+			}
 			calloutBuilder.setResult(ValueUtil.validateNull(result));
 			
 			setAdditionalContext(request.getCallout(), windowNo, calloutBuilder);


### PR DESCRIPTION
when a callout is executed for example in `C Payment`, it does not have `IsSOTrx` as a field, but the callout sends it to the context and the value does not reach the client.

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/1122