### PR TITLE
fix: Query warehouses with limit and access filter and records.

### DIFF
--- a/src/main/java/org/spin/grpc/service/CoreFunctionalityImplementation.java
+++ b/src/main/java/org/spin/grpc/service/CoreFunctionalityImplementation.java
@@ -832,6 +832,7 @@ public class CoreFunctionalityImplementation extends CoreFunctionalityImplBase {
 			responseObserver.onCompleted();
 		} catch (Exception e) {
 			log.severe(e.getLocalizedMessage());
+			e.printStackTrace();
 			responseObserver.onError(Status.INTERNAL
 				.withDescription(e.getLocalizedMessage())
 				.withCause(e)
@@ -865,14 +866,15 @@ public class CoreFunctionalityImplementation extends CoreFunctionalityImplBase {
 			whereClause,
 			null
 		)
+			.setParameters(organizationId, false)
 			.setOnlyActiveRecords(true)
 			.setApplyAccessFilter(MRole.SQL_FULLYQUALIFIED, MRole.SQL_RO)
-			.setParameters(organizationId, false)
 		;
 		//	Count
 		int count = query.count();
 		//	Get List
-		query.setLimit(limit, offset)
+		// TODO: Fix .setLimit combined with .setApplyAccessFilter and with access record (ROWNUM error)
+		query //.setLimit(limit, offset)
 			.<MWarehouse>list()
 			.forEach(warehouse -> {
 				builder.addWarehouses(ConvertUtil.convertWarehouse(warehouse));


### PR DESCRIPTION

#### Request

```bash
curl --location 'http://0.0.0.0:8085/api/adempiere/common/warehouses?organization_uuid=e1a4a3f6-f352-4e64-b068-a333ef6c747d&page_size=100&ts=1692903771838' \
--header 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIxMTM1NDQ3IiwiQURfQ2xpZW50X0lEIjoxMDAwMDAwLCJBRF9PcmdfSUQiOjEwMDAwMjAsIkFEX1JvbGVfSUQiOjEwMDAxMTEsIkFEX1VzZXJfSUQiOjEwMDAwOTMsIk1fV2FyZWhvdXNlX0lEIjoxMDAwMDcwLCJBRF9MYW5ndWFnZSI6ImVzX1ZFIiwiaWF0IjoxNjkyOTAyODg1LCJleHAiOjE2OTI5ODkyODV9.mlAoSAJAkOf_Pl6z56ESkBdL38sw9MwS9293aceUagE'
```


#### Response

Before this changes
```json
{
    "code": 500,
    "result": "org.postgresql.util.PSQLException: ERROR: column \"rownum\" does not exist\n  Position: 277, SQL=SELECT AD_Client_ID,AD_Org_ID,C_Location_ID,Created,CreatedBy,Description,IsActive,IsInTransit,M_Warehouse_ID,M_WarehouseSource_ID,Name,ReplenishmentClass,Separator,Updated,UpdatedBy,UUID,Value FROM M_Warehouse WHERE (AD_Org_ID = ? AND IsInTransit = ? ) AND IsActive=? AND ROWNUM <= 100 AND ROWNUM >= 0 AND M_Warehouse.AD_Client_ID IN(0,1000000) AND M_Warehouse.AD_Org_ID IN(0,1000020) AND M_Warehouse.M_Warehouse_ID NOT IN (1000295) AND (M_Warehouse.M_WarehouseSource_ID IS NULL OR  NOT EXISTS(SELECT 1 FROM M_Warehouse AS bbbc WHERE bbbc.M_Warehouse_ID = M_Warehouse.M_WarehouseSource_ID AND bbbc.M_Warehouse_ID=1000295))"
}
```

After this changes
```json
{
    "code": 200,
    "result": {
        "record_count": 1,
        "next_page_token": "",
        "records": [
            {
                "id": 1000070,
                "uuid": "c77879d2-4f11-4d9a-8ed8-77a39c988f2b",
                "name": "Principal (AC)",
                "description": ""
            }
        ]
    }
}
```

#### Additional context
There is an error in the `Query` class of adempiere, when combining the `.setLimit` and `setApplyAccessFilter` methods, and having active records in `AD_Record_Access` referencing the main table of the query, the sql error is generated.

This is because in the `Convert_PostgresSQL` class, specifically in the `convertRowNum` method, when evaluating the subquery that is at the end of the sql, it does not evaluate correctly the main query.



