### PR TITLE
fix: (Transcoding) Main Dashboards with role and user from backend context.

### DIFF
--- a/src/main/proto/dashboarding.proto
+++ b/src/main/proto/dashboarding.proto
@@ -85,7 +85,6 @@ message ListDashboardsRequest {
 	int32 page_size = 5;
 	string page_token = 6;
 	string search_value = 7;
-	int32 role_id = 8;
 }
 
 //	Dashboards List
@@ -104,7 +103,6 @@ message ListFavoritesRequest {
 	int32 page_size = 5;
 	string page_token = 6;
 	string search_value = 7;
-	int32 user_id = 8;
 }
 
 // Recent Item
@@ -132,8 +130,6 @@ message ListPendingDocumentsRequest {
 	int32 page_size = 5;
 	string page_token = 6;
 	string search_value = 7;
-	int32 user_id = 8;
-	int32 role_id = 9;
 }
 
 //	Recent Items List


### PR DESCRIPTION
Get main dashboards wihtout `Role ID` or `User ID`.

#### Request

```bash
curl 'http://0.0.0.0/api/dashboard/dashboards?role_id=0&page_size=15' -H 'Accept: application/json, text/plain, */*' -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIxMDAwMDk4IiwiQURfQ2xpZW50X0lEIjowLCJBRF9PcmdfSUQiOjAsIkFEX1JvbGVfSUQiOjAsIkFEX1VzZXJfSUQiOjEwMCwiTV9XYXJlaG91c2VfSUQiOjAsIkFEX0xhbmd1YWdlIjoiZXNfTVgiLCJpYXQiOjE2OTcwMzczNzMsImV4cCI6MTY5NzEyMzc3M30.sL4trGbkWXCvwTI4u0ATgFrRECUuM9xurjZq8G1FO5U'
```

#### Response

```json
{
	"code": 13,
	"message": "Rol * No encontrado *",
	"details": []
}
```

