### PR TITLE
fix: Context with `parallelStream`.

### DIFF
--- a/src/main/java/org/spin/base/interim/ContextTemporaryWorkaround.java
+++ b/src/main/java/org/spin/base/interim/ContextTemporaryWorkaround.java
@@ -64,7 +64,7 @@ public class ContextTemporaryWorkaround {
 			org.compiere.model.CalloutPayment.class.getName()
 		);
 
-		calloutsList.parallelStream().forEach(calloutClassAndMethod -> {
+		calloutsList.forEach(calloutClassAndMethod -> {
 			if (Util.isEmpty(calloutClassAndMethod, true)) {
 				// empty class name
 				return;

--- a/src/main/java/org/spin/base/util/ContextManager.java
+++ b/src/main/java/org/spin/base/util/ContextManager.java
@@ -167,7 +167,7 @@ public class ContextManager {
 		}
 
 		//	Fill context
-		attributes.entrySet().parallelStream()
+		attributes.entrySet()
 			.forEach(attribute -> {
 				setWindowContextByObject(context, windowNo, attribute.getKey(), attribute.getValue());
 			});

--- a/src/main/java/org/spin/grpc/service/Security.java
+++ b/src/main/java/org/spin/grpc/service/Security.java
@@ -371,7 +371,6 @@ public class Security extends SecurityImplBase {
 		ListRolesResponse.Builder builder = ListRolesResponse.newBuilder();
 		query.setLimit(limit, offset)
 			.<MRole>list()
-			.parallelStream()
 			.forEach(role -> {
 				builder.addRoles(
 					convertRole(role)
@@ -492,7 +491,6 @@ public class Security extends SecurityImplBase {
 		query.setLimit(limit, offset)
 			// .getIDsAsList() // do not use the list of identifiers because it cannot be instantiated zero (0)
 			.<MOrg>list()
-			.parallelStream()
 			.forEach(organization -> {
 				// MOrg.get static method not instance the organization in 0=* (asterisk)
 				// MOrg organization = MOrg.get(Env.getCtx(), organizationId);
@@ -643,7 +641,6 @@ public class Security extends SecurityImplBase {
 		query //.setLimit(limit, offset)
 			// .getIDsAsList() // do not use the list of identifiers because it cannot be instantiated zero (0)
 			.<MWarehouse>list()
-			.parallelStream()
 			.forEach(warehouse -> {
 				// MWarehouse.get static method not instance the warehouse in 0=* (asterisk)
 				// MWarehouse warehouse = MWarehouse.get(Env.getCtx(), warehouseId);
@@ -1037,7 +1034,8 @@ public class Security extends SecurityImplBase {
 			ValueManager.validateNull(ContextManager.getDefaultLanguage(Env.getAD_Language(Env.getCtx()))));
 		//	Set default context
 		Struct.Builder contextValues = Struct.newBuilder();
-		Env.getCtx().entrySet().parallelStream()
+		Env.getCtx().entrySet()
+			.stream()
 			.filter(keyValue -> {
 				return ContextManager.isSessionContext(
 					String.valueOf(

--- a/src/main/java/org/spin/grpc/service/core_functionality/CoreFunctionality.java
+++ b/src/main/java/org/spin/grpc/service/core_functionality/CoreFunctionality.java
@@ -214,7 +214,7 @@ public class CoreFunctionality extends CoreFunctionalityImplBase {
 	@Override
 	public void listLanguages(ListLanguagesRequest request, StreamObserver<ListLanguagesResponse> responseObserver) {
 		try {
-			ListLanguagesResponse.Builder languagesList = convertLanguagesList(request);
+			ListLanguagesResponse.Builder languagesList = listLanguages(request);
 			responseObserver.onNext(languagesList.build());
 			responseObserver.onCompleted();
 		} catch (Exception e) {
@@ -235,7 +235,7 @@ public class CoreFunctionality extends CoreFunctionalityImplBase {
 	 * @param request
 	 * @return
 	 */
-	private ListLanguagesResponse.Builder convertLanguagesList(ListLanguagesRequest request) {
+	private ListLanguagesResponse.Builder listLanguages(ListLanguagesRequest request) {
 		Query query = new Query(
 			Env.getCtx(),
 			I_AD_Language.Table_Name,
@@ -253,7 +253,6 @@ public class CoreFunctionality extends CoreFunctionalityImplBase {
 		;
 		query
 			.<MLanguage>list()
-			.parallelStream()
 			.forEach(language -> {
 				Language.Builder languaBuilder = convertLanguage(language);
 				builder.addLanguages(


### PR DESCRIPTION
when using parallel stream to handle multiple threads to traverse a list, the context is not set correctly generating data inconsistency.

![imagen](https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/94201b21-1989-4a3d-8dd3-fab8e72b2369)
