### PR TITLE
fix: Order By clause to window records.

### DIFF
--- a/src/main/java/org/spin/base/db/OrderByUtil.java
+++ b/src/main/java/org/spin/base/db/OrderByUtil.java
@@ -45,7 +45,7 @@ public class OrderByUtil {
 		}
 
 		//	Second Prio: Fields (save it)
-		orderByClause = getTabOrderByClause(tab);
+		orderByClause = getTabOrderByWithFields(tab);
 		if (!Util.isEmpty(orderByClause, true)) {
 			return orderByClause;
 		}

--- a/src/main/java/org/spin/base/db/OrderByUtil.java
+++ b/src/main/java/org/spin/base/db/OrderByUtil.java
@@ -17,10 +17,16 @@ package org.spin.base.db;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.adempiere.core.domains.models.I_AD_Element;
 import org.adempiere.model.MBrowse;
 import org.adempiere.model.MBrowseField;
 import org.adempiere.model.MViewColumn;
+import org.compiere.model.MColumn;
+import org.compiere.model.MField;
+import org.compiere.model.MTab;
 import org.compiere.util.Env;
+import org.compiere.util.Util;
+import org.spin.dictionary.util.WindowUtil;
 import org.spin.util.ASPUtil;
 
 /**
@@ -30,6 +36,89 @@ import org.spin.util.ASPUtil;
 public class OrderByUtil {
 
 	public static String SQL_ORDER_BY_REGEX = "\\s+(ORDER BY)\\s+";
+
+	public static String getTabOrderByClause(MTab tab) {
+		//	First Prio: Tab Order By
+		String orderByClause = tab.getOrderByClause();
+		if (!Util.isEmpty(orderByClause, true)) {
+			return orderByClause;
+		}
+
+		//	Second Prio: Fields (save it)
+		orderByClause = getTabOrderByClause(tab);
+		if (!Util.isEmpty(orderByClause, true)) {
+			return orderByClause;
+		}
+
+		//	Third Prio: onlyCurrentRows
+		orderByClause = I_AD_Element.COLUMNNAME_Created;
+		boolean isOnlyCurrentRows = true;
+		if (isOnlyCurrentRows && !(WindowUtil.isDetail(tab))) {
+			//	first tab only
+			orderByClause += " DESC";
+		}
+
+		return orderByClause;
+	}
+
+	public static String getTabOrderByWithFields(MTab tab) {
+		String[] orderBys = getTabOrderBysColumns(tab);
+		//	Second Prio: Fields (save it)
+		String orderByClause = "";
+		int count = 0;
+		for (String orderColumnName : orderBys) {
+			// String orderColumnName = orderBys[i];
+			if (!Util.isEmpty(orderColumnName, true)) {
+				if (orderByClause.length() > 0) {
+					orderByClause += ",";
+				}
+				orderByClause += orderColumnName;
+				count++;
+			}
+			if (count > 2) {
+				break;
+			}
+		}
+
+		return orderByClause;
+	}
+
+	public static String[] getTabOrderBysColumns(MTab tab) {
+		String orderBys[] = new String[3];
+		for (MField field : tab.getASPFields()) {
+			if (field.getSortNo() == null || field.getSortNo().compareTo(Env.ZERO) == 0) {
+				continue;
+			}
+			MColumn column = MColumn.get(Env.getCtx(), field.getAD_Column_ID());
+			String columnName = column.getColumnName();
+			//	Order By
+			int sortNo = field.getSortNo().intValue();
+			if (sortNo == 0) {
+				;
+			}
+			else if (Math.abs(sortNo) == 1) {
+				orderBys[0] = columnName;
+				if (sortNo < 0) {
+					orderBys[0] += " DESC";
+				}
+			}
+			else if (Math.abs(sortNo) == 2) {
+				orderBys[1] = columnName;
+				if (sortNo < 0) {
+					orderBys[1] += " DESC";
+				}
+			}
+			else if (Math.abs(sortNo) == 3) {
+				orderBys[2] = columnName;
+				if (sortNo < 0) {
+					orderBys[2] += " DESC";
+				}
+			}
+		};
+
+		return orderBys;
+	}
+
 
 	/**
 	 * Get Order By

--- a/src/main/java/org/spin/dictionary/util/WindowUtil.java
+++ b/src/main/java/org/spin/dictionary/util/WindowUtil.java
@@ -62,6 +62,34 @@ public class WindowUtil {
 	}
 
 
+	/**
+	 *	Returns true if this is a detail record
+	 *  @return true if not parent tab
+	 */
+	public static boolean isDetail(MTab tab)
+	{
+		// First Tab Level is not a detail 
+		if (tab.getTabLevel() == 0) {
+			return false;
+		}
+
+		boolean isWithParentFields = tab.getASPFields()
+			.stream()
+			.filter(field -> {
+				MColumn column = MColumn.get(Env.getCtx(), field.getAD_Column_ID());
+				return column.isParent();
+			})
+			.findFirst()
+			.isPresent();
+		;
+		//	We have IsParent columns and/or a link column
+		if (isWithParentFields || tab.getAD_Column_ID() > 0) {
+			return true;
+		}
+		return false;
+	}	//	isDetail
+
+
 
 	/**
 	 * Get Direct Partent Tab by Current Tab

--- a/src/main/java/org/spin/grpc/service/UserInterface.java
+++ b/src/main/java/org/spin/grpc/service/UserInterface.java
@@ -795,7 +795,7 @@ public class UserInterface extends UserInterfaceImplBase {
 		if (!Util.isEmpty(request.getSortBy(), true)) {
 			orderByClause = " ORDER BY " + SortingManager.newInstance(request.getSortBy()).getSotingAsSQL();
 		} else {
-			String tabOrderBy = OrderByUtil.getTabOrderByWithFields(tab);
+			String tabOrderBy = OrderByUtil.getTabOrderByClause(tab);
 			if (!Util.isEmpty(tabOrderBy, true)) {
 				String parsedTabOrderBy = Env.parseContext(context, windowNo, tabOrderBy, false);
 				if (Util.isEmpty(parsedTabOrderBy, true)) {

--- a/src/main/java/org/spin/grpc/service/UserInterface.java
+++ b/src/main/java/org/spin/grpc/service/UserInterface.java
@@ -554,10 +554,11 @@ public class UserInterface extends UserInterfaceImplBase {
 		} catch (Exception e) {
 			log.severe(e.getLocalizedMessage());
 			e.printStackTrace();
-			responseObserver.onError(Status.INTERNAL
-				.withDescription(e.getLocalizedMessage())
-				.withCause(e)
-				.asRuntimeException()
+			responseObserver.onError(
+				Status.INTERNAL
+					.withDescription(e.getLocalizedMessage())
+					.withCause(e)
+					.asRuntimeException()
 			);
 		}
 	}
@@ -712,17 +713,24 @@ public class UserInterface extends UserInterfaceImplBase {
 		if (tabId <= 0) {
 			throw new AdempiereException("@FillMandatory@ @AD_Tab_ID@");
 		}
-		//	
-		MTab tab = MTab.get(Env.getCtx(), tabId);
-		if (tab == null || tab.getAD_Tab_ID() <= 0) {
+		Properties context = Env.getCtx();
+
+		MTab originalTab = MTab.get(context, tabId);
+		if (originalTab == null || originalTab.getAD_Tab_ID() <= 0) {
 			throw new AdempiereException("@AD_Tab_ID@ @NotFound@");
 		}
+		MTab tab = ASPUtil.getInstance(context)
+			.getWindowTab(
+				originalTab.getAD_Window_ID(),
+				originalTab.getAD_Tab_ID()
+			)
+		;
 
-		MTable table = MTable.get(Env.getCtx(), tab.getAD_Table_ID());
+		//	
+		MTable table = MTable.get(context, tab.getAD_Table_ID());
 		String tableName = table.getTableName();
 
 		//	Fill context
-		Properties context = Env.getCtx();
 		int windowNo = ThreadLocalRandom.current().nextInt(1, 8996 + 1);
 		ContextManager.setContextWithAttributesFromString(
 			windowNo, context, request.getContextAttributes()
@@ -786,6 +794,15 @@ public class UserInterface extends UserInterfaceImplBase {
 		String orderByClause = "";
 		if (!Util.isEmpty(request.getSortBy(), true)) {
 			orderByClause = " ORDER BY " + SortingManager.newInstance(request.getSortBy()).getSotingAsSQL();
+		} else {
+			String tabOrderBy = OrderByUtil.getTabOrderByWithFields(tab);
+			if (!Util.isEmpty(tabOrderBy, true)) {
+				String parsedTabOrderBy = Env.parseContext(context, windowNo, tabOrderBy, false);
+				if (Util.isEmpty(parsedTabOrderBy, true)) {
+					throw new AdempiereException("@AD_Tab_ID@ @OrderByClause@ @Unparseable@");
+				}
+				orderByClause = " ORDER BY " + parsedTabOrderBy;
+			}
 		}
 
 		//	Count records


### PR DESCRIPTION

#### Business Partner window without `SQL Order By` clause

![imagen](https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/caeee6fd-9f3b-4f8b-9d69-0597ba97e473)


![imagen](https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/01df3e22-7a2c-49bf-9171-e452b353b701)

#### Migration window with `SQL Order By` clause

![imagen](https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/c859c424-9d6e-426b-a069-b84d202b8e46)

![imagen](https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/a1b55f66-f72a-489a-97d4-13d43f83e8ac)

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/1671

