### PR TITLE
fix: `Smart Browse` cast boolean to string.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ dependencies {
 
 	// ADempiere Projects with additional features
 	//	ADempiere gRPC Utils Base (https://central.sonatype.com/artifact/io.github.adempiere/adempiere-grpc-utils)
-	implementation "${baseGroupId}:adempiere-grpc-utils:1.4.0"
+	implementation "${baseGroupId}:adempiere-grpc-utils:1.4.1"
 	// Dashboard Improvements (https://central.sonatype.com/artifact/io.github.adempiere/adempiere-dashboard-improvements)
 	implementation "${baseGroupId}:adempiere-dashboard-improvements:1.0.8"
 	// Point Of Sales Improvements (https://central.sonatype.com/artifact/io.github.adempiere/adempiere-pos-improvements)
@@ -100,7 +100,7 @@ dependencies {
 	// Business Processors (To Task's and Schedulers) (https://central.sonatype.com/artifact/io.github.adempiere/adempiere-business-processors)
 	implementation "${baseGroupId}:adempiere-business-processors:1.1.0"
 	// Engine as Queue (https://central.sonatype.com/artifact/io.github.adempiere/adempiere-kafka-connector)
-	implementation "${baseGroupId}:adempiere-kafka-connector:1.2.8"
+	implementation "${baseGroupId}:adempiere-kafka-connector:1.2.9"
 	// Third part access using JWT (https://central.sonatype.com/artifact/io.github.adempiere/adempiere-jwt-token)
 	implementation "${baseGroupId}:adempiere-jwt-token:1.0.2"
 	// https://mvnrepository.com/artifact/com.nimbusds/oauth2-oidc-sdk


### PR DESCRIPTION

```bash
curl 'http://192.168.3.53/api/user-interface/browser-items/50108?filters=[%7B%22name%22:%22CONTACT_IsActive%22,%22operator%22:%22equal%22,%22values%22:true%7D,%7B%22name%22:%22CONTACT_IsLoginUser%22,%22operator%22:%22equal%22,%22values%22:%22Y%22%7D]&context_attributes=%7B%7D&page_token=1&page_size=15' \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIxMDAwMTYwIiwiQURfQ2xpZW50X0lEIjoxMSwiQURfT3JnX0lEIjo1MDAwNiwiQURfUm9sZV9JRCI6MTAyLCJBRF9Vc2VyX0lEIjoxMDAsIk1fV2FyZWhvdXNlX0lEIjo1MDAwNiwiQURfTGFuZ3VhZ2UiOiJlbl9VUyIsImlhdCI6MTcxNzU1MjI3MiwiZXhwIjoxNzE3NjM4NjcyfQ.o9mFygoEQgusNi4flFlRhSNH0sZbFgDvOTso-XjGqps'
```

```json
{
 "code": 13,
 "message": "class java.lang.Boolean cannot be cast to class java.lang.String (java.lang.Boolean and java.lang.String are in module java.base of loader 'bootstrap')",
 "details": []
}
```

```log
===========> UserInterface.listBrowserItems: class java.lang.Boolean cannot be cast to class java.lang.String (java.lang.Boolean and java.lang.String are in module java.base of loader 'bootstrap') [20]
java.lang.ClassCastException: class java.lang.Boolean cannot be cast to class java.lang.String (java.lang.Boolean and java.lang.String are in module java.base of loader 'bootstrap')
        at org.spin.service.grpc.util.db.ParameterUtil.getValueToFilterRestriction(ParameterUtil.java:222)
        at org.spin.base.db.WhereClauseUtil.getRestrictionByOperator(WhereClauseUtil.java:329)
        at org.spin.base.db.WhereClauseUtil.lambda$9(WhereClauseUtil.java:820)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
        at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)
        at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
        at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497)
        at org.spin.base.db.WhereClauseUtil.getBrowserWhereClauseFromCriteria(WhereClauseUtil.java:800)
        at org.spin.grpc.service.UserInterface.listBrowserItems(UserInterface.java:2474)
        at org.spin.grpc.service.UserInterface.listBrowserItems(UserInterface.java:2401)
        at org.spin.backend.grpc.user_interface.UserInterfaceGrpc$MethodHandlers.invoke(UserInterfaceGrpc.java:2052)
        at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
        at io.grpc.Contexts$ContextualizedServerCallListener.onHalfClose(Contexts.java:86)
        at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:356)
        at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:861)
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
```



#### Additional context
fixes https://github.com/solop-develop/adempiere-grpc-server/issues/520