### PR TITLE
feat: `Product` info field filter by groups.

### DIFF
--- a/src/main/java/org/spin/grpc/service/field/product/ProductInfo.java
+++ b/src/main/java/org/spin/grpc/service/field/product/ProductInfo.java
@@ -25,6 +25,7 @@ import org.spin.backend.grpc.field.product.ListAvailableToPromisesResponse;
 import org.spin.backend.grpc.field.product.ListPricesListVersionsRequest;
 import org.spin.backend.grpc.field.product.ListProductCategoriesRequest;
 import org.spin.backend.grpc.field.product.ListProductClasessRequest;
+import org.spin.backend.grpc.field.product.ListProductClassificationsRequest;
 import org.spin.backend.grpc.field.product.ListProductGroupsRequest;
 import org.spin.backend.grpc.field.product.ListProductsInfoRequest;
 import org.spin.backend.grpc.field.product.ListProductsInfoResponse;
@@ -217,6 +218,29 @@ public class ProductInfo extends ProductInfoServiceImplBase {
 	public void listProductClasses(ListProductClasessRequest request, StreamObserver<ListLookupItemsResponse> responseObserver) {
 		try {
 			ListLookupItemsResponse.Builder buildersList = ProductInfoLogic.listProductClasses(
+				request
+			);
+			responseObserver.onNext(
+				buildersList.build()
+			);
+			responseObserver.onCompleted();
+		} catch (Exception e) {
+			log.severe(e.getLocalizedMessage());
+			e.printStackTrace();
+			responseObserver.onError(
+				Status.INTERNAL
+					.withDescription(e.getLocalizedMessage())
+					.withCause(e)
+					.asRuntimeException()
+			);
+		}
+	}
+
+
+	@Override
+	public void listProductClassifications(ListProductClassificationsRequest request, StreamObserver<ListLookupItemsResponse> responseObserver) {
+		try {
+			ListLookupItemsResponse.Builder buildersList = ProductInfoLogic.listProductClassifications(
 				request
 			);
 			responseObserver.onNext(

--- a/src/main/java/org/spin/grpc/service/field/product/ProductInfoLogic.java
+++ b/src/main/java/org/spin/grpc/service/field/product/ProductInfoLogic.java
@@ -29,6 +29,8 @@ import org.adempiere.core.domains.models.I_M_PriceList_Version;
 import org.adempiere.core.domains.models.I_M_Product;
 import org.adempiere.core.domains.models.I_M_Product_Category;
 import org.adempiere.core.domains.models.I_M_Product_Class;
+import org.adempiere.core.domains.models.I_M_Product_Classification;
+import org.adempiere.core.domains.models.I_M_Product_Group;
 import org.adempiere.core.domains.models.I_M_Product_PO;
 import org.adempiere.core.domains.models.I_M_Warehouse;
 import org.adempiere.exceptions.AdempiereException;
@@ -51,6 +53,7 @@ import org.spin.backend.grpc.field.product.ListAvailableToPromisesResponse;
 import org.spin.backend.grpc.field.product.ListPricesListVersionsRequest;
 import org.spin.backend.grpc.field.product.ListProductCategoriesRequest;
 import org.spin.backend.grpc.field.product.ListProductClasessRequest;
+import org.spin.backend.grpc.field.product.ListProductClassificationsRequest;
 import org.spin.backend.grpc.field.product.ListProductGroupsRequest;
 import org.spin.backend.grpc.field.product.ListProductsInfoRequest;
 import org.spin.backend.grpc.field.product.ListProductsInfoResponse;
@@ -262,7 +265,7 @@ public class ProductInfoLogic {
 			DisplayType.TableDir,
 			0, 0, 0,
 			0,
-			I_M_Product_Category.COLUMNNAME_M_Product_Category_ID, I_M_Product_Category.Table_Name
+			I_M_Product_Group.COLUMNNAME_M_Product_Group_ID, I_M_Product_Group.Table_Name
 		);
 
 		ListLookupItemsResponse.Builder builderList = UserInterface.listLookupItems(
@@ -284,6 +287,27 @@ public class ProductInfoLogic {
 			0, 0, 0,
 			0,
 			I_M_Product_Class.COLUMNNAME_M_Product_Class_ID, I_M_Product_Class.Table_Name
+		);
+
+		ListLookupItemsResponse.Builder builderList = UserInterface.listLookupItems(
+			reference,
+			null,
+			request.getPageSize(),
+			request.getPageToken(),
+			request.getSearchValue(),
+			true
+		);
+
+		return builderList;
+	}
+
+	public static ListLookupItemsResponse.Builder listProductClassifications(ListProductClassificationsRequest request) {
+		// Warehouse
+		MLookupInfo reference = ReferenceInfo.getInfoFromRequest(
+			DisplayType.TableDir,
+			0, 0, 0,
+			0,
+			I_M_Product_Classification.COLUMNNAME_M_Product_Classification_ID, I_M_Product_Classification.Table_Name
 		);
 
 		ListLookupItemsResponse.Builder builderList = UserInterface.listLookupItems(
@@ -473,6 +497,13 @@ public class ProductInfoLogic {
 			sqlWhere += " AND p.M_Product_Class_ID = ? ";
 			parametersList.add(
 				request.getProductClassId()
+			);
+		}
+		// Product Classification
+		if (request.getProductClassificationId() > 0) {
+			sqlWhere += " AND p.M_Product_Classification_ID = ? ";
+			parametersList.add(
+				request.getProductClassificationId()
 			);
 		}
 		// Attribute Set

--- a/src/main/proto/product.proto
+++ b/src/main/proto/product.proto
@@ -61,6 +61,9 @@ service ProductInfoService {
 	rpc ListProductClasses(ListProductClasessRequest) returns (data.ListLookupItemsResponse) {
 		option (google.api.http) = { get: "/field/products/clasess" };
 	}
+	rpc ListProductClassifications(ListProductClassificationsRequest) returns (data.ListLookupItemsResponse) {
+		option (google.api.http) = { get: "/field/products/classifications" };
+	}
 	rpc ListVendors(ListVendorsRequest) returns (data.ListLookupItemsResponse) {
 		option (google.api.http) = { get: "/field/products/vendors" };
 	}
@@ -197,6 +200,17 @@ message ListProductClasessRequest {
 	string context_attributes = 8;
 }
 
+message ListProductClassificationsRequest {
+	string filters = 1;
+	string sort_by = 2;
+	repeated string group_columns = 3;
+	repeated string select_columns = 4;
+	int32 page_size = 5;
+	string page_token = 6;
+	string search_value = 7;
+	string context_attributes = 8;
+}
+
 message ListVendorsRequest {
 	string filters = 1;
 	string sort_by = 2;
@@ -277,10 +291,11 @@ message ListProductsInfoRequest {
 	int32 product_category_id = 23;
 	int32 product_group_id = 24;
 	int32 product_class_id = 25;
-	int32 attribute_set_id = 26;
-	int32 attribute_set_instance_id = 27;
-	int32 vendor_id = 28;
-	string is_stocked = 29;
+	int32 product_classification_id = 26;
+	int32 attribute_set_id = 27;
+	int32 attribute_set_instance_id = 28;
+	int32 vendor_id = 29;
+	string is_stocked = 30;
 }
 
 


### PR DESCRIPTION
Add filters by Product Category, Product Group, Product Class and Product Classification.

https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/439551ea-2969-4ad8-878f-e39d220d4b6e

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/1034