### PR TITLE
fix: `Search Value` decode url value.

### DIFF
--- a/src/main/java/org/spin/base/db/FromUtil.java
+++ b/src/main/java/org/spin/base/db/FromUtil.java
@@ -59,7 +59,7 @@ public class FromUtil {
 			patternTableWithAliases = patternOnlyTableAlias;
 		}
 
-		// if (!Util.isEmpty(patternOnlyTableAlias, false)) {
+		// if (!Util.isEmpty(patternOnlyTableAlias, true)) {
 		// 	patternTableWithAliases = patternOnlyTableAlias + "|" + patternOnlyTableName;
 		// }
 

--- a/src/main/java/org/spin/base/util/RecordUtil.java
+++ b/src/main/java/org/spin/base/util/RecordUtil.java
@@ -15,8 +15,6 @@
  *************************************************************************************/
 package org.spin.base.util;
 
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -333,7 +331,9 @@ public class RecordUtil {
 		}
 
 		// URL decode to change characteres
-		String searchValue = URLDecoder.decode(search_value, StandardCharsets.UTF_8);
+		final String searchValue = ValueManager.getDecodeUrl(
+			search_value
+		);
 
 		String lang = Env.getAD_Language(Env.getCtx());
 		// search on trl table

--- a/src/main/java/org/spin/form/import_file_loader/ImportFileLoaderServiceLogic.java
+++ b/src/main/java/org/spin/form/import_file_loader/ImportFileLoaderServiceLogic.java
@@ -123,11 +123,14 @@ public class ImportFileLoaderServiceLogic {
 			.setRecordCount(charsetsList.size())
 		;
 
-		if (!Util.isEmpty(request.getSearchValue(), true)) {
-			final String searchValue = request.getSearchValue().toLowerCase();
-
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if (!Util.isEmpty(searchValue, true)) {
 			charsetsList = charsetsList.stream().filter(charset -> {
-				return charset.name().toLowerCase().contains(searchValue);
+				return charset.name().toLowerCase().contains(
+					searchValue.toLowerCase()
+				);
 			})
 			.collect(Collectors.toList());
 		}

--- a/src/main/java/org/spin/grpc/service/CoreFunctionality.java
+++ b/src/main/java/org/spin/grpc/service/CoreFunctionality.java
@@ -216,16 +216,18 @@ public class CoreFunctionality extends CoreFunctionalityImplBase {
 			if(request == null) {
 				throw new AdempiereException("Object Request Null");
 			}
-			log.fine("Add Line for Order = " + request.getSearchValue());
 			ListBusinessPartnersResponse.Builder businessPartnerList = getBusinessPartnerList(request);
 			responseObserver.onNext(businessPartnerList.build());
 			responseObserver.onCompleted();
 		} catch (Exception e) {
 			log.severe(e.getLocalizedMessage());
-			responseObserver.onError(Status.INTERNAL
+			e.printStackTrace();
+			responseObserver.onError(
+				Status.INTERNAL
 					.withDescription(e.getLocalizedMessage())
 					.withCause(e)
-					.asRuntimeException());
+					.asRuntimeException()
+			);
 		}
 	}
 	
@@ -236,16 +238,18 @@ public class CoreFunctionality extends CoreFunctionalityImplBase {
 			if(request == null) {
 				throw new AdempiereException("Object Request Null");
 			}
-			log.fine("Object Requested = " + request.getSearchValue());
 			BusinessPartner.Builder businessPartner = getBusinessPartner(request);
 			responseObserver.onNext(businessPartner.build());
 			responseObserver.onCompleted();
 		} catch (Exception e) {
 			log.severe(e.getLocalizedMessage());
-			responseObserver.onError(Status.INTERNAL
+			e.printStackTrace();
+			responseObserver.onError(
+				Status.INTERNAL
 					.withDescription(e.getLocalizedMessage())
 					.withCause(e)
-					.asRuntimeException());
+					.asRuntimeException()
+			);
 		}
 	}
 	
@@ -364,8 +368,12 @@ public class CoreFunctionality extends CoreFunctionalityImplBase {
 		StringBuffer whereClause = new StringBuffer();
 		//	Parameters
 		List<Object> parameters = new ArrayList<Object>();
+
 		//	For search value
-		if(!Util.isEmpty(request.getSearchValue())) {
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if(!Util.isEmpty(searchValue, true)) {
 			whereClause.append("("
 				+ "UPPER(Value) LIKE '%' || UPPER(?) || '%' "
 				+ "OR UPPER(Name) LIKE '%' || UPPER(?) || '%' "
@@ -373,10 +381,10 @@ public class CoreFunctionality extends CoreFunctionalityImplBase {
 				+ "OR UPPER(Description) LIKE '%' || UPPER(?) || '%'"
 				+ ")");
 			//	Add parameters
-			parameters.add(request.getSearchValue());
-			parameters.add(request.getSearchValue());
-			parameters.add(request.getSearchValue());
-			parameters.add(request.getSearchValue());
+			parameters.add(searchValue);
+			parameters.add(searchValue);
+			parameters.add(searchValue);
+			parameters.add(searchValue);
 		}
 		//	For value
 		if(!Util.isEmpty(request.getValue())) {
@@ -637,15 +645,19 @@ public class CoreFunctionality extends CoreFunctionalityImplBase {
 		StringBuffer whereClause = new StringBuffer();
 		//	Parameters
 		List<Object> parameters = new ArrayList<Object>();
+
 		//	For search value
-		if(!Util.isEmpty(request.getSearchValue())) {
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if(!Util.isEmpty(searchValue, true)) {
 			whereClause.append("("
 				+ "UPPER(Value) = UPPER(?) "
 				+ "OR UPPER(Name) = UPPER(?)"
 				+ ")");
 			//	Add parameters
-			parameters.add(request.getSearchValue());
-			parameters.add(request.getSearchValue());
+			parameters.add(searchValue);
+			parameters.add(searchValue);
 		}
 		//	For value
 		if(!Util.isEmpty(request.getValue())) {

--- a/src/main/java/org/spin/grpc/service/MatchPOReceiptInvoice.java
+++ b/src/main/java/org/spin/grpc/service/MatchPOReceiptInvoice.java
@@ -413,8 +413,12 @@ public class MatchPOReceiptInvoice extends MatchPORReceiptInvoiceImplBase {
 		String whereClause = "IsPurchased = 'Y' AND IsSummary = 'N' ";
 		//	Parameters
 		List<Object> parameters = new ArrayList<Object>();
+
 		//	For search value
-		if (!Util.isEmpty(request.getSearchValue(), true)) {
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if (!Util.isEmpty(searchValue, true)) {
 			whereClause += " AND ("
 				+ "UPPER(Value) LIKE '%' || UPPER(?) || '%' "
 				+ "OR UPPER(Name) LIKE '%' || UPPER(?) || '%' "
@@ -423,10 +427,10 @@ public class MatchPOReceiptInvoice extends MatchPORReceiptInvoiceImplBase {
 				+ ")"
 			;
 			//	Add parameters
-			parameters.add(request.getSearchValue());
-			parameters.add(request.getSearchValue());
-			parameters.add(request.getSearchValue());
-			parameters.add(request.getSearchValue());
+			parameters.add(searchValue);
+			parameters.add(searchValue);
+			parameters.add(searchValue);
+			parameters.add(searchValue);
 		}
 
 		Query query = new Query(

--- a/src/main/java/org/spin/grpc/service/MaterialManagement.java
+++ b/src/main/java/org/spin/grpc/service/MaterialManagement.java
@@ -414,9 +414,12 @@ public class MaterialManagement extends MaterialManagementImplBase {
 		parameters.add(productAttributeSetId);
 
 		// Add search value to filter
-		if (!Util.isEmpty(request.getSearchValue(), true)) {
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if (!Util.isEmpty(searchValue, true)) {
 			whereClause += " AND (UPPER(Description) LIKE '%' || UPPER(?) || '%')";
-			parameters.add(request.getSearchValue());
+			parameters.add(searchValue);
 		}
 
 		Query query =  new Query(
@@ -834,15 +837,18 @@ public class MaterialManagement extends MaterialManagementImplBase {
 		}
 
 		// Add search value to filter
-		if (!Util.isEmpty(request.getSearchValue(), true)) {
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if (!Util.isEmpty(searchValue, true)) {
 			whereClause += " AND ("
 				+ "UPPER(Value) LIKE '%' || UPPER(?) || '%'"
 				+ "OR UPPER(Name) LIKE '%' || UPPER(?) || '%' "
 				+ "OR UPPER(Description) LIKE '%' || UPPER(?) || '%' "
 			+ ")";
-			parameters.add(request.getSearchValue());
-			parameters.add(request.getSearchValue());
-			parameters.add(request.getSearchValue());
+			parameters.add(searchValue);
+			parameters.add(searchValue);
+			parameters.add(searchValue);
 		}
 
 		Query query = new Query(
@@ -966,9 +972,12 @@ public class MaterialManagement extends MaterialManagementImplBase {
 		}
 
 		// Add search value to filter
-		if (!Util.isEmpty(request.getSearchValue(), true)) {
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if (!Util.isEmpty(searchValue, true)) {
 			whereClause += " AND (UPPER(Value) LIKE '%' || UPPER(?) || '%')";
-			parameters.add(request.getSearchValue());
+			parameters.add(searchValue);
 		}
 
 		// Add dynamic validation to filter

--- a/src/main/java/org/spin/grpc/service/PointOfSalesForm.java
+++ b/src/main/java/org/spin/grpc/service/PointOfSalesForm.java
@@ -1455,11 +1455,17 @@ public class PointOfSalesForm extends StoreImplBase {
 			//	Count records
 			parameters.add(request.getCustomerId());
 			parameters.add(pos.getAD_Org_ID());
-			if(!Util.isEmpty(request.getSearchValue())) {
+
+			// search value
+			final String searchValue = ValueManager.getDecodeUrl(
+				request.getSearchValue()
+			);
+			if(!Util.isEmpty(searchValue, true)) {
 				whereClause.append(" AND UPPER(i.DocumentNo) LIKE '%' || UPPER(?) || '%'");
 				//	Add parameters
-				parameters.add(request.getSearchValue());
+				parameters.add(searchValue);
 			}
+
 			if(request.getDocumentTypeId() > 0) {
 				sql.append(" AND i.C_DocType_ID = ?");
 				parameters.add(request.getDocumentTypeId());
@@ -1471,8 +1477,9 @@ public class PointOfSalesForm extends StoreImplBase {
 			int index = 1;
 			pstmt.setInt(index++, request.getCustomerId());
 			pstmt.setInt(index++, pos.getAD_Org_ID());
+
 			if(whereClause.length() > 0) {
-				pstmt.setString(index++, request.getSearchValue());
+				pstmt.setString(index++, searchValue);
 			}
 			if(request.getDocumentTypeId() > 0) {
 				pstmt.setInt(index++, request.getDocumentTypeId());
@@ -5416,8 +5423,12 @@ public class PointOfSalesForm extends StoreImplBase {
 		StringBuffer whereClause = new StringBuffer();
 		//	Parameters
 		List<Object> parameters = new ArrayList<Object>();
+
 		//	For search value
-		if(!Util.isEmpty(request.getSearchValue())) {
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if(!Util.isEmpty(searchValue, true)) {
 			whereClause.append("IsSold = 'Y' "
 				+ "AND ("
 				+ "UPPER(Value) LIKE '%' || UPPER(?) || '%'"
@@ -5426,10 +5437,10 @@ public class PointOfSalesForm extends StoreImplBase {
 				+ "OR UPPER(SKU) = UPPER(?)"
 				+ ")");
 			//	Add parameters
-			parameters.add(request.getSearchValue());
-			parameters.add(request.getSearchValue());
-			parameters.add(request.getSearchValue());
-			parameters.add(request.getSearchValue());
+			parameters.add(searchValue);
+			parameters.add(searchValue);
+			parameters.add(searchValue);
+			parameters.add(searchValue);
 		} 
 		//	for price list
 		if(whereClause.length() > 0) {
@@ -5686,7 +5697,17 @@ public class PointOfSalesForm extends StoreImplBase {
 	private ProductPrice.Builder getProductPrice(GetProductPriceRequest request) {
 		//	Get Product
 		MProduct product = null;
-		if(!Util.isEmpty(request.getSearchValue(), true)) {
+
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if(!Util.isEmpty(searchValue, true)) {
+			List<Object> parameters = new ArrayList<Object>();
+			parameters.add(searchValue);
+			parameters.add(searchValue);
+			parameters.add(searchValue);
+			parameters.add(searchValue);
+
 			product = new Query(
 				Env.getCtx(),
 				I_M_Product.Table_Name,
@@ -5698,7 +5719,7 @@ public class PointOfSalesForm extends StoreImplBase {
 				+ ")",
 				null
 			)
-				.setParameters(request.getSearchValue(), request.getSearchValue(), request.getSearchValue(), request.getSearchValue())
+				.setParameters(parameters)
 				.setClient_ID()
 				.setOnlyActiveRecords(true)
 				.first();

--- a/src/main/java/org/spin/grpc/service/TimeRecord.java
+++ b/src/main/java/org/spin/grpc/service/TimeRecord.java
@@ -601,13 +601,16 @@ public class TimeRecord extends TimeRecordImplBase {
 			whereClause += " AND AssignDateTo = ? ";
 		}
 
-		if (!Util.isEmpty(request.getSearchValue(), true)) {
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if (!Util.isEmpty(searchValue, true)) {
 			whereClause += " AND ("
 				+ "UPPER(Name) LIKE '%' || UPPER(?) || '%' "
 				+ "OR UPPER(Description) LIKE '%' || UPPER(?) || '%' "
 			+ ")";
-			parametersList.add(request.getSearchValue());
-			parametersList.add(request.getSearchValue());
+			parametersList.add(searchValue);
+			parametersList.add(searchValue);
 		}
 
 		Query query = new Query(

--- a/src/main/java/org/spin/grpc/service/UserCustomization.java
+++ b/src/main/java/org/spin/grpc/service/UserCustomization.java
@@ -111,12 +111,16 @@ public class UserCustomization extends UserCustomizationImplBase {
 	private ListUsersResponse.Builder listUsers(ListUsersRequest request) {
 		String whereClause = "";
 		List<Object> parameters = new ArrayList<>();
-		if (!Util.isEmpty(request.getSearchValue(), true)) {
+
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if (!Util.isEmpty(searchValue, true)) {
 			whereClause += "(UPPER(Name) LIKE '%' || UPPER(?) || '%' "
 				+ "OR UPPER(Value) LIKE '%' || UPPER(?) || '%')"
 			;
-			parameters.add(request.getSearchValue());
-			parameters.add(request.getSearchValue());
+			parameters.add(searchValue);
+			parameters.add(searchValue);
 		}
 
 		Query query = new Query(
@@ -214,12 +218,16 @@ public class UserCustomization extends UserCustomizationImplBase {
 	private ListRolesResponse.Builder listRoles(ListRolesRequest request) {
 		List<Object> parameters = new ArrayList<>();
 		String whereClause = "";
-		if (!Util.isEmpty(request.getSearchValue(), true)) {
+
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if (!Util.isEmpty(searchValue, true)) {
 			whereClause += "(UPPER(Name) LIKE '%' || UPPER(?) || '%' "
 				+ "OR UPPER(Value) LIKE '%' || UPPER(?) || '%')"
 			;
-			parameters.add(request.getSearchValue());
-			parameters.add(request.getSearchValue());
+			parameters.add(searchValue);
+			parameters.add(searchValue);
 		}
 
 		Query query = new Query(
@@ -312,12 +320,16 @@ public class UserCustomization extends UserCustomizationImplBase {
 	private ListCustomizationsLevelResponse.Builder listCustomizationsLevel(ListCustomizationsLevelRequest request) {
 		List<Object> parameters = new ArrayList<>();
 		String whereClause = "";
-		if (!Util.isEmpty(request.getSearchValue(), true)) {
+
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if (!Util.isEmpty(searchValue, true)) {
 			whereClause += "AND (UPPER(Name) LIKE '%' || UPPER(?) || '%' "
 				+ "OR UPPER(Value) LIKE '%' || UPPER(?) || '%')"
 			;
-			parameters.add(request.getSearchValue());
-			parameters.add(request.getSearchValue());
+			parameters.add(searchValue);
+			parameters.add(searchValue);
 		}
 
 		Query query = new Query(

--- a/src/main/java/org/spin/grpc/service/field/location_address/LocationAddressLogic.java
+++ b/src/main/java/org/spin/grpc/service/field/location_address/LocationAddressLogic.java
@@ -55,14 +55,17 @@ public class LocationAddressLogic {
 		String whereClause = null;
 		List<Object> parameters = new ArrayList<Object>();
 
-		if (!Util.isEmpty(request.getSearchValue(), true)) {
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if (!Util.isEmpty(searchValue, true)) {
 			whereClause = "("
 				+ "UPPER(CountryCode) = UPPER(?) "
 				+ "OR UPPER(Name) = UPPER(?) "
 				+ ")"
 			;
-			parameters.add(request.getSearchValue());
-			parameters.add(request.getSearchValue());
+			parameters.add(searchValue);
+			parameters.add(searchValue);
 		}
 		Query query = new Query(
 			Env.getCtx(),
@@ -136,14 +139,17 @@ public class LocationAddressLogic {
 		List<Object> parameters = new ArrayList<Object>();
 		parameters.add(country.getC_Country_ID());
 
-		if (!Util.isEmpty(request.getSearchValue(), true)) {
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if (!Util.isEmpty(searchValue, true)) {
 			whereClause = "AND ("
 				+ "UPPER(CountryCode) = UPPER(?) "
 				+ "OR UPPER(Name) = UPPER(?) "
 				+ ")"
 			;
-			parameters.add(request.getSearchValue());
-			parameters.add(request.getSearchValue());
+			parameters.add(searchValue);
+			parameters.add(searchValue);
 		}
 		Query query = new Query(
 			Env.getCtx(),
@@ -195,14 +201,18 @@ public class LocationAddressLogic {
 				parameters.add(request.getRegionId());
 			}
 		}
-		if (!Util.isEmpty(request.getSearchValue(), true)) {
+
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if (!Util.isEmpty(searchValue, true)) {
 			whereClause += "AND ("
 				+ "UPPER(CountryCode) = UPPER(?) "
 				+ "OR UPPER(Name) = UPPER(?) "
 				+ ")"
 			;
-			parameters.add(request.getSearchValue());
-			parameters.add(request.getSearchValue());
+			parameters.add(searchValue);
+			parameters.add(searchValue);
 		}
 		Query query = new Query(
 			Env.getCtx(),

--- a/src/main/java/org/spin/grpc/service/form/ExpressMovement.java
+++ b/src/main/java/org/spin/grpc/service/form/ExpressMovement.java
@@ -17,8 +17,6 @@ package org.spin.grpc.service.form;
 import org.adempiere.exceptions.AdempiereException;
 
 import java.math.BigDecimal;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -104,10 +102,10 @@ public class ExpressMovement extends ExpressMovementImplBase {
 		List<Object> parameters = new ArrayList<Object>();
 
 		//	For search value
-		if (!Util.isEmpty(request.getSearchValue(), true)) {
-			// URL decode to change characteres
-			String searchValue = URLDecoder.decode(request.getSearchValue(), StandardCharsets.UTF_8);
-
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if (!Util.isEmpty(searchValue, true)) {
 			whereClause += " AND ("
 				+ "UPPER(Value) LIKE '%' || UPPER(?) || '%' "
 				+ "OR UPPER(Name) LIKE '%' || UPPER(?) || '%' "
@@ -207,10 +205,10 @@ public class ExpressMovement extends ExpressMovementImplBase {
 		List<Object> parameters = new ArrayList<Object>();
 
 		//	For search value
-		if (!Util.isEmpty(request.getSearchValue(), true)) {
-			// URL decode to change characteres
-			String searchValue = URLDecoder.decode(request.getSearchValue(), StandardCharsets.UTF_8);
-
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if (!Util.isEmpty(searchValue, true)) {
 			whereClause += " AND ("
 				+ "UPPER(Value) LIKE '%' || UPPER(?) || '%' "
 				+ "OR UPPER(Name) LIKE '%' || UPPER(?) || '%' "

--- a/src/main/java/org/spin/grpc/service/form/ExpressReceipt.java
+++ b/src/main/java/org/spin/grpc/service/form/ExpressReceipt.java
@@ -17,8 +17,6 @@ package org.spin.grpc.service.form;
 import org.adempiere.exceptions.AdempiereException;
 
 import java.math.BigDecimal;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -115,10 +113,10 @@ public class ExpressReceipt extends ExpressReceiptImplBase {
 		List<Object> parameters = new ArrayList<Object>();
 
 		//	For search value
-		if (!Util.isEmpty(request.getSearchValue(), true)) {
-			// URL decode to change characteres
-			String searchValue = URLDecoder.decode(request.getSearchValue(), StandardCharsets.UTF_8);
-
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if (!Util.isEmpty(searchValue, true)) {
 			whereClause += " AND ("
 				+ "UPPER(Value) LIKE '%' || UPPER(?) || '%' "
 				+ "OR UPPER(Name) LIKE '%' || UPPER(?) || '%' "
@@ -243,10 +241,10 @@ public class ExpressReceipt extends ExpressReceiptImplBase {
 		parameters.add(businessPartnerId);
 
 		//	For search value
-		if (!Util.isEmpty(request.getSearchValue(), true)) {
-			// URL decode to change characteres
-			String searchValue = URLDecoder.decode(request.getSearchValue(), StandardCharsets.UTF_8);
-
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if (!Util.isEmpty(searchValue, true)) {
 			whereClause += " AND ("
 				+ "UPPER(DocumentNo) LIKE '%' || UPPER(?) || '%' "
 				+ ")"
@@ -351,10 +349,10 @@ public class ExpressReceipt extends ExpressReceiptImplBase {
 		parameters.add(orderId);
 
 		//	For search value
-		if (!Util.isEmpty(request.getSearchValue(), true)) {
-			// URL decode to change characteres
-			String searchValue = URLDecoder.decode(request.getSearchValue(), StandardCharsets.UTF_8);
-
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if (!Util.isEmpty(searchValue, true)) {
 			whereClause += " AND ("
 				+ "UPPER(Value) LIKE '%' || UPPER(?) || '%' "
 				+ "OR UPPER(Name) LIKE '%' || UPPER(?) || '%' "

--- a/src/main/java/org/spin/grpc/service/form/ExpressShipment.java
+++ b/src/main/java/org/spin/grpc/service/form/ExpressShipment.java
@@ -17,8 +17,6 @@ package org.spin.grpc.service.form;
 import org.adempiere.exceptions.AdempiereException;
 
 import java.math.BigDecimal;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -114,10 +112,10 @@ public class ExpressShipment extends ExpressShipmentImplBase {
 		List<Object> parameters = new ArrayList<Object>();
 
 		//	For search value
-		if (!Util.isEmpty(request.getSearchValue(), true)) {
-			// URL decode to change characteres
-			String searchValue = URLDecoder.decode(request.getSearchValue(), StandardCharsets.UTF_8);
-
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if (!Util.isEmpty(searchValue, true)) {
 			whereClause += " AND ("
 				+ "UPPER(Value) LIKE '%' || UPPER(?) || '%' "
 				+ "OR UPPER(Name) LIKE '%' || UPPER(?) || '%' "
@@ -241,10 +239,10 @@ public class ExpressShipment extends ExpressShipmentImplBase {
 		parameters.add(businessPartnerId);
 
 		//	For search value
-		if (!Util.isEmpty(request.getSearchValue(), true)) {
-			// URL decode to change characteres
-			String searchValue = URLDecoder.decode(request.getSearchValue(), StandardCharsets.UTF_8);
-
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if (!Util.isEmpty(searchValue, true)) {
 			whereClause += " AND ("
 				+ "UPPER(DocumentNo) LIKE '%' || UPPER(?) || '%' "
 				+ ")"
@@ -348,10 +346,10 @@ public class ExpressShipment extends ExpressShipmentImplBase {
 		parameters.add(orderId);
 
 		//	For search value
-		if (!Util.isEmpty(request.getSearchValue(), true)) {
-			// URL decode to change characteres
-			String searchValue = URLDecoder.decode(request.getSearchValue(), StandardCharsets.UTF_8);
-
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if (!Util.isEmpty(searchValue, true)) {
 			whereClause += " AND ("
 				+ "UPPER(Value) LIKE '%' || UPPER(?) || '%' "
 				+ "OR UPPER(Name) LIKE '%' || UPPER(?) || '%' "

--- a/src/main/java/org/spin/grpc/service/form/PaymentAllocation.java
+++ b/src/main/java/org/spin/grpc/service/form/PaymentAllocation.java
@@ -405,7 +405,7 @@ public class PaymentAllocation extends PaymentAllocationImplBase {
 
 
 	public static TransactionType.Builder convertTransactionType(String value) {
-		if (Util.isEmpty(value, false)) {
+		if (Util.isEmpty(value, true)) {
 			return TransactionType.newBuilder();
 		}
 

--- a/src/main/java/org/spin/grpc/service/form/bank_statement_match/BankStatementMatchConvertUtil.java
+++ b/src/main/java/org/spin/grpc/service/form/bank_statement_match/BankStatementMatchConvertUtil.java
@@ -282,7 +282,7 @@ public class BankStatementMatchConvertUtil {
 
 
 	public static TenderType.Builder convertTenderType(String value) {
-		if (Util.isEmpty(value, false)) {
+		if (Util.isEmpty(value, true)) {
 			return TenderType.newBuilder();
 		}
 

--- a/src/main/java/org/spin/pos/service/POSLogic.java
+++ b/src/main/java/org/spin/pos/service/POSLogic.java
@@ -46,8 +46,12 @@ public class POSLogic {
 		StringBuffer whereClause = new StringBuffer();
 		//	Parameters
 		List<Object> parameters = new ArrayList<Object>();
+
 		//	For search value
-		if(!Util.isEmpty(request.getSearchValue(), true)) {
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if(!Util.isEmpty(searchValue, true)) {
 			whereClause.append("("
 				+ "UPPER(Value) LIKE '%' || UPPER(?) || '%' "
 				+ "OR UPPER(Name) LIKE '%' || UPPER(?) || '%' "
@@ -56,10 +60,10 @@ public class POSLogic {
 				+ ")"
 			);
 			//	Add parameters
-			parameters.add(request.getSearchValue());
-			parameters.add(request.getSearchValue());
-			parameters.add(request.getSearchValue());
-			parameters.add(request.getSearchValue());
+			parameters.add(searchValue);
+			parameters.add(searchValue);
+			parameters.add(searchValue);
+			parameters.add(searchValue);
 		}
 		//	For value
 		if(!Util.isEmpty(request.getValue(), true)) {
@@ -201,16 +205,20 @@ public class POSLogic {
 		StringBuffer whereClause = new StringBuffer();
 		//	Parameters
 		List<Object> parameters = new ArrayList<Object>();
+
 		//	For search value
-		if(!Util.isEmpty(request.getSearchValue(), true)) {
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if(!Util.isEmpty(searchValue, true)) {
 			// TODO: Check if it is better with the `LIKE` operator 
 			whereClause.append(
 				"(UPPER(Value) = UPPER(?) "
 				+ "OR UPPER(Name) = UPPER(?))"
 			);
 			//	Add parameters
-			parameters.add(request.getSearchValue());
-			parameters.add(request.getSearchValue());
+			parameters.add(searchValue);
+			parameters.add(searchValue);
 		}
 		//	For value
 		if(!Util.isEmpty(request.getValue(), true)) {

--- a/src/main/java/org/spin/pos/service/bank/BankManagement.java
+++ b/src/main/java/org/spin/pos/service/bank/BankManagement.java
@@ -59,8 +59,11 @@ public class BankManagement {
 		List<Object> filtersList = new ArrayList<>();
 
 		String whereClause = "BankType = 'B' ";
-		if (!Util.isEmpty(request.getSearchValue(), false)) {
-			filtersList.add(request.getSearchValue());
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if (!Util.isEmpty(searchValue, true)) {
+			filtersList.add(searchValue);
 			whereClause += "AND UPPER(Name) LIKE '%' || UPPER(?) || '%' ";
 		}
 
@@ -110,8 +113,11 @@ public class BankManagement {
 		List<Object> filtersList = new ArrayList<>();
 		filtersList.add(bank.getC_Bank_ID());
 		String whereClause = "C_Bank_ID = ? ";
-		if (!Util.isEmpty(request.getSearchValue(), false)) {
-			filtersList.add(request.getSearchValue());
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if (!Util.isEmpty(searchValue, true)) {
+			filtersList.add(searchValue);
 			whereClause = "AND UPPER(Name) LIKE '%' || UPPER(?) || '%' ";
 		}
 

--- a/src/main/java/org/spin/pos/service/pos/POS.java
+++ b/src/main/java/org/spin/pos/service/pos/POS.java
@@ -31,6 +31,7 @@ import org.spin.backend.grpc.pos.ListCampaignsRequest;
 import org.spin.backend.grpc.pos.ListCampaignsResponse;
 import org.spin.base.util.RecordUtil;
 import org.spin.pos.util.POSConvertUtil;
+import org.spin.service.grpc.util.value.ValueManager;
 
 /**
  * @author Edwin Betancourt, EdwinBetanc0urt@outlook.com, https://github.com/EdwinBetanc0urt
@@ -91,8 +92,12 @@ public class POS {
 		List<Object> filtersList = new ArrayList<>();
 
 		String whereClause = null;
-		if (!Util.isEmpty(request.getSearchValue(), false)) {
-			filtersList.add(request.getSearchValue());
+
+		final String searchValue = ValueManager.getDecodeUrl(
+			request.getSearchValue()
+		);
+		if (!Util.isEmpty(searchValue, true)) {
+			filtersList.add(searchValue);
 			whereClause = "UPPER(Name) LIKE '%' || UPPER(?) || '%' ";
 		}
 


### PR DESCRIPTION
When listing or getting values, they are done via http with the `GET` method, so the search value is sent in the url, and spaces are defined as `+`, among other characters that can change.

If `test 5` is sent, `test+5` will arrive, so it will never match the values stored in the database, maybe `Test 5`.