### PR TITLE
feat: Return `JWT` by keycloack.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,9 @@ jobs:
           gradle-version: 8.0.2
           arguments: build
 
-      - name: Upload descriptor file artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: adempiere-grpc-server.pb
-          path: build/descriptors/adempiere-grpc-server.pb
-          retention-days: 7
+    #   - name: Upload descriptor file artifact
+    #     uses: actions/upload-artifact@v4
+    #     with:
+    #       name: adempiere-grpc-server.pb
+    #       path: build/descriptors/adempiere-grpc-server.pb
+    #       retention-days: 7

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
 	implementation 'com.sun.xml.bind:jaxb-core:3.0.0-M4'
 	implementation 'javax.activation:activation:1.1.1'
 
-	implementation "${baseGroupId}:adempiere-grpc-utils:1.3.3"
+	implementation "${baseGroupId}:adempiere-grpc-utils:1.3.4"
 
 	//	ADempiere Core
 	implementation "${baseGroupId}:base:${baseVersion}"
@@ -109,7 +109,7 @@ dependencies {
 	// https://mvnrepository.com/artifact/net.minidev/accessors-smart
 	implementation 'net.minidev:accessors-smart:2.4.8'
 	//	Temporary projects
-	//	Keycloak and Okta connector (Open-ID  based)
+	//	Keycloak and Okta connector (Open-ID based)
 	implementation "${baseGroupId}:adempiere-open-id-connector:1.0.0"
 }
 
@@ -139,11 +139,10 @@ protobuf {
 			  // task.outputBaseDir. Default is false.
 			  // See --descriptor_set_out in protoc documentation about what it is.
 			  task.generateDescriptorSet = true
-			
-			  // Allows to override the default for the descriptor set location
-			  task.descriptorSetOptions.path =
-			    "${projectDir}/build/descriptors/adempiere-grpc-server.pb"
-			
+
+			// Allows to override the default for the descriptor set location
+			task.descriptorSetOptions.path = "${projectDir}/build/descriptors/adempiere-grpc-server.pb"
+
 			  // If true, the descriptor set will contain line number information
 			  // and comments. Default is false.
 			  task.descriptorSetOptions.includeSourceInfo = true

--- a/docker/envoy_template.yaml
+++ b/docker/envoy_template.yaml
@@ -1,11 +1,12 @@
 static_resources:
   listeners:
-  - name: adempiere_grpc_proxy
+  - name: adempiere_grpc_backend_proxy
     address:
       socket_address: {
         address: 0.0.0.0,
         port_value: 5555
       }
+    per_connection_buffer_limit_bytes: 94371840 # 90 MiB
     filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -27,7 +28,7 @@ static_resources:
                   grpc: {}
                 }
                 route: {
-                  cluster: adempiere_grpc_cluster,
+                  cluster: adempiere_grpc_backend_cluster,
                   timeout: 60s
                 }
           http_filters:
@@ -91,7 +92,7 @@ static_resources:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
   clusters:
-  - name: adempiere_grpc_cluster
+  - name: adempiere_grpc_backend_cluster
     type: LOGICAL_DNS
     lb_policy: ROUND_ROBIN
     dns_lookup_family: V4_ONLY
@@ -101,7 +102,7 @@ static_resources:
         explicit_http_config:
           http2_protocol_options: {}
     load_assignment:
-      cluster_name: adempiere_grpc_cluster
+      cluster_name: adempiere_grpc_backend_cluster
       endpoints:
       - lb_endpoints:
         - endpoint:

--- a/resources/envoy.yaml
+++ b/resources/envoy.yaml
@@ -38,7 +38,7 @@ static_resources:
                 # package.service
                 - bank_statement_match.BankStatementMatch
                 - data.BusinessData
-                - data.CoreFunctionality
+                - core_functionality.CoreFunctionality
                 - dashboarding.Dashboarding
                 - dictionary.Dictionary
                 - enrollment.Register
@@ -57,6 +57,7 @@ static_resources:
                 - logs.Logs
                 - match_po_receipt_invoice.MatchPORReceiptInvoice
                 - material_management.MaterialManagement
+                - notice_management.NoticeManagement
                 - order.Order
                 - payment_allocation.PaymentAllocation
                 - payment_print_export.PaymentPrintExport
@@ -66,8 +67,10 @@ static_resources:
                 - record_management.RecordManagement
                 - report_management.ReportManagement
                 - security.Security
+                - task_management.TaskManagement
                 - time_control.TimeControl
                 - time_record.TimeRecord
+                - trial_balance_drillable.TrialBalanceDrillable
                 - updates.UpdateCenter
                 - user_customization.UserCustomization
                 - user_interface.UserInterface


### PR DESCRIPTION
When authenticating with OpenID through keycloack, the token generated from keycloack is now returned to the fronend and not the one generated by adempiere.

![imagen](https://github.com/adempiere/adempiere-grpc-utils/assets/20288327/1a2881c2-78d9-46cc-bea7-36097029d5f0)


![imagen](https://github.com/adempiere/adempiere-grpc-utils/assets/20288327/69f5f5a5-158f-423c-a2ef-849cf656b00f)



[open-id-session-id.xml.zip](https://github.com/adempiere/adempiere-grpc-utils/files/14578780/open-id-session-id.xml.zip)



fixes https://github.com/solop-develop/frontend-core/issues/1968