### PR TITLE
fix: Downgrade `adempiere-kafka-connector` to 1.3.0 version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     compileOnly 'org.apache.tomcat:annotations-api:6.0.53'
 
 	//	ADempiere Core + Patches + Features
-	implementation "com.solop:adempiere.solop_libs:3.9.4.001-1.0.5"
+	implementation "com.solop:adempiere.solop_libs:3.9.4.001-1.0.6"
 }
 
 configurations.all {


### PR DESCRIPTION
The version of `adempiere-kafka-connector` is downgraded until the multi-tenant dictionary is stabilized.