### PR TITLE
fix: NPE With callout is not custom context.

### DIFF
--- a/src/main/java/org/spin/grpc/service/UserInterface.java
+++ b/src/main/java/org/spin/grpc/service/UserInterface.java
@@ -2688,29 +2688,34 @@ public class UserInterface extends UserInterfaceImplBase {
 			return calloutBuilder;
 		}
 
-		List<String> calloutClassList = new ArrayList<>();
-		calloutClassList.add(
-			org.compiere.model.CalloutOrder.class.getName()
-		);
-		calloutClassList.add(
+		// separate `org.package.CalloutX.firstMethod; org.any.CalloutY.secondMethod`
+		List<String> calloutsList = Arrays.asList(callouts.split("\\s*(,|;)\\s*"));
+		if (calloutsList == null || calloutsList.isEmpty()) {
+			return calloutBuilder;
+		}
+
+		// callouts that modify the context in a customized way
+		List<String> calloutsListCustomContext = Arrays.asList(
+			org.compiere.model.CalloutOrder.class.getName(),
 			org.compiere.model.CalloutPayment.class.getName()
 		);
 
-		// separate `org.package.CalloutX.firstMethod; org.any.CalloutY.secondMethod`
-		List<String> calloutsList = Arrays.asList(callouts.split("\\s*(,|;)\\s*"));
-		calloutsList.forEach(calloutClass -> {
-			String className = null;
-			for (String calloutClassName: calloutClassList) {
-				if (calloutClass.startsWith(calloutClassName)) {
-					className = calloutClassName;
-					break;
-				}
-			}
-			if (!calloutClass.startsWith(className)) {
+		calloutsList.forEach(calloutClassAndMethod -> {
+			if (Util.isEmpty(calloutClassAndMethod, true)) {
+				// empty class name
 				return;
 			}
+			// the current callout is not in the custom context list
+			boolean isCustomContext = calloutsListCustomContext.stream()
+				.anyMatch(calloutClassNameCustomContext -> {
+					return calloutClassAndMethod.startsWith(calloutClassNameCustomContext);
+				});
+			if (isCustomContext) {
+				return;
+			}
+
 			Struct.Builder contextValues = calloutBuilder.getValuesBuilder();
-			if (calloutClass.equals("org.compiere.model.CalloutOrder.docType")) {
+			if (calloutClassAndMethod.equals("org.compiere.model.CalloutOrder.docType")) {
 				// - OrderType
 				String docSubTypeSO = Env.getContext(Env.getCtx(), windowNo, "OrderType");
 				contextValues.putFields(
@@ -2725,7 +2730,7 @@ public class UserInterface extends UserInterfaceImplBase {
 					ValueManager.getValueFromStringBoolean(hasCharges).build()
 				);
 			}
-			else if (calloutClass.equals("org.compiere.model.CalloutOrder.priceList")) {
+			else if (calloutClassAndMethod.equals("org.compiere.model.CalloutOrder.priceList")) {
 				// - M_PriceList_Version_ID
 				int priceListVersionId = Env.getContextAsInt(Env.getCtx(), windowNo, "M_PriceList_Version_ID");
 				contextValues.putFields(
@@ -2733,14 +2738,14 @@ public class UserInterface extends UserInterfaceImplBase {
 					ValueManager.getValueFromInteger(priceListVersionId).build()
 				);
 			}
-			else if (calloutClass.equals("org.compiere.model.CalloutOrder.product")) {
+			else if (calloutClassAndMethod.equals("org.compiere.model.CalloutOrder.product")) {
 				// - M_PriceList_Version_ID
 				int priceListVersionId = Env.getContextAsInt(Env.getCtx(), windowNo, "M_PriceList_Version_ID");
 				contextValues.putFields(
 					"M_PriceList_Version_ID",
 					ValueManager.getValueFromInteger(priceListVersionId).build()
 				);
-				
+
 				// - DiscountSchema
 				String isDiscountSchema = Env.getContext(Env.getCtx(), windowNo, "DiscountSchema");
 				contextValues.putFields(
@@ -2748,7 +2753,7 @@ public class UserInterface extends UserInterfaceImplBase {
 					ValueManager.getValueFromStringBoolean(isDiscountSchema).build()
 				);
 			}
-			else if (calloutClass.equals("org.compiere.model.CalloutOrder.charge")) {
+			else if (calloutClassAndMethod.equals("org.compiere.model.CalloutOrder.charge")) {
 				// - DiscountSchema
 				String isDiscountSchema = Env.getContext(Env.getCtx(), windowNo, "DiscountSchema");
 				contextValues.putFields(
@@ -2756,7 +2761,7 @@ public class UserInterface extends UserInterfaceImplBase {
 					ValueManager.getValueFromStringBoolean(isDiscountSchema).build()
 				);
 			}
-			else if (calloutClass.equals("org.compiere.model.CalloutOrder.amt")) {
+			else if (calloutClassAndMethod.equals("org.compiere.model.CalloutOrder.amt")) {
 				// - DiscountSchema
 				String isDiscountSchema = Env.getContext(Env.getCtx(), windowNo, "DiscountSchema");
 				contextValues.putFields(
@@ -2764,14 +2769,14 @@ public class UserInterface extends UserInterfaceImplBase {
 					ValueManager.getValueFromStringBoolean(isDiscountSchema).build()
 				);
 			}
-			else if (calloutClass.equals("org.compiere.model.CalloutOrder.qty")) {
+			else if (calloutClassAndMethod.equals("org.compiere.model.CalloutOrder.qty")) {
 				// - UOMConversion
 				String isConversion = Env.getContext(Env.getCtx(), windowNo, "UOMConversion");
 				contextValues.putFields(
 					"UOMConversion",
 					ValueManager.getValueFromStringBoolean(isConversion).build()
 				);
-			} else if (calloutClass.equals("org.compiere.model.CalloutPayment.docType")) {
+			} else if (calloutClassAndMethod.equals("org.compiere.model.CalloutPayment.docType")) {
 				String isSalesTransaction = Env.getContext(Env.getCtx(), windowNo, "IsSOTrx");
 				contextValues.putFields(
 					"IsSOTrx",


### PR DESCRIPTION
If the current callout is not in the list of callouts that modify the context, it generates a `Null Pointer Exception`.

```log
===========> UserInterface.runCallout: null [20]
java.lang.NullPointerException
        at java.base/java.lang.String.startsWith(String.java:1428)
        at java.base/java.lang.String.startsWith(String.java:1470)
        at org.spin.grpc.service.UserInterface.lambda$26(UserInterface.java:2709)
        at java.base/java.util.Arrays$ArrayList.forEach(Arrays.java:4390)
        at org.spin.grpc.service.UserInterface.setAdditionalContext(UserInterface.java:2701)
        at org.spin.grpc.service.UserInterface.lambda$22(UserInterface.java:2672)
        at org.compiere.util.Trx.run(Trx.java:529)
        at org.compiere.util.Trx.run(Trx.java:497)
        at org.spin.grpc.service.UserInterface.runcallout(UserInterface.java:2563)
        at org.spin.grpc.service.UserInterface.runCallout(UserInterface.java:2536)
        at org.spin.backend.grpc.user_interface.UserInterfaceGrpc$MethodHandlers.invoke(UserInterfaceGrpc.java:2208)
        at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
        at io.grpc.Contexts$ContextualizedServerCallListener.onHalfClose(Contexts.java:86)
        at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:351)
        at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:861)
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
```

