### PR TITLE
feat: Add `action_uuid` on Menu structure.

### DIFF
--- a/src/main/java/org/spin/grpc/service/Security.java
+++ b/src/main/java/org/spin/grpc/service/Security.java
@@ -1527,6 +1527,11 @@ public class Security extends SecurityImplBase {
 					)
 				;
 				builder.setActionId(form.getAD_Form_ID())
+					.setActionUuid(
+						ValueManager.validateNull(
+							form.getUUID()
+						)
+					)
 					.setForm(actionReference)
 				;
 			} else if (menu.getAction().equals(MMenu.ACTION_Window) && menu.getAD_Window_ID() > 0) {
@@ -1556,6 +1561,11 @@ public class Security extends SecurityImplBase {
 					)
 				;
 				builder.setActionId(window.getAD_Window_ID())
+					.setActionUuid(
+						ValueManager.validateNull(
+							window.getUUID()
+						)
+					)
 					.setWindow(actionReference)
 				;
 				
@@ -1587,6 +1597,11 @@ public class Security extends SecurityImplBase {
 					)
 				;
 				builder.setActionId(process.getAD_Process_ID())
+					.setActionUuid(
+						ValueManager.validateNull(
+							process.getUUID()
+						)
+					)
 					.setProcess(actionReference)
 				;
 			} else if (menu.getAction().equals(MMenu.ACTION_SmartBrowse) && menu.getAD_Browse_ID() > 0) {
@@ -1616,6 +1631,11 @@ public class Security extends SecurityImplBase {
 					)
 				;
 				builder.setActionId(smartBrowser.getAD_Browse_ID())
+					.setActionUuid(
+						ValueManager.validateNull(
+							smartBrowser.getUUID()
+						)
+					)
 					.setBrowse(actionReference)
 				;
 			} else if (menu.getAction().equals(MMenu.ACTION_WorkFlow) && menu.getAD_Workflow_ID() > 0) {
@@ -1645,6 +1665,11 @@ public class Security extends SecurityImplBase {
 					)
 				;
 				builder.setActionId(workflow.getAD_Workflow_ID())
+					.setActionUuid(
+						ValueManager.validateNull(
+							workflow.getUUID()
+						)
+					)
 					.setWorkflow(actionReference)
 				;
 			}

--- a/src/main/proto/security.proto
+++ b/src/main/proto/security.proto
@@ -311,13 +311,14 @@ message Menu {
 	// Supported References
 	optional string action = 10;
 	optional int32 action_id = 11;
-	optional DictionaryEntity window = 12;
-	optional DictionaryEntity process = 13;
-	optional DictionaryEntity form = 14;
-	optional DictionaryEntity browse = 15;
-	optional DictionaryEntity workflow = 16;
+	optional string action_uuid = 12;
+	optional DictionaryEntity window = 13;
+	optional DictionaryEntity process = 14;
+	optional DictionaryEntity form = 15;
+	optional DictionaryEntity browse = 16;
+	optional DictionaryEntity workflow = 17;
 	// Tree menu childs
-	repeated Menu children = 17;
+	repeated Menu children = 18;
 }
 message MenuRequest {
 }


### PR DESCRIPTION
To prevent the frontend from constructing the `action_id` (as `reference_id`) or `action_uuid` (as `reference_uuid`) by searching inside process, smart browse, window, workflow or form, the attribute is rounded by placing it at the root of the structure.


![imagen](https://github.com/adempiere/adempiere-kafka-connector/assets/20288327/6cf5d3e1-0329-4882-82d1-dd7c3bb8d641)


