### PR TITLE
feat: Dashboard metrics `NPE` when name is null.

### DIFF
--- a/src/main/java/org/spin/grpc/service/Dashboarding.java
+++ b/src/main/java/org/spin/grpc/service/Dashboarding.java
@@ -149,13 +149,17 @@ public class Dashboarding extends DashboardingImplBase {
 					List<ChartData> serieStub = new ArrayList<ChartData>();
 					serie.getDataSet().forEach(dataSet -> {
 						ChartData.Builder chartDataBuilder = ChartData.newBuilder()
-								.setName(dataSet.getName())
-								.setValue(
-									NumberManager.getBigDecimalToString(
-										dataSet.getAmount()
-									)
+							.setName(
+								ValueManager.validateNull(
+									dataSet.getName()
 								)
-							;
+							)
+							.setValue(
+								NumberManager.getBigDecimalToString(
+									dataSet.getAmount()
+								)
+							)
+						;
 						serieStub.add(chartDataBuilder.build());
 					});
 					chartSeries.put(serie.getName(), serieStub);
@@ -224,10 +228,18 @@ public class Dashboarding extends DashboardingImplBase {
 		);
 
 		//	Add all
-		chartSeries.keySet().stream().sorted().forEach(serie -> {
+		chartSeries.entrySet().stream().forEach(serie -> {
 			ChartSerie.Builder chartSerieBuilder = ChartSerie.newBuilder()
-				.setName(serie)
-				.addAllDataSet(chartSeries.get(serie))
+				.setName(
+					ValueManager.validateNull(
+						serie.getKey()
+					)
+				)
+				.addAllDataSet(
+					chartSeries.get(
+						serie.getKey()
+					)
+				)
 			;
 			builder.addSeries(chartSerieBuilder);
 		});


### PR DESCRIPTION
#### Request

```bash
curl 'http://192.168.5.101/api/dashboard/dashboards/1000017/metrics'   -H 'Accept: application/json, text/plain, */*'   -H 'Accept-Language: es-419,es;q=0.9,es-VE;q=0.8'   -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIyMDE3NDc3IiwiQURfQ2xpZW50X0lEIjoxMDAwMDAxLCJBRF9PcmdfSUQiOjEwMDAwMDEsIkFEX1JvbGVfSUQiOjEwMDAwMTcsIkFEX1VzZXJfSUQiOjEwMDAwMDQsIk1fV2FyZWhvdXNlX0lEIjoxMDAwMDI4LCJBRF9MYW5ndWFnZSI6ImVzX01YIiwiaWF0IjoxNzA2MDI1MzExLCJleHAiOjE3MDYxMTE3MTF9.Wz4kvS6EdZ0Ugm12jYqOvEWBLNvgiF6EdMEEd0PhAeU'   -H 'Connection: keep-alive'   -H 'Origin: http://localhost:9527'   -H 'Referer: http://localhost:9527/'   -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'   --compressed   --insecure
```


#### Response
![imagen](https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/360e70f6-f1dd-4cda-899f-6044c942f027)


```json
{
 "id": 0,
 "name": "",
 "description": "",
 "x_axis_label": "",
 "y_axis_label": "",
 "measure_target": "10.0",
 "measure_actual": "0",
 "performance_goal": "0.000000",
 "color_schemas": [
  {
   "name": "",
   "color": "#FF0000",
   "percent": "50"
  },
  {
   "name": "",
   "color": "#FFFF00",
   "percent": "100"
  },
  {
   "name": "",
   "color": "#00FF00",
   "percent": "9999"
  },
  {
   "name": "",
   "color": "",
   "percent": "0"
  }
 ],
 "series": [
  {
   "name": "",
   "data_set": [
    {
     "name": "Clipping semanal MSD-DxP Abiertos",
     "value": ""
    }
   ]
  },
  {
   "name": "50000.00",
   "data_set": [
    {
     "name": "Running Verano 2024-Costos Planeados",
     "value": "50000.00"
    }
   ]
  },
  {
   "name": "0.00",
   "data_set": [
    {
     "name": "Clipping semanal MSD-Costos Planeados",
     "value": "0.00"
    }
   ]
  },
  {
   "name": "3000",
   "data_set": [
    {
     "name": "Running Verano 2024-DxP Abiertos",
     "value": "3000"
    }
   ]
  }
 ]
}
```


#### Additional context

```log
===========> Dashboarding.getMetrics: null [239]
java.lang.NullPointerException
        at java.base/java.lang.String.compareTo(String.java:1196)
        at java.base/java.lang.String.compareTo(String.java:125)
        at java.base/java.util.Comparators$NaturalOrderComparator.compare(Comparators.java:52)
        at java.base/java.util.Comparators$NaturalOrderComparator.compare(Comparators.java:47)
        at java.base/java.util.TimSort.countRunAndMakeAscending(TimSort.java:355)
        at java.base/java.util.TimSort.sort(TimSort.java:220)
        at java.base/java.util.Arrays.sort(Arrays.java:1515)
        at java.base/java.util.stream.SortedOps$SizedRefSortingSink.end(SortedOps.java:353)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:485)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
        at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497)
        at org.spin.grpc.service.Dashboarding.getMetrics(Dashboarding.java:227)
        at org.spin.grpc.service.Dashboarding.getMetrics(Dashboarding.java:116)
        at org.spin.backend.grpc.dashboarding.DashboardingGrpc$MethodHandlers.invoke(DashboardingGrpc.java:791)
        at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
        at io.grpc.Contexts$ContextualizedServerCallListener.onHalfClose(Contexts.java:86)
        at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:351)
        at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:860)
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
``