### PR TITLE
fix: Smart Browse process all records context no query criteria arguments.

### DIFF
--- a/src/main/java/org/spin/grpc/service/ui/BrowserLogic.java
+++ b/src/main/java/org/spin/grpc/service/ui/BrowserLogic.java
@@ -249,7 +249,7 @@ public class BrowserLogic {
 	}
 
 
-	public static List<KeyValueSelection> getAllSelectionByCriteria(int browserId, String criteriaFilters, String contextAttributes) {
+	public static List<KeyValueSelection> getAllSelectionByCriteria(int browserId, String contextAttributes, String criteriaFilters) {
 		List<KeyValueSelection> selectionsList = new ArrayList<KeyValueSelection>();
 
 		Properties context = Env.getCtx();


### PR DESCRIPTION

![imagen](https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/155f20fa-49ef-4718-8297-3b53e8427693)


![imagen](https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/7de19c4d-146c-4697-96d0-64befc4a5a95)


#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/1880