### PR TITLE
fix: Smart Browse search with range query criteria.

### DIFF
--- a/src/main/java/org/spin/base/db/WhereClauseUtil.java
+++ b/src/main/java/org/spin/base/db/WhereClauseUtil.java
@@ -810,7 +810,7 @@ public class WhereClauseUtil {
 				if (rangeAdd.containsKey(viewColumn.getColumnName())) {
 					return;
 				}
-				if (browseField.isRange()) {
+				if (browseField.isRange() && (ValueUtil.isEmptyValue(value) || ValueUtil.isEmptyValue(valueTo))) {
 					final String columnNameParameter = viewColumn.getColumnName();
 					Condition conditionStart = parametersList.stream().filter(parameter -> {
 						return parameter.getColumnName().equals(columnNameParameter);
@@ -829,12 +829,17 @@ public class WhereClauseUtil {
 							.orElse(Condition.newBuilder().build())
 						;
 						valueTo = conditionEnd.getValue();
-						operatorTo = conditionEnd.getOperatorValue();
+						operatorValue = conditionEnd.getOperatorValue();
+						if (conditionStart.getOperatorValue() > 0 && operatorValue == Operator.VOID_VALUE) {
+							operatorValue = conditionStart.getOperatorValue();
+						}
 					}
 	
 					columnName = viewColumn.getColumnSQL();
 					if (conditionStart.getOperator() == Operator.GREATER_EQUAL && operatorTo == Operator.LESS_EQUAL_VALUE) {
 						operatorValue = Operator.BETWEEN_VALUE;
+					} else if (operatorValue == Operator.BETWEEN_VALUE) {
+						; // omit
 					} else {
 						if (whereClause.length() > 0) {
 							whereClause.append(" AND ");

--- a/src/main/java/org/spin/base/util/ValueUtil.java
+++ b/src/main/java/org/spin/base/util/ValueUtil.java
@@ -55,6 +55,19 @@ public class ValueUtil {
 
 
 	/**
+	 * Value is empty
+	 * @param value
+	 * @return
+	 */
+	public static boolean isEmptyValue(Value value) {
+		return value == null
+			|| value.isInitialized()
+			|| value.getValueType() == ValueType.UNKNOWN
+		;
+	}
+
+
+	/**
 	 * Get Value 
 	 * @param value
 	 * @return


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Process Orders of selection` smart browse.
2. Displayed `Date Ordered` query criteria field.
3. Select any range.

#### Screenshot or Gif

https://github.com/solop-develop/frontend-core/assets/20288327/d0e71f96-1451-4212-8a69-f70c2b7834dc


#### Additional context
fixes https://github.com/solop-develop/adempiere-grpc-server/issues/515

