### PR TITLE
fix: Default value empty if `IsActive='Y'` restriction.

### DIFF
--- a/src/main/java/org/spin/base/db/WhereClauseUtil.java
+++ b/src/main/java/org/spin/base/db/WhereClauseUtil.java
@@ -110,6 +110,33 @@ public class WhereClauseUtil {
 		return sqlWithActiveRecords;
 	}
 
+	/**
+	 * Add and get sql with active records
+	 * @param tableAlias
+	 * @param dynamicValidation
+	 * @return {String}
+	 */
+	public static String removeIsActiveRestriction(String tableAlias, String sql) {
+		String SQL_WHERE_REGEX = "(WHERE|(AND|OR))(\\s+(" + tableAlias + ".IsActive|IsActive)\\s*=\\s*'(Y|N)')";
+
+		String sqlWithoutRestriction = sql;
+		// remove order by clause
+		Pattern patternWhere = Pattern.compile(
+			SQL_WHERE_REGEX,
+			Pattern.CASE_INSENSITIVE | Pattern.DOTALL
+		);	
+		Matcher matcherWhere = patternWhere
+			.matcher(sql);
+		if(matcherWhere.find()) {
+			int startPosition = matcherWhere.start();
+			String initialPart = sql.substring(0, startPosition);
+			int endPosition = matcherWhere.end();
+			String finalPart = sql.substring(endPosition, sql.length());
+			sqlWithoutRestriction = initialPart + finalPart;
+		}
+
+		return sqlWithoutRestriction;
+	}
 
 	/**
 	 * Get sql restriction by operator

--- a/src/main/java/org/spin/grpc/service/UserInterface.java
+++ b/src/main/java/org/spin/grpc/service/UserInterface.java
@@ -1881,11 +1881,19 @@ public class UserInterface extends UserInterfaceImplBase {
 					}
 				}
 
-				MLookupInfo lookupInfo = ReferenceUtil.getReferenceLookupInfo(displayTypeId, referenceValueId, columnName, validationRuleId);
+				MLookupInfo lookupInfo = ReferenceUtil.getReferenceLookupInfo(
+					displayTypeId,
+					referenceValueId,
+					columnName,
+					validationRuleId
+				);
 				if(lookupInfo == null || Util.isEmpty(lookupInfo.QueryDirect, true)) {
 					return builder;
 				}
-				final String sql = lookupInfo.QueryDirect;
+				final String sql = WhereClauseUtil.removeIsActiveRestriction(
+					lookupInfo.TableName,
+					lookupInfo.QueryDirect
+				);
 				// final String sql = MRole.getDefault(context, false).addAccessSQL(
 				// 	lookupInfo.QueryDirect,
 				// 	lookupInfo.TableName,


### PR DESCRIPTION
#### Request

```bash
curl 'http://10.11.12.101/api/user-interface/default-value/field/1343?value=102' -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0' -H 'Accept: application/json, text/plain, */*' -H 'Accept-Language: es-MX,es;q=0.8,en-US;q=0.5,en;q=0.3' -H 'Accept-Encoding: gzip, deflate' -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIyMDE3MTEwIiwiQURfQ2xpZW50X0lEIjoxMDAwMDAxLCJBRF9PcmdfSUQiOjEwMDAwMDEsIkFEX1JvbGVfSUQiOjEwMDAwMTcsIkFEX1VzZXJfSUQiOjEwMDEyMTIsIk1fV2FyZWhvdXNlX0lEIjoxMDAwMDI4LCJBRF9MYW5ndWFnZSI6ImVzX01YIiwiaWF0IjoxNzA4NjI4NDg3LCJleHAiOjE3MDg3MTQ4ODd9.J0ZGVviWmYIY_5fz8XX1yE0lJ7KVpLcZmE90-4Bfsuw' -H 'Origin: http://0.0.0.0:9527' -H 'Connection: keep-alive' -H 'Referer: http://0.0.0.0:9527/' -H 'Pragma: no-cache' -H 'Cache-Control: no-cache'
```

#### Response

Before this changes


```json
{
 "id": 0,
  "values": {},
 "is_active": true
}
````

After this changes

```json
{
 "id": 102,
 "values": {
  "KeyColumn": 102,
  "DisplayColumn": "EUR",
  "UUID": "a5673830-fb40-11e8-a479-7a0060f0aa01"
 },
 "is_active": false
}
````

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/1685