### PR TITLE
fix: Filter status category issue form.

### DIFF
--- a/src/main/java/org/spin/grpc/service/form/issue_management/IssueManagementServiceLogic.java
+++ b/src/main/java/org/spin/grpc/service/form/issue_management/IssueManagementServiceLogic.java
@@ -763,7 +763,7 @@ public class IssueManagementServiceLogic {
 			whereClause += " AND EXISTS("
 				+ "SELECT 1 FROM R_Status AS sc "
 				+ "WHERE sc.R_StatusCategory_ID = ? "
-				+ "AND R_Request.R_StatusCategory_ID = sc.R_StatusCategory_ID"
+				+ "AND R_Request.R_Status_ID = sc.R_Status_ID"
 				+ ")"
 			;
 			parametersList.add(request.getStatusCategoryId());


### PR DESCRIPTION

```log
Uncaught (in promise) Error: org.postgresql.util.PSQLException: ERROR: column r_request.r_statuscategory_id does not exist
  Position: 269, SQL=SELECT COUNT(*) FROM R_Request WHERE (Processed='N' AND (SalesRep_ID=? OR AD_Role_ID = ?) AND (R_Status_ID IS NULL OR R_Status_ID IN (SELECT R_Status_ID FROM R_Status WHERE IsClosed='N')) AND EXISTS(SELECT 1 FROM R_Status AS sc WHERE sc.R_StatusCategory_ID = ? AND R_Request.R_StatusCategory_ID = sc.R_StatusCategory_ID)) AND IsActive=? AND R_Request.AD_Client_ID IN(0,1000001) AND R_Request.AD_Org_ID IN(0,1000003,1000004,1000005,1000006,1000010,1000001,1000002,1000007,1000008,1000009) AND (R_Request.R_Request_ID IS NULL OR R_Request.R_Request_ID NOT IN ( SELECT Record_ID FROM AD_Private_Access WHERE AD_Table_ID = 417 AND AD_User_ID <> 1001212 AND IsActive = 'Y' ))
 ```