### PR TITLE
fix: NPE with default operator filter.

### DIFF
--- a/src/main/java/org/spin/base/db/OperatorUtil.java
+++ b/src/main/java/org/spin/base/db/OperatorUtil.java
@@ -34,6 +34,9 @@ public class OperatorUtil {
 	 */
 	public static String convertOperator(String serviceOperator) {
 		String operator = MQuery.EQUAL;
+		if (serviceOperator == null) {
+			return operator;
+		}
 		switch (serviceOperator.toLowerCase()) {
 			case Filter.BETWEEN:
 				operator = MQuery.BETWEEN;

--- a/src/main/java/org/spin/base/db/WhereClauseUtil.java
+++ b/src/main/java/org/spin/base/db/WhereClauseUtil.java
@@ -103,9 +103,13 @@ public class WhereClauseUtil {
 	 * @return
 	 */
 	public static String getRestrictionByOperator(Filter condition, int displayType, List<Object> parameters) {
+		String operatorValue = Filter.EQUAL;
+		if (!Util.isEmpty(condition.getOperator(), true)) {
+			operatorValue = condition.getOperator().toLowerCase();
+		}
 		String sqlOperator = OperatorUtil.convertOperator(condition.getOperator());
+
 		String columnName = condition.getColumnName();
-		String operatorValue = condition.getOperator().toLowerCase();
 		String sqlValue = "";
 		StringBuilder additionalSQL = new StringBuilder();
 		//	For IN or NOT IN


### PR DESCRIPTION
When the filter has no operator, it is not set to the default operator, which is equal to.

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/1686