### PR TITLE
feat: Update github actions versions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Java JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-package: 'jdk'
@@ -54,3 +54,10 @@ jobs:
         with:
           gradle-version: 8.0.2
           arguments: build
+
+      - name: Upload descriptor file artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: adempiere-grpc-server.pb
+          path: build/descriptors/adempiere-grpc-server.pb
+          retention-days: 7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Java JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-package: 'jdk'
@@ -47,37 +47,37 @@ jobs:
           GITHUB_DEPLOY_REPOSITORY: ${{ secrets.DEPLOY_REPOSITORY }}
 
       - name: Upload descriptor file artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: adempiere-grpc-server.pb
           path: build/descriptors/adempiere-grpc-server.pb
 
       - name: Upload envoy file artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: envoy.yaml
           path: resources/envoy.yaml
 
       - name: Upload dist app zip artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: adempiere-grpc-server.zip
           path: build/release/adempiere-grpc-server.zip
 
       - name: Upload dist app zip.MD5 artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: adempiere-grpc-server.zip.MD5
           path: build/release/adempiere-grpc-server.zip.MD5
 
       - name: Upload dist app tar artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: adempiere-grpc-server.tar
           path: build/release/adempiere-grpc-server.tar
 
       - name: Upload dist app tar.MD5 artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: adempiere-grpc-server.tar.MD5
           path: build/release/adempiere-grpc-server.tar.MD5
@@ -115,10 +115,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Java JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-package: 'jdk'
@@ -146,7 +146,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Upload Descriptor
         uses: skx/github-action-publish-binaries@master
@@ -224,9 +224,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download build dist app
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: adempiere-grpc-server.zip
       - name: Unzip Asset
@@ -260,9 +260,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download build dist app
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: adempiere-grpc-server.zip
       - name: Unzip Asset
@@ -301,10 +301,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download build dist app
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: adempiere-grpc-server.pb
           path: docker/


### PR DESCRIPTION
```log
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-java@v3, gradle/gradle-build-action@v2, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```
- `actions/checkout@v3` to `actions/checkout@v4`.
- `actions/setup-java@v3` to `actions/setup-java@v4`.
- `actions/upload-artifact@v3` to `actions/upload-artifact@v4`.
- `actions/donwload-artifact@v3` to `actions/donwload-artifact@v4`.


![image](https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/ab96ee5e-12d8-4ed2-b171-1e45c8499ef1)
