### PR TITLE
fix: Smart Browse with ASP custom.

### DIFF
--- a/src/main/java/org/spin/base/dictionary/custom/BrowseFieldCustomUtil.java
+++ b/src/main/java/org/spin/base/dictionary/custom/BrowseFieldCustomUtil.java
@@ -27,7 +27,7 @@ public class BrowseFieldCustomUtil {
 
 	public static MBrowseFieldCustom getBrowseFieldCustom(int browseFieldId) {
 		final int userId = Env.getAD_User_ID(Env.getCtx());
-		final String whereClauseUser = "AD_BrowseField_ID = ? AND EXISTS( "
+		final String whereClauseUser = "AD_Browse_Field_ID = ? AND EXISTS( "
 			+ "SELECT 1 FROM AD_BrowseCustom AS bc "
 			+ "WHERE bc.AD_User_ID = ? "
 			+ "AND bc.AD_BrowseCustom_ID = AD_BrowseFieldCustom.AD_BrowseCustom_ID"
@@ -44,7 +44,7 @@ public class BrowseFieldCustomUtil {
 		;
 		if (browseFieldCustom == null) {
 			final int roleId = Env.getAD_Role_ID(Env.getCtx());
-			final String whereClauseRole = "AD_BrowseField_ID = ? AND EXISTS( "
+			final String whereClauseRole = "AD_Browse_Field_ID = ? AND EXISTS( "
 				+ "SELECT 1 FROM AD_BrowseCustom AS bc "
 				+ "WHERE bc.AD_Role_ID = ? "
 				+ "AND bc.AD_BrowseCustom_ID = AD_BrowseFieldCustom.AD_BrowseCustom_ID"


### PR DESCRIPTION

```log
===========> Query.first: SELECT AD_BrowseCustom_ID,AD_BrowseFieldCustom_ID,AD_Browse_Field_ID,AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Reference_Value_ID,AD_Val_Rule_ID,Axis_Column_ID,Axis_Parent_Column_ID,Callout,Created,CreatedBy,DefaultValue,DefaultValue2,Description,DisplayLogic,Help,InfoFactoryClass,IsActive,IsDisplayed,IsDisplayedAsPanel,IsDisplayedAsTable,IsIdentifier,IsInfoOnly,IsKey,IsMandatory,IsOrderBy,IsQueryCriteria,IsRange,IsReadOnly,Name,ReadOnlyLogic,SeqNo,SeqNoGrid,SortNo,UUID,Updated,UpdatedBy,VFormat,ValueMax,ValueMin FROM AD_BrowseFieldCustom WHERE (AD_BrowseField_ID = ? AND EXISTS( SELECT 1 FROM AD_BrowseCustom AS bc WHERE bc.AD_User_ID = ? AND bc.AD_BrowseCustom_ID = AD_BrowseFieldCustom.AD_BrowseCustom_ID)) AND IsActive=? [22]
org.postgresql.util.PSQLException: ERROR: column "ad_browsefield_id" does not exist
  Hint: Perhaps you meant to reference the column "ad_browsefieldcustom.ad_browse_field_id".
  Position: 553; State=42703; ErrorCode=0
        at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2675)
        at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2365)
        at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:355)
        at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:490)
        at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:408)
        at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:166)
        at org.postgresql.jdbc.PgPreparedStatement.executeQuery(PgPreparedStatement.java:118)
        at com.zaxxer.hikari.pool.ProxyPreparedStatement.executeQuery(ProxyPreparedStatement.java:52)
        at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeQuery(HikariProxyPreparedStatement.java)
        at jdk.internal.reflect.GeneratedMethodAccessor1.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.compiere.db.StatementProxy.invoke(StatementProxy.java:100)
        at com.sun.proxy.$Proxy4.executeQuery(Unknown Source)
        at org.compiere.model.Query.createResultSet(Query.java:781)
        at org.compiere.model.Query.first(Query.java:315)
        at org.spin.base.dictionary.custom.BrowseFieldCustomUtil.getBrowseFieldCustom(BrowseFieldCustomUtil.java:43)
        at org.spin.grpc.service.DictionaryServiceImplementation.convertBrowseField(DictionaryServiceImplementation.java:1075)
        at org.spin.grpc.service.DictionaryServiceImplementation.convertBrowser(DictionaryServiceImplementation.java:847)
        at org.spin.grpc.service.DictionaryServiceImplementation.convertBrowser(DictionaryServiceImplementation.java:519)
        at org.spin.grpc.service.DictionaryServiceImplementation.getBrowser(DictionaryServiceImplementation.java:217)

===========> DictionaryServiceImplementation.getBrowser: org.postgresql.util.PSQLException: ERROR: column "ad_browsefield_id" does not exist
  Hint: Perhaps you meant to reference the column "ad_browsefieldcustom.ad_browse_field_id".
  Position: 553, SQL=SELECT AD_BrowseCustom_ID,AD_BrowseFieldCustom_ID,AD_Browse_Field_ID,AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Reference_Value_ID,AD_Val_Rule_ID,Axis_Column_ID,Axis_Parent_Column_ID,Callout,Created,CreatedBy,DefaultValue,DefaultValue2,Description,DisplayLogic,Help,InfoFactoryClass,IsActive,IsDisplayed,IsDisplayedAsPanel,IsDisplayedAsTable,IsIdentifier,IsInfoOnly,IsKey,IsMandatory,IsOrderBy,IsQueryCriteria,IsRange,IsReadOnly,Name,ReadOnlyLogic,SeqNo,SeqNoGrid,SortNo,UUID,Updated,UpdatedBy,VFormat,ValueMax,ValueMin FROM AD_BrowseFieldCustom WHERE (AD_BrowseField_ID = ? AND EXISTS( SELECT 1 FROM AD_BrowseCustom AS bc WHERE bc.AD_User_ID = ? AND bc.AD_BrowseCustom_ID = AD_BrowseFieldCustom.AD_BrowseCustom_ID)) AND IsActive=? [22]
``