### PR TITLE
fix: Generate report with arial font.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,8 @@ dependencies {
 	implementation "${baseGroupId}:jasperreports:${baseVersion}"
 	//	Others
     compileOnly 'org.apache.tomcat:annotations-api:6.0.53'
+	implementation 'net.sf.jasperreports:jasperreports-fonts:6.21.0'
+
 	// ADempiere External Libraries
 	implementation 'com.github.jjYBdx4IL:ecs:1.4.2.1'
 	implementation 'com.itextpdf:itextpdf:5.5.13.3' // used by org.adempiere.pdf.iText7Document


### PR DESCRIPTION
#### Before this changes
```json
{
 "id": 2000059,
 "name": "",
 "description": "",
 "instance_id": 2186193,
 "is_error": true,
 "summary": "ProcessError Font \"Arial\" is not available to the JVM. See the Javadoc for more details.",
 "result_table_name": "",
 "is_processing": false,
 "last_run": "2023-12-21T21:36:34Z",
 "logs": [],
 "process_intance_parameters": []
}

```

https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/1c051f9b-c040-4f6c-a891-142954e76b45


#### After this changes


https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/4def33ff-96fa-47ce-9ef6-d5d19fe9eee3



#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/1091
