### PR TITLE
feat: Add `Goal` chart sequence.

### DIFF
--- a/src/main/java/org/spin/grpc/service/Dashboarding.java
+++ b/src/main/java/org/spin/grpc/service/Dashboarding.java
@@ -375,18 +375,19 @@ public class Dashboarding extends DashboardingImplBase {
 		queryCharts
 			.setOrderBy(I_PA_Goal.COLUMNNAME_SeqNo)
 			.<MGoal>list()
-			.forEach(chartDefinition -> {
+			.forEach(goalDefinition -> {
 				Dashboard.Builder dashboardBuilder = Dashboard.newBuilder()
-					.setId(chartDefinition.getPA_Goal_ID())
+					.setId(goalDefinition.getPA_Goal_ID())
 					.setName(
-						ValueManager.validateNull(chartDefinition.getName())
+						ValueManager.validateNull(goalDefinition.getName())
 					)
 					.setDescription(
-						ValueManager.validateNull(chartDefinition.getDescription())
+						ValueManager.validateNull(goalDefinition.getDescription())
 					)
+					.setSequence(goalDefinition.getSeqNo())
 					.setDashboardType("chart")
 					.setChartType(
-						ValueManager.validateNull(chartDefinition.getChartType())
+						ValueManager.validateNull(goalDefinition.getChartType())
 					)
 					.setIsCollapsible(true)
 					.setIsOpenByDefault(true)

--- a/src/main/proto/dashboarding.proto
+++ b/src/main/proto/dashboarding.proto
@@ -61,20 +61,21 @@ service Dashboarding {
 
 // Dashboard
 message Dashboard {
-	int32 window_id = 1;
-	int32 browser_id = 2;
-	string name = 3;
-	string description = 4;
-	string html = 5;
-	int32 column_no = 6;
-	int32 line_no = 7;
-	bool is_collapsible = 8;
-	bool is_open_by_default = 9;
-	bool is_event_required = 10;
-	string file_name = 11;
-	string dashboard_type = 12;
-	string chart_type = 13;
-	int32 id = 14;
+	int32 id = 1;
+	string name = 2;
+	string description = 3;
+	string file_name = 4;
+	string dashboard_type = 5;
+	string chart_type = 6;
+	int32 sequence = 7;
+	string html = 8;
+	int32 column_no = 9;
+	int32 line_no = 10;
+	bool is_collapsible = 11;
+	bool is_open_by_default = 12;
+	bool is_event_required = 13;
+	int32 browser_id = 14;
+	int32 window_id = 15;
 }
 
 // Dashboards Request


### PR DESCRIPTION

Add sequence to list dashboards.

```json
{
 "record_count": "22",
 "dashboards": [
  {
   "id": 1000041,
   "name": "Ventas",
   "description": "Venta neta",
   "file_name": "",
   "dashboard_type": "chart",
   "chart_type": "LC",
   "sequence": 0,
   "html": "",
   "column_no": 0,
   "line_no": 0,
   "is_collapsible": true,
   "is_open_by_default": true,
   "is_event_required": false,
   "browser_id": 0,
   "window_id": 0
  }
 ],
 "next_page_token": ""
}
```

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/1748