### PR TITLE
fix: Smart Browse `Order By` lookups by display columns.

### DIFF
--- a/src/main/java/org/spin/base/db/OrderByUtil.java
+++ b/src/main/java/org/spin/base/db/OrderByUtil.java
@@ -18,11 +18,16 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.adempiere.core.domains.models.I_AD_Element;
+import org.adempiere.model.MBrowse;
+import org.adempiere.model.MBrowseField;
+import org.adempiere.model.MViewColumn;
 import org.compiere.model.MColumn;
 import org.compiere.model.MField;
 import org.compiere.model.MTab;
 import org.compiere.util.Env;
 import org.compiere.util.Util;
+import org.spin.base.util.LookupUtil;
+import org.spin.base.util.ReferenceUtil;
 import org.spin.dictionary.util.WindowUtil;
 
 /**
@@ -114,6 +119,37 @@ public class OrderByUtil {
 		};
 
 		return orderBys;
+	}
+
+
+	/**
+	 * Get Order By
+	 * @param browser
+	 * @return
+	 */
+	public static String getBrowseOrderBy(MBrowse browser) {
+		StringBuilder sqlOrderBy = new StringBuilder();
+		List<MBrowseField> browseFieldsList = browser.getOrderByFields();
+		for (MBrowseField field : browseFieldsList) {
+			if (sqlOrderBy.length() > 0) {
+				sqlOrderBy.append(", ");
+			}
+
+			MViewColumn viewColumn = MViewColumn.getById(browser.getCtx(), field.getAD_View_Column_ID(), null);
+			String sortColumn = viewColumn.getColumnSQL();
+			if (ReferenceUtil.validateReference(field.getAD_Reference_ID())) {
+				final String displayColumnName = LookupUtil.getDisplayColumnName(
+					viewColumn.getColumnName()
+				);
+				sortColumn = "\"" + displayColumnName + "\"";
+				// if (DB.isPostgreSQL()) {
+				// 	// sort null columns on top rows
+				// 	sortColumn += " NULLS FIRST ";
+				// }
+			}
+			sqlOrderBy.append(sortColumn);
+		}
+		return sqlOrderBy.length() > 0 ? sqlOrderBy.toString(): "";
 	}
 
 }

--- a/src/main/java/org/spin/base/util/LookupUtil.java
+++ b/src/main/java/org/spin/base/util/LookupUtil.java
@@ -157,4 +157,23 @@ public class LookupUtil {
 		return builder;
 	}
 
+
+	/**
+	 * Get display column name
+	 * @param columnName
+	 * @return example DisplayColumn_AD_Client_ID
+	 */
+	public static String getDisplayColumnName(String columnName) {
+		return LookupUtil.DISPLAY_COLUMN_KEY + "_" + columnName;
+	}
+
+	/**
+	 * Get uuid column name
+	 * @param columnName
+	 * @return example AD_Client_ID_UUID
+	 */
+	public static String getUuidColumnName(String columnName) {
+		return columnName + "_" + LookupUtil.UUID_COLUMN_KEY;
+	}
+
 }

--- a/src/main/java/org/spin/grpc/service/UserInterface.java
+++ b/src/main/java/org/spin/grpc/service/UserInterface.java
@@ -2503,7 +2503,7 @@ public class UserInterface extends UserInterfaceImplBase {
 			sqlWithRoleAccess += whereClause;
 		}
 
-		String orderByClause = org.spin.service.grpc.util.db.OrderByUtil.getBrowseOrderBy(browser);
+		String orderByClause = OrderByUtil.getBrowseOrderBy(browser);
 		if (!Util.isEmpty(orderByClause, true)) {
 			orderByClause = " ORDER BY " + orderByClause;
 		}


### PR DESCRIPTION
When adding a lookup type field it sorts by the value of the Identifier, now it sorts by the display value

#### After this changes
![imagen](https://github.com/user-attachments/assets/ed68e9fe-16ac-4464-80b4-b3e4d4a27e9e)

This is the generated sorting sql
```sql
ORDER BY p.C_SalesRegion_ID, p.C_BPartner_ID, p.C_ProjectCategory_ID
```


#### Before this changes
![imagen](https://github.com/user-attachments/assets/49cfe186-4f96-4f06-98b8-15cd9b1e5092)

This is the generated sorting sql:
```sql
ORDER BY "DisplayColumn_P_C_SalesRegion_ID", "DisplayColumn_P_C_BPartner_ID", "DisplayColumn_P_C_ProjectCategory_ID"
```


#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/2379