### PR TITLE
Minor change for source code

### DIFF
--- a/src/main/java/org/spin/base/db/WhereClauseUtil.java
+++ b/src/main/java/org/spin/base/db/WhereClauseUtil.java
@@ -624,6 +624,7 @@ public class WhereClauseUtil {
 	 * @param values
 	 * @return
 	 */
+	@Deprecated
 	public static String getBrowserWhereClause(MBrowse browser, String parsedWhereClause,
 			List<KeyValue> contextAttributes, HashMap<String, Object> parameterMap, List<Object> values) {
 		AtomicReference<String> convertedWhereClause = new AtomicReference<String>(parsedWhereClause);


### PR DESCRIPTION
Avoid warning at building

```Java
adempiere-grpc-server/src/main/java/org/spin/base/db/WhereClauseUtil.java:627:
warning: [dep-ann] deprecated item is not annotated with @Deprecated
        public static String getBrowserWhereClause(MBrowse browser,
String parsedWhereClause,
                             ^
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
1 warning
```