### PR TITLE
Error in DefaultValue with Special Values

### DIFF
--- a/src/main/java/org/spin/grpc/service/field/field_management/FieldManagementLogic.java
+++ b/src/main/java/org/spin/grpc/service/field/field_management/FieldManagementLogic.java
@@ -228,9 +228,7 @@ public class FieldManagementLogic {
 		if (Optional.ofNullable(request.getValue()).isPresent()
 			&& !Util.isEmpty(request.getValue().getStringValue())) {
 			// URL decode to change characteres
-			final String overwriteValue = ValueManager.getDecodeUrl(
-				request.getValue().getStringValue()
-			);
+			final String overwriteValue = request.getValue().getStringValue();
 			defaultValue = overwriteValue;
 		}
 


### PR DESCRIPTION
### Possible solution
As the request is a `GET` the `value` parameter of the default path is already `encodeURI` so this step is in addition to `ValueManager.getDecodeUrl()`.

### GIf

https://github.com/user-attachments/assets/168d1c1e-fb51-4a62-8dcb-42ab9d9439f7


### Nota

The problem lies in the fact that the `+` character has a special meaning in URL encoding. When you URL decode a string, the `+` character is replaced with a space (` `) character. This is because, in URL encoding, the `+` character is used to represent a space.


### CURL

```
curl 'http://spdev01.solopapp.com:24610/api/fields/default-value/field/3482?value=V%2B' \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Accept-Language: es-419,es;q=0.9,es-VE;q=0.8,en;q=0.7' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIyMDIzMDk2IiwiQURfQ2xpZW50X0lEIjoxMDAwMDAxLCJBRF9PcmdfSUQiOjEwMDAwMDMsIkFEX1JvbGVfSUQiOjEwMDAwMDIsIkFEX1VzZXJfSUQiOjEwMDEyMTIsIk1fV2FyZWhvdXNlX0lEIjoxMDAwMDQ1LCJBRF9MYW5ndWFnZSI6ImVzX01YIiwiaWF0IjoxNzI1OTc2NjI0LCJleHAiOjE3MjYwNjMwMjR9._R-cwwlViLljARy-vhrK6lyKl-oDQKkhv9lGiaRtOfU' \
  -H 'Connection: keep-alive' \
  -H 'Referer: http://spdev01.solopapp.com:24610/vue' \
  -H 'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36' \
  --insecure
  ```

#### Additional attributes
fixes

