### PR TITLE
Add support to Envoy proxy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,12 @@ jobs:
           GITHUB_DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
           GITHUB_DEPLOY_REPOSITORY: ${{ secrets.DEPLOY_REPOSITORY }}
 
+      - name: Upload descriptor file artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: adempiere-grpc-server.pb
+          path: build/descriptors/adempiere-grpc-server.pb
+          
       - name: Upload dist app zip artifact
         uses: actions/upload-artifact@v3
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,24 @@ protobuf {
         all()*.plugins {
             grpc {}
         }
+        all().configureEach { task ->
+      		  // If true, will generate a descriptor_set.desc file under
+			  // task.outputBaseDir. Default is false.
+			  // See --descriptor_set_out in protoc documentation about what it is.
+			  task.generateDescriptorSet = true
+			
+			  // Allows to override the default for the descriptor set location
+			  task.descriptorSetOptions.path =
+			    "${projectDir}/build/descriptors/adempiere-grpc-server.pb"
+			
+			  // If true, the descriptor set will contain line number information
+			  // and comments. Default is false.
+			  task.descriptorSetOptions.includeSourceInfo = true
+			
+			  // If true, the descriptor set will contain all transitive imports and
+			  // is therefore self-contained. Default is false.
+			  task.descriptorSetOptions.includeImports = true
+    	}
     }
 }
 

--- a/resources/envoy.yaml
+++ b/resources/envoy.yaml
@@ -1,0 +1,60 @@
+static_resources:
+  listeners:
+  - name: listener1
+    address:
+      socket_address: {address: 0.0.0.0, port_value: 51051}
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: grpc_json
+          codec_type: AUTO
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: ["*"]
+              routes:
+              # NOTE: by default, matching happens based on the gRPC route, and not on the incoming request path.
+              # Reference: https://envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/grpc_json_transcoder_filter#route-configs-for-transcoded-requests
+              # https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/grpc_json_transcoder_filter#sample-envoy-configuration
+              - match: {prefix: "/"}
+                route: {cluster: grpc, timeout: 60s}
+          http_filters:
+          - name: envoy.filters.http.grpc_json_transcoder
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder
+              proto_descriptor: "/data/service_definition.pb"
+              services: ["security.Security"]
+              print_options:
+                add_whitespace: true
+                always_print_primitive_fields: true
+                always_print_enums_as_ints: false
+                preserve_proto_field_names: false
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+  clusters:
+  - name: grpc
+    type: LOGICAL_DNS
+    lb_policy: ROUND_ROBIN
+    dns_lookup_family: V4_ONLY
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http2_protocol_options: {}
+    load_assignment:
+      cluster_name: grpc
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                # WARNING: "docker.for.mac.localhost" has been deprecated from Docker v18.03.0.
+                # If you're running an older version of Docker, please use "docker.for.mac.localhost" instead.
+                # Reference: https://docs.docker.com/docker-for-mac/release-notes/#docker-community-edition-18030-ce-mac59-2018-03-26
+                address: adempiere.grpc.server
+                port_value: 50059

--- a/src/main/proto/security.proto
+++ b/src/main/proto/security.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 option java_multiple_files = true;
 option java_package = "org.spin.backend.grpc.security";
 option java_outer_classname = "ADempiereSecurity";
+import "google/api/annotations.proto";
 
 package security;
 
@@ -38,7 +39,11 @@ service Security {
 	// List Roles
 	rpc ListRoles(ListRolesRequest) returns (ListRolesResponse) {}
 	// List Available Services
-	rpc ListServices(ListServicesRequest) returns (ListServicesResponse) {}
+	rpc ListServices(ListServicesRequest) returns (ListServicesResponse) {
+		// Client example - returns the first shelf:
+  		// curl http://DOMAIN_NAME/v1/services/
+  		option (google.api.http) = { get: "/security/services" };
+	}
 	// Request login from Open ID
 	rpc RunLoginOpenID(LoginOpenIDRequest) returns (Session) {}
 }


### PR DESCRIPTION
This pull request allows generate descriptor file for envoy proxy and transcoding gRPC to JSON, see:
- https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/grpc_json_transcoder_filter#route-configs-for-transcoded-requests
- https://github.com/google/protobuf-gradle-plugin/pull/30
- https://github.com/google/protobuf-gradle-plugin#generate-descriptor-set-files
- https://github.com/toefel18/transcoding-grpc-to-http-json