### PR TITLE
fix: Record logs order.

### DIFF
--- a/src/main/java/org/spin/log/LogsConvertUtil.java
+++ b/src/main/java/org/spin/log/LogsConvertUtil.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 
 import org.adempiere.core.domains.models.I_AD_PInstance;
 import org.adempiere.core.domains.models.I_AD_PInstance_Log;
@@ -178,31 +179,33 @@ public class LogsConvertUtil {
 			recordLogBuilder.addChangeLogs(changeLog);
 			indexMap.put(recordLog.getAD_ChangeLog_ID(), recordLogBuilder);
 		});
-		ListEntityLogsResponse.Builder builder = ListEntityLogsResponse.newBuilder();
-		indexMap.values().stream()
+		List<EntityLog.Builder> entitiesListBuilder = indexMap.values().stream()
 			// .sorted(
-			// 	Comparator.comparing(EntityLog::getLogDate)
-			// 		// .thenComparing(EntityLog::getTabLevel)
-			// 		// .reversed()
+			// 	Comparator.comparing(EntityLog.Builder::getLogDate)
+			// 		.reversed()
 			// )
-			.sorted((u1, u2) -> {
+			.sorted((log1, log2) -> {
 				Timestamp from = TimeManager.convertValueToDate(
-					u1.getLogDate()
+					log1.getLogDate()
 				);
 
 				Timestamp to = TimeManager.convertValueToDate(
-					u2.getLogDate()
+					log2.getLogDate()
 				);
 
 				if (from == null || to == null) {
 					// prevent Null Pointer Exception
 					return 1;
 				}
-				return (int) (from.getTime() - to.getTime());
+				return to.compareTo(from);
 			})
-			.forEach(recordLog -> {
-				builder.addEntityLogs(recordLog);
-			});
+			.collect(Collectors.toList())
+		;
+
+		ListEntityLogsResponse.Builder builder = ListEntityLogsResponse.newBuilder();
+		entitiesListBuilder.forEach(recordLog -> {
+			builder.addEntityLogs(recordLog);
+		});
 		return builder;
 	}
 

--- a/src/main/java/org/spin/log/LogsServiceLogic.java
+++ b/src/main/java/org/spin/log/LogsServiceLogic.java
@@ -196,7 +196,7 @@ public class LogsServiceLogic {
 				// prevent Null Pointer Exception
 				return 0;
 			}
-			return (int) (to.getTime() - from.getTime());
+			return to.compareTo(from);
 
 		})
 		.collect(Collectors.toList());

--- a/src/main/proto/logs.proto
+++ b/src/main/proto/logs.proto
@@ -157,6 +157,12 @@ message ListEntityLogsResponse {
 	int64 record_count = 1;
 	repeated EntityLog entity_logs = 2;
 	string next_page_token = 3;
+	google.protobuf.Timestamp created = 4;
+	int32 created_by = 5;
+	string created_by_name = 6;
+	google.protobuf.Timestamp updated = 7;
+	int32 updated_by = 8;
+	string updated_by_name = 9;
 }
 
 // Exists References Request


### PR DESCRIPTION
* 13 de diciembre de 2023, 02:22:32 p. m. Se edita el campo `IsTotallyInvoiced`.

![imagen](https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/1d975847-ef2f-4a45-bfe4-d9123ab506eb)

![imagen](https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/ef044eae-26b5-452d-8750-189a082c804e)


* 13 de diciembre de 2023, 02:18:18 p. m. Se edita el campo `IsAllowToInvoice`.

![imagen](https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/ad365c92-cac0-404d-bf3d-95e58fc3e38b)

![imagen](https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/91bf26cb-db53-471d-ae48-e0e726080502)


* 13 de diciembre de 2023, 02:04:55 p. m. Se editan los campos `DocStatus`, `DocAction`, `Weight`, `Volume`, `ProcessedOn`, `C_DocType_ID`, `IsApproved`, `TotalLines`, `GrandTotal`, y `Processed`

![imagen](https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/59c6c3ed-ba97-4c0f-96d9-f37a36f519c0)

![imagen](https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/e15e4eae-aa8c-469b-a6d4-557af869345e)



* 13 de diciembre de 2023, 02:04:55 p. m. Se edita el campo `Link_Order_ID`.

![imagen](https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/bc8bdfa5-0b65-4870-930e-5d525d1a3c49)

![imagen](https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/2bd76be7-1556-4784-b421-e45805c98fdb)


* 13 de diciembre de 2023, 02:04:54 p. m. Se edita el campo `C_Order_ID`.

![imagen](https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/916758d0-e58a-4d3e-97f7-d1aea1663e68)

![imagen](https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/14736d34-d533-41ad-a10a-267843c2a4a8)


#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/1752
fixes https://github.com/solop-develop/frontend-core/issues/1753