### PR TITLE
fix: When the process exists in the access table generates NPE.

### DIFF
--- a/src/main/java/org/spin/grpc/service/BusinessData.java
+++ b/src/main/java/org/spin/grpc/service/BusinessData.java
@@ -218,7 +218,10 @@ public class BusinessData extends BusinessDataImplBase {
 		if(process == null || process.getAD_Process_ID() <= 0) {
 			throw new AdempiereException("@AD_Process_ID@ @NotFound@");
 		}
-		if(!MRole.getDefault().getProcessAccess(process.getAD_Process_ID())) {
+
+		// Role access
+		Boolean isWithAccess = MRole.getDefault().getProcessAccess(process.getAD_Process_ID());
+		if(isWithAccess == null || !isWithAccess.booleanValue()) {
 			if (process.isReport()) {
 				throw new AdempiereException("@AccessCannotReport@");
 			}


### PR DESCRIPTION
when the process no exists in the access table it generates NPE since it returns the `Boolean` object in null, and on this it tries to cascade to `boolean`.


fixes https://github.com/solop-develop/frontend-core/issues/1640