### PR TITLE
fix: Filter manager without list.

### DIFF
--- a/src/main/java/org/spin/base/db/WhereClauseUtil.java
+++ b/src/main/java/org/spin/base/db/WhereClauseUtil.java
@@ -512,7 +512,7 @@ public class WhereClauseUtil {
 			.filter(condition -> !Util.isEmpty(condition.getColumnName(), true))
 			.forEach(condition -> {
 				MColumn column = table.getColumn(condition.getColumnName());
-				if (column != null && column.getAD_Column_ID() > 0) {
+				if (column == null || column.getAD_Column_ID() <= 0) {
 					// filter key does not exist as a column, next loop
 					return;
 				}

--- a/src/main/java/org/spin/base/query/Filter.java
+++ b/src/main/java/org/spin/base/query/Filter.java
@@ -43,11 +43,19 @@ public class Filter {
 	}
 
 	public String getColumnName() {
-		return (String) this.condition.get(NAME);
+		Object key = this.condition.get(OPERATOR);
+		if (key == null) {
+			return null;
+		}
+		return (String) key;
 	}
 
 	public String getOperator() {
-		return (String) this.condition.get(OPERATOR);
+		Object operator = this.condition.get(OPERATOR);
+		if (operator == null) {
+			return null;
+		}
+		return (String) operator;
 	}
 
 	public Object getValue() {
@@ -57,6 +65,9 @@ public class Filter {
 	@SuppressWarnings("unchecked")
 	public List<Object> getValues() {
 		Object value = this.condition.get(VALUES);
+		if (value == null) {
+			return null;
+		}
 		if(value instanceof List) {
 			return (List<Object>) value;
 		}

--- a/src/main/java/org/spin/base/query/FilterManager.java
+++ b/src/main/java/org/spin/base/query/FilterManager.java
@@ -16,13 +16,17 @@
 package org.spin.base.query;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.compiere.util.Util;
+import org.spin.service.grpc.util.db.OperatorUtil;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+// import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
@@ -46,9 +50,42 @@ public class FilterManager {
 		} else {
 			ObjectMapper fileMapper = new ObjectMapper();
 			try {
+				/*
+					[
+						{"name: "C_BPartner_ID", "operator": "in", "values": [1234, 4321]},
+						{"name": "C_Invoice", "operator": "equal", "values": 333}
+					]
+				*/
 				this.fillValues = fileMapper.readValue(filter, List.class);
 			} catch (JsonProcessingException e) {
-				throw new RuntimeException("Invalid filter");
+				try {
+					/*
+						{
+							"C_BPartner_ID": 1234,
+							"C_Invoice": 333
+						}
+					*/
+					TypeReference<HashMap<String,Object>> typeRef = new TypeReference<HashMap<String,Object>>() {};
+					this.fillValues = new ArrayList<>();
+
+					Map<String, Object> keyValueFilters = fileMapper.readValue(filter, typeRef);
+					if (keyValueFilters != null && !keyValueFilters.isEmpty()) {
+						keyValueFilters.entrySet().forEach(entry -> {
+							Map<String, Object> condition = new HashMap<>();
+							condition.put(Filter.NAME, entry.getKey());
+							condition.put(Filter.OPERATOR, OperatorUtil.EQUAL);
+							Object value = entry.getValue();
+							if (value != null && value instanceof List) {
+								condition.put(Filter.OPERATOR, OperatorUtil.IN);
+							}
+							condition.put(Filter.VALUES, value);
+
+							this.fillValues.add(condition);
+						});
+					}
+				} catch (JsonProcessingException e2) {
+					throw new RuntimeException("Invalid filter");
+				}
 			}
 		}
 	}
@@ -67,10 +104,20 @@ public class FilterManager {
 	}
 
 	public static void main(String[] args) {
-		FilterManager.newInstance("[{\"name\":\"AD_Client_ID\", \"operator\":\"equal\", \"values\": 1000000}, {\"name\":\"AD_Org_ID\", \"operator\":\"in\", \"values\": [1000000, 11, 0]}]")
-		.getConditions().forEach(condition -> {
-			System.out.println(condition);
-		});
+		String completeFilter = "[{\"name\":\"AD_Client_ID\", \"operator\":\"equal\", \"values\": 1000000}, {\"name\":\"AD_Org_ID\", \"operator\":\"in\", \"values\": [1000000, 11, 0]}]";
+		FilterManager.newInstance(completeFilter)
+			.getConditions()
+			.forEach(condition -> {
+				System.out.println(condition);
+			})
+		;
+		String simplyFilter = "{\"AD_Client_ID\": 1000000, \"AD_Org_ID\": [1000000, 11, 0]}]";
+		FilterManager.newInstance(simplyFilter)
+			.getConditions()
+			.forEach(condition -> {
+				System.out.println(condition);
+			})
+		;
 	}
 
 }

--- a/src/main/java/org/spin/base/query/FilterManager.java
+++ b/src/main/java/org/spin/base/query/FilterManager.java
@@ -26,6 +26,7 @@ import org.spin.service.grpc.util.db.OperatorUtil;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+// import com.fasterxml.jackson.databind.JavaType;
 // import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -65,10 +66,11 @@ public class FilterManager {
 							"C_Invoice": 333
 						}
 					*/
-					TypeReference<HashMap<String,Object>> typeRef = new TypeReference<HashMap<String,Object>>() {};
+					TypeReference<HashMap<String,Object>> valueType = new TypeReference<HashMap<String,Object>>() {};
+					// JavaType valueType = fileMapper.getTypeFactory().constructMapLikeType(Map.class, String.class, Object.class);
 					this.fillValues = new ArrayList<>();
 
-					Map<String, Object> keyValueFilters = fileMapper.readValue(filter, typeRef);
+					Map<String, Object> keyValueFilters = fileMapper.readValue(filter, valueType);
 					if (keyValueFilters != null && !keyValueFilters.isEmpty()) {
 						keyValueFilters.entrySet().forEach(entry -> {
 							Map<String, Object> condition = new HashMap<>();


### PR DESCRIPTION
```bash
curl 'http://10.11.12.102/api/general-ledger/accounts/combinations?organization_id=12&account_id=50025&page_token=1&page_size=15&filters=%7B%22C_BPartner_ID%22:1000015%7D'   -H 'Accept: application/json, text/plain, */*'   -H 'Accept-Language: es-419,es;q=0.9,es-VE;q=0.8,en;q=0.7'   -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIyMDE4MzAwIiwiQURfQ2xpZW50X0lEIjoxMSwiQURfT3JnX0lEIjowLCJBRF9Sb2xlX0lEIjoxMDIsIkFEX1VzZXJfSUQiOjEwMSwiTV9XYXJlaG91c2VfSUQiOjAsIkFEX0xhbmd1YWdlIjoiZXNfTVgiLCJpYXQiOjE3MTM5MDExMjEsImV4cCI6MTcxMzk4NzUyMX0.q_gJ5Oloj_sTKNoMvyOdslhi9Q4YXI17SdFXmlDKTWM'   -H 'Connection: keep-alive'
```
The filter
```json
{
  "C_BPartner_ID": 1000015
}
```

Convert as
```json
[
  {
    "name": "C_BPartner_ID",
    "operator": "equal",
    "values": 1000015
  }
]
```



