### PR TITLE
fix: SQL Count without where clause.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,10 @@ plugins {
 }
 
 group 'com.nikhilm'
+
 sourceCompatibility = 1.11
-def grpcVersion = '1.58.0'
+
+def grpcVersion = '1.62.2'
 def baseVersion = '3.9.4'
 def baseGroupId = 'io.github.adempiere'
 def customBaseVersion = ""
@@ -47,7 +49,7 @@ dependencies {
 	implementation 'com.sun.xml.bind:jaxb-core:3.0.0-M4'
 	implementation 'javax.activation:activation:1.1.1'
 
-	implementation "${baseGroupId}:adempiere-grpc-utils:1.3.4"
+	implementation "${baseGroupId}:adempiere-grpc-utils:1.3.5"
 
 	//	ADempiere Core
 	implementation "${baseGroupId}:base:${baseVersion}"
@@ -117,7 +119,7 @@ configurations.all {
 	resolutionStrategy {
 		// used by aws-java-sdk-core (storefront is joda-time-2.10.4)
 		force("joda-time:joda-time:2.8.1")
-		// force("io.github.adempiere:adempiere-grpc-utils:local-1.0.1")
+		// force("io.github.adempiere:adempiere-grpc-utils:local-1.0.0")
 	}
 }
 

--- a/src/main/java/org/spin/server/AllInOneServices.java
+++ b/src/main/java/org/spin/server/AllInOneServices.java
@@ -140,10 +140,16 @@ public class AllInOneServices {
 
 		ServerBuilder<?> serverBuilder;
 		if(SetupLoader.getInstance().getServer().isTlsEnabled()) {
-			serverBuilder = NettyServerBuilder.forPort(SetupLoader.getInstance().getServer().getPort())
-				.sslContext(getSslContextBuilder().build());
+			serverBuilder = NettyServerBuilder.forPort(
+					SetupLoader.getInstance().getServer().getPort()
+				)
+				.sslContext(
+					getSslContextBuilder().build()
+				);
 		} else {
-			serverBuilder = ServerBuilder.forPort(SetupLoader.getInstance().getServer().getPort());
+			serverBuilder = ServerBuilder.forPort(
+				SetupLoader.getInstance().getServer().getPort()
+			);
 		}
 
 		// Validate JWT on all requests


### PR DESCRIPTION
Original SQL:
```sql
SELECT C_BankAccount.C_BankAccount_ID,NULL,
	COALESCE((SELECT COALESCE(C_Bank.Name,'')||' - '||COALESCE(C_Bank.RoutingNo,'') FROM C_Bank WHERE C_BankAccount.C_Bank_ID=C_Bank.C_Bank_ID),'-1') ||'_'|| COALESCE(C_BankAccount.AccountNo,'-1') ||'_'|| COALESCE((SELECT COALESCE(C_Currency.ISO_Code,'') FROM C_Currency WHERE C_BankAccount.C_Currency_ID=C_Currency.C_Currency_ID),'-1'),
	C_BankAccount.IsActive,
	C_BankAccount.UUID 
FROM C_BankAccount 
ORDER BY 3
```

Generate SQL
```sql
SELECT COUNT(*)
FROM C_BankAccount 
ORDER BY 3
```



https://github.com/adempiere/adempiere-grpc-utils/assets/20288327/375ef408-f9f4-4443-83b2-5d33335627bc



fixes https://github.com/solop-develop/frontend-core/issues/2012
