### PR TITLE
fix: Field with multiple callouts.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
 	implementation 'com.sun.xml.bind:jaxb-core:3.0.0-M4'
 	implementation 'javax.activation:activation:1.1.1'
 
-	implementation "${baseGroupId}:adempiere-grpc-utils:1.2.9"
+	implementation "${baseGroupId}:adempiere-grpc-utils:1.3.0"
 
 	//	ADempiere Core
 	implementation "${baseGroupId}:base:${baseVersion}"

--- a/src/main/java/org/spin/grpc/service/UserInterface.java
+++ b/src/main/java/org/spin/grpc/service/UserInterface.java
@@ -2643,77 +2643,85 @@ public class UserInterface extends UserInterfaceImplBase {
 	 * @param calloutBuilder
 	 * @return
 	 */
-	private org.spin.backend.grpc.user_interface.Callout.Builder setAdditionalContext(String calloutClass, int windowNo,
+	private org.spin.backend.grpc.user_interface.Callout.Builder setAdditionalContext(String callouts, int windowNo,
 		org.spin.backend.grpc.user_interface.Callout.Builder calloutBuilder) {
+		if (Util.isEmpty(callouts, true)) {
+			return calloutBuilder;
+		}
+
 		Class<CalloutOrder> clazz = org.compiere.model.CalloutOrder.class;
 		String className = clazz.getName();
 
-		if (calloutClass.startsWith(className)) {
-			Struct.Builder contextValues = calloutBuilder.getValuesBuilder();
-			if (calloutClass.equals("org.compiere.model.CalloutOrder.docType")) {
-				// - OrderType
-				String docSubTypeSO = Env.getContext(Env.getCtx(), windowNo, "OrderType");
-				contextValues.putFields(
-					"OrderType",
-					ValueManager.getValueFromString(docSubTypeSO).build()
-				);
+		// separate `org.package.CalloutX.firstMethod; org.any.CalloutY.secondMethod`
+		List<String> calloutsList = Arrays.asList(callouts.split("\\s*(,|;)\\s*"));
+		calloutsList.forEach(calloutClass -> {
+			if (calloutClass.startsWith(className)) {
+				Struct.Builder contextValues = calloutBuilder.getValuesBuilder();
+				if (calloutClass.equals("org.compiere.model.CalloutOrder.docType")) {
+					// - OrderType
+					String docSubTypeSO = Env.getContext(Env.getCtx(), windowNo, "OrderType");
+					contextValues.putFields(
+						"OrderType",
+						ValueManager.getValueFromString(docSubTypeSO).build()
+					);
 
-				// - HasCharges
-				String hasCharges = Env.getContext(Env.getCtx(), windowNo, "HasCharges");
-				contextValues.putFields(
-					"HasCharges",
-					ValueManager.getValueFromStringBoolean(hasCharges).build()
-				);
+					// - HasCharges
+					String hasCharges = Env.getContext(Env.getCtx(), windowNo, "HasCharges");
+					contextValues.putFields(
+						"HasCharges",
+						ValueManager.getValueFromStringBoolean(hasCharges).build()
+					);
+				}
+				else if (calloutClass.equals("org.compiere.model.CalloutOrder.priceList")) {
+					// - M_PriceList_Version_ID
+					int priceListVersionId = Env.getContextAsInt(Env.getCtx(), windowNo, "M_PriceList_Version_ID");
+					contextValues.putFields(
+						"M_PriceList_Version_ID",
+						ValueManager.getValueFromInteger(priceListVersionId).build()
+					);
+				}
+				else if (calloutClass.equals("org.compiere.model.CalloutOrder.product")) {
+					// - M_PriceList_Version_ID
+					int priceListVersionId = Env.getContextAsInt(Env.getCtx(), windowNo, "M_PriceList_Version_ID");
+					contextValues.putFields(
+						"M_PriceList_Version_ID",
+						ValueManager.getValueFromInteger(priceListVersionId).build()
+					);
+					
+					// - DiscountSchema
+					String isDiscountSchema = Env.getContext(Env.getCtx(), "DiscountSchema");
+					contextValues.putFields(
+						"DiscountSchema",
+						ValueManager.getValueFromStringBoolean(isDiscountSchema).build()
+					);
+				}
+				else if (calloutClass.equals("org.compiere.model.CalloutOrder.charge")) {
+					// - DiscountSchema
+					String isDiscountSchema = Env.getContext(Env.getCtx(), "DiscountSchema");
+					contextValues.putFields(
+						"DiscountSchema",
+						ValueManager.getValueFromStringBoolean(isDiscountSchema).build()
+					);
+				}
+				else if (calloutClass.equals("org.compiere.model.CalloutOrder.amt")) {
+					// - DiscountSchema
+					String isDiscountSchema = Env.getContext(Env.getCtx(), "DiscountSchema");
+					contextValues.putFields(
+						"DiscountSchema",
+						ValueManager.getValueFromStringBoolean(isDiscountSchema).build()
+					);
+				}
+				else if (calloutClass.equals("org.compiere.model.CalloutOrder.qty")) {
+					// - UOMConversion
+					String isConversion = Env.getContext(Env.getCtx(), "UOMConversion");
+					contextValues.putFields(
+						"UOMConversion",
+						ValueManager.getValueFromStringBoolean(isConversion).build()
+					);
+				}
+				calloutBuilder.setValues(contextValues);
 			}
-			else if (calloutClass.equals("org.compiere.model.CalloutOrder.priceList")) {
-				// - M_PriceList_Version_ID
-				int priceListVersionId = Env.getContextAsInt(Env.getCtx(), windowNo, "M_PriceList_Version_ID");
-				contextValues.putFields(
-					"M_PriceList_Version_ID",
-					ValueManager.getValueFromInteger(priceListVersionId).build()
-				);
-			}
-			else if (calloutClass.equals("org.compiere.model.CalloutOrder.product")) {
-				// - M_PriceList_Version_ID
-				int priceListVersionId = Env.getContextAsInt(Env.getCtx(), windowNo, "M_PriceList_Version_ID");
-				contextValues.putFields(
-					"M_PriceList_Version_ID",
-					ValueManager.getValueFromInteger(priceListVersionId).build()
-				);
-				
-				// - DiscountSchema
-				String isDiscountSchema = Env.getContext(Env.getCtx(), "DiscountSchema");
-				contextValues.putFields(
-					"DiscountSchema",
-					ValueManager.getValueFromStringBoolean(isDiscountSchema).build()
-				);
-			}
-			else if (calloutClass.equals("org.compiere.model.CalloutOrder.charge")) {
-				// - DiscountSchema
-				String isDiscountSchema = Env.getContext(Env.getCtx(), "DiscountSchema");
-				contextValues.putFields(
-					"DiscountSchema",
-					ValueManager.getValueFromStringBoolean(isDiscountSchema).build()
-				);
-			}
-			else if (calloutClass.equals("org.compiere.model.CalloutOrder.amt")) {
-				// - DiscountSchema
-				String isDiscountSchema = Env.getContext(Env.getCtx(), "DiscountSchema");
-				contextValues.putFields(
-					"DiscountSchema",
-					ValueManager.getValueFromStringBoolean(isDiscountSchema).build()
-				);
-			}
-			else if (calloutClass.equals("org.compiere.model.CalloutOrder.qty")) {
-				// - UOMConversion
-				String isConversion = Env.getContext(Env.getCtx(), "UOMConversion");
-				contextValues.putFields(
-					"UOMConversion",
-					ValueManager.getValueFromStringBoolean(isConversion).build()
-				);
-			}
-			calloutBuilder.setValues(contextValues);
-		}
+		});
 
 		return calloutBuilder;
 	}


### PR DESCRIPTION
### Request

```bash
curl --location --request POST 'http://192.168.5.101/api/user-interface/run-callout/186/DateOrdered/org.compiere.model.CalloutEngine.dateAcct;%20org.compiere.model.CalloutOrder.priceList' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIyMDE3NTI4IiwiQURfQ2xpZW50X0lEIjoxMDAwMDAxLCJBRF9PcmdfSUQiOjEwMDAwMTAsIkFEX1JvbGVfSUQiOjEwMDAwMjMsIkFEX1VzZXJfSUQiOjEwMDEzOTgsIk1fV2FyZWhvdXNlX0lEIjoxMDAwMDgwLCJBRF9MYW5ndWFnZSI6ImVzX01YIiwiaWF0IjoxNzA2MjgyNzE5LCJleHAiOjE3MDYzNjkxMTl9.7rEIUfi0j_mzv7CsIYTPUE_vncKs2fNjgBXPimsQUP8' \
--data '{
    "tab_id": 186,
    "column_name": "DateOrdered",
    "context_attributes": {},
    "callout": "org.compiere.model.CalloutEngine.dateAcct; org.compiere.model.CalloutOrder.priceList",
    "value":  "2024-01-29T00:00:00.000Z",
    "old_value": null
}'
```

### Response
```json
{
    "result": "",
    "values": {
        "DateOrdered": null
    }
}
```

### Additional context
In addition, the `setAdditionalContext` method ensures that the text containing the value of the callout classes is correctly separated in case you have several callouts as in the case of `org.compiere.model.CalloutEngine.dateAcct; org.compiere.model.CalloutOrder.priceList`.

Related changes https://github.com/adempiere/adempiere-grpc-utils/pull/21

Fixes https://github.com/solop-develop/frontend-core/issues/1883
