### PR TITLE
fix: Convert ID value as string when is Table or Search.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ dependencies {
 	implementation 'com.sun.xml.bind:jaxb-core:3.0.0-M4'
 	implementation 'javax.activation:activation:1.1.1'
 
-	implementation "${baseGroupId}:adempiere-grpc-utils:1.2.4"
+	implementation "${baseGroupId}:adempiere-grpc-utils:1.2.5"
 
 	//	ADempiere Core
 	implementation "${baseGroupId}:base:${baseVersion}"


### PR DESCRIPTION
If display type isID, and reference is `Table` or `Search`, and column is `AD_Language` or `EntityType` with value, return builder value as null.


#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/1699