### PR TITLE
fix: Smart Browser omit `isInfoOnly` fields from query criteria.

### DIFF
--- a/src/main/java/org/spin/base/db/WhereClauseUtil.java
+++ b/src/main/java/org/spin/base/db/WhereClauseUtil.java
@@ -803,7 +803,7 @@ public class WhereClauseUtil {
 					String rangeColumnName = columnName.substring(0, columnName.length() - "_To".length());
 					browseField = browseFields.get(rangeColumnName);
 				}
-				if (browseField == null) {
+				if (browseField == null || browseField.isInfoOnly()) {
 					return;
 				}
 				MViewColumn viewColumn = browseField.getAD_View_Column();
@@ -829,9 +829,9 @@ public class WhereClauseUtil {
 							.orElse(Condition.newBuilder().build())
 						;
 						valueTo = conditionEnd.getValue();
-						operatorValue = conditionEnd.getOperatorValue();
+						operatorTo = conditionEnd.getOperatorValue();
 						if (conditionStart.getOperatorValue() > 0 && operatorValue == Operator.VOID_VALUE) {
-							operatorValue = conditionStart.getOperatorValue();
+							operatorTo = conditionStart.getOperatorValue();
 						}
 					}
 	

--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -2928,8 +2928,10 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 				throw new AdempiereException("@AD_Browse_ID@ @WhereClause@ @Unparseable@");
 			}
 			whereClause
-				.append(" AND ")
-				.append(parsedWhereClause);
+				.append(" AND (")
+				.append(parsedWhereClause)
+				.append(")")
+			;
 		}
 
 		//	For dynamic condition


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce



#### Screenshot or Gif


https://github.com/solop-develop/frontend-core/assets/20288327/3ac66537-5fa7-403d-b32c-cde3bf40b21c

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/1478

