### PR TITLE
fix: `Null Pointer Exception` on `addAllDependentFields` method.

### DIFF
--- a/src/main/java/org/spin/base/util/ReferenceUtil.java
+++ b/src/main/java/org/spin/base/util/ReferenceUtil.java
@@ -84,8 +84,8 @@ public class ReferenceUtil {
 			|| DisplayType.Account == displayTypeId
 			|| DisplayType.ID == displayTypeId
 			|| DisplayType.Location == displayTypeId
-			|| DisplayType.PAttribute == displayTypeId
 			|| DisplayType.Locator == displayTypeId
+			|| DisplayType.PAttribute == displayTypeId
 		) {
 			return true;
 		}

--- a/src/main/java/org/spin/grpc/service/dictionary/BrowseConverUtil.java
+++ b/src/main/java/org/spin/grpc/service/dictionary/BrowseConverUtil.java
@@ -300,6 +300,9 @@ public class BrowseConverUtil {
 
 	public static List<DependentField> generateDependentBrowseFields(MBrowseField browseField) {
 		List<DependentField> depenentFieldsList = new ArrayList<>();
+		if (browseField == null) {
+			return depenentFieldsList;
+		}
 
 		MViewColumn viewColumn = MViewColumn.getById(Env.getCtx(), browseField.getAD_View_Column_ID(), null);
 		String parentColumnName = viewColumn.getColumnName();
@@ -316,6 +319,9 @@ public class BrowseConverUtil {
 
 		MBrowse browse = ASPUtil.getInstance().getBrowse(browseField.getAD_Browse_ID());
 		List<MBrowseField> browseFieldsList = ASPUtil.getInstance().getBrowseFields(browseField.getAD_Browse_ID());
+		if (browseFieldsList == null || browseFieldsList.isEmpty()) {
+			return depenentFieldsList;
+		}
 
 		browseFieldsList.parallelStream()
 			.filter(currentBrowseField -> {

--- a/src/main/java/org/spin/grpc/service/dictionary/DictionaryConvertUtil.java
+++ b/src/main/java/org/spin/grpc/service/dictionary/DictionaryConvertUtil.java
@@ -493,6 +493,9 @@ public class DictionaryConvertUtil {
 
 		MTable table = MTable.get(Env.getCtx(), column.getAD_Table_ID());
 		List<MColumn> columnsList = table.getColumnsAsList(false);
+		if (columnsList == null || columnsList.isEmpty()) {
+			return depenentFieldsList;
+		}
 
 		columnsList.parallelStream()
 			.filter(currentColumn -> {

--- a/src/main/java/org/spin/grpc/service/dictionary/ProcessConvertUtil.java
+++ b/src/main/java/org/spin/grpc/service/dictionary/ProcessConvertUtil.java
@@ -205,11 +205,17 @@ public class ProcessConvertUtil {
 
 	public static List<DependentField> generateDependentProcessParameters(MProcessPara processParameter) {
 		List<DependentField> depenentFieldsList = new ArrayList<>();
+		if (processParameter == null) {
+			return depenentFieldsList;
+		}
 
 		String parentColumnName = processParameter.getColumnName();
 
 		MProcess process = ASPUtil.getInstance().getProcess(processParameter.getAD_Process_ID());
 		List<MProcessPara> parametersList = ASPUtil.getInstance().getProcessParameters(processParameter.getAD_Process_ID());
+		if (parametersList == null || parametersList.isEmpty()) {
+			return depenentFieldsList;
+		}
 
 		parametersList.parallelStream()
 			.filter(currentParameter -> {

--- a/src/main/java/org/spin/grpc/service/dictionary/WindowConvertUtil.java
+++ b/src/main/java/org/spin/grpc/service/dictionary/WindowConvertUtil.java
@@ -568,7 +568,7 @@ public class WindowConvertUtil {
 
 		MTab parentTab = MTab.get(Env.getCtx(), field.getAD_Tab_ID());
 		List<MTab> tabsList = ASPUtil.getInstance(Env.getCtx()).getWindowTabs(parentTab.getAD_Window_ID());
-		if (tabsList == null) {
+		if (tabsList == null || tabsList.isEmpty()) {
 			return depenentFieldsList;
 		}
 		tabsList.parallelStream()
@@ -578,7 +578,7 @@ public class WindowConvertUtil {
 			})
 			.forEach(tab -> {
 				List<MField> fieldsList = ASPUtil.getInstance().getWindowFields(tab.getAD_Tab_ID());
-				if (fieldsList == null) {
+				if (fieldsList == null || fieldsList.isEmpty()) {
 					return;
 				}
 


### PR DESCRIPTION

```log
===========> Dictionary.getBrowser: null [6250]                                                                      
java.lang.NullPointerException                                                                                       
        at org.spin.grpc.service.dictionary.BrowseConverUtil.generateDependentBrowseFields(BrowseConverUtil.java:320) 
        at org.spin.grpc.service.dictionary.BrowseConverUtil.convertBrowseField(BrowseConverUtil.java:293)                                                                                                                                 
        at org.spin.grpc.service.dictionary.BrowseConverUtil.convertBrowser(BrowseConverUtil.java:136)
        at org.spin.grpc.service.dictionary.Dictionary.getBrowser(Dictionary.java:270)
        at org.spin.grpc.service.dictionary.Dictionary.getBrowser(Dictionary.java:240)
        at org.spin.backend.grpc.dictionary.DictionaryGrpc$MethodHandlers.invoke(DictionaryGrpc.java:900)
        at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
        at io.grpc.Contexts$ContextualizedServerCallListener.onHalfClose(Contexts.java:86)
        at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:351)
        at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:861)
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829) 
````