### PR TITLE
fix: SQL column index.

### DIFF
--- a/src/main/java/org/spin/base/util/RecordUtil.java
+++ b/src/main/java/org/spin/base/util/RecordUtil.java
@@ -539,7 +539,7 @@ public class RecordUtil {
 		if (metaData == null) {
 			return -1;
 		}
-		for(int columnIndex = 0; columnIndex <= metaData.getColumnCount(); columnIndex++) {
+		for(int columnIndex = 1; columnIndex <= metaData.getColumnCount(); columnIndex++) {
 			String metaDataColumnName = metaData.getColumnName(columnIndex);
 			if(metaDataColumnName != null && metaDataColumnName.toLowerCase().equals(columnName.toLowerCase())) {
 				return columnIndex;


### PR DESCRIPTION
#### Request
http://0.0.0.0:8080/api/user-interface/lookups/field/58065?search_value=&table_name=AD_Client&column_name=AD_Client_ID&page_size=15

#### Response

```json
{
	"code": 13,
	"message": "org.postgresql.util.PSQLException: El índice de la columna está fuera de rango: 0, número de columnas: 5.",
	"details": []
}
```

#### Additional context

```log
===========> UserInterface.listLookupItems: org.postgresql.util.PSQLException: El índice de la columna está fuera de rango: 0, número de columnas: 5. [110]
org.adempiere.exceptions.AdempiereException: org.postgresql.util.PSQLException: El índice de la columna está fuera de rango: 0, número de columnas: 5.
        at org.spin.grpc.service.UserInterface.listLookupItems(UserInterface.java:2318)
        at org.spin.grpc.service.UserInterface.listLookupItems(UserInterface.java:2214)
        at org.spin.grpc.service.UserInterface.listLookupItems(UserInterface.java:214)
        at org.spin.backend.grpc.user_interface.UserInterfaceGrpc$MethodHandlers.invoke(UserInterfaceGrpc.java:2220)
        at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
        at io.grpc.Contexts$ContextualizedServerCallListener.onHalfClose(Contexts.java:86)
        at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:351)
        at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:860)
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: org.postgresql.util.PSQLException: El índice de la columna está fuera de rango: 0, número de columnas: 5.
        at org.postgresql.jdbc.PgResultSetMetaData.getField(PgResultSetMetaData.java:399)
        at org.postgresql.jdbc.PgResultSetMetaData.getColumnLabel(PgResultSetMetaData.java:145)
        at org.postgresql.jdbc.PgResultSetMetaData.getColumnName(PgResultSetMetaData.java:150)
        at org.spin.base.util.RecordUtil.getColumnIndex(RecordUtil.java:543)
        at org.spin.grpc.service.UserInterface.listLookupItems(UserInterface.java:2302)
        ... 15 more
feat: Add display type structure.
```