### PR TITLE
fix: `IsActive` restriction with default value.

### DIFF
--- a/src/main/java/org/spin/base/db/WhereClauseUtil.java
+++ b/src/main/java/org/spin/base/db/WhereClauseUtil.java
@@ -163,7 +163,8 @@ public class WhereClauseUtil {
 	 * @return {String}
 	 */
 	public static String removeIsActiveRestriction(String tableAlias, String sql) {
-		String SQL_WHERE_REGEX = "(WHERE|(AND|OR))(\\s+(" + tableAlias + ".IsActive|IsActive)\\s*=\\s*'(Y|N)')";
+		// String SQL_WHERE_REGEX = "(WHERE|(AND|OR))(\\s+(" + tableAlias + ".IsActive|IsActive)\\s*=\\s*'(Y|N)')";
+		String SQL_WHERE_REGEX = "(" + tableAlias + ".IsActive|IsActive)\\s*=\\s*'(Y|N)'";
 
 		String sqlWithoutRestriction = sql;
 		// remove order by clause
@@ -178,7 +179,7 @@ public class WhereClauseUtil {
 			String initialPart = sql.substring(0, startPosition);
 			int endPosition = matcherWhere.end();
 			String finalPart = sql.substring(endPosition, sql.length());
-			sqlWithoutRestriction = initialPart + finalPart;
+			sqlWithoutRestriction = initialPart + " 1=1 " + finalPart;
 		}
 
 		return sqlWithoutRestriction;


### PR DESCRIPTION
### Request

```bash
curl 'http://0.0.0.0/api/fields/default-value/field/1004288?value=1000328' -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:131.0) Gecko/20100101 Firefox/131.0' -H 'Accept: application/json, text/plain, */*' -H 'Accept-Language: es-MX,es;q=0.8,en-US;q=0.5,en;q=0.3' -H 'Accept-Encoding: gzip, deflate' -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIyMDE2MDczIiwiQURfQ2xpZW50X0lEIjoxMDAwMDAxLCJBRF9PcmdfSUQiOjAsIkFEX1JvbGVfSUQiOjEwMDAwMDIsIkFEX1VzZXJfSUQiOjEwMDAwNjUsIk1fV2FyZWhvdXNlX0lEIjowLCJBRF9MYW5ndWFnZSI6ImVuX1VTIiwiaWF0IjoxNzI5MDQxMjM4LCJleHAiOjE3MjkxMjc2Mzh9.RGqB-XbCVTkUSBjXm-YW_Y0eAZriLNyd8Za9PH_c1N4' -H 'Origin: http://0.0.0.0:9527' -H 'Connection: keep-alive' -H 'Referer: http://0.0.0.0:9527/' -H 'Priority: u=0'
```

### Response
```json
{
 "code": 13,
 "message": "org.postgresql.util.PSQLException: ERROR: syntax error at or near \"AND\"\n  Position: 146",
 "details": []
}
```

### After this changes
Convert this sql
```sql
SELECT
	C_ElementValue.C_ElementValue_ID,NULL,
	COALESCE(C_ElementValue.Name,'-1'),
	C_ElementValue.IsActive, C_ElementValue.UUID

FROM C_ElementValue 

WHERE
	C_ElementValue.IsActive='Y'
	AND C_ElementValue.IsSummary='N' 
	AND C_ElementValue.C_Element_ID IN (
		SELECT C_Element_ID
		FROM C_AcctSchema_Element ase
		WHERE ase.ElementType='U4'
		AND ase.AD_Client_ID=1000001
	)
	AND C_ElementValue.C_ElementValue_ID=1000328
```

To sql
```sql
SELECT
	C_ElementValue.C_ElementValue_ID,NULL,
	COALESCE(C_ElementValue.Name,'-1'),
	C_ElementValue.IsActive, C_ElementValue.UUID

FROM C_ElementValue 

WHERE
	AND C_ElementValue.IsSummary='N' 
	AND C_ElementValue.C_Element_ID IN (
		SELECT C_Element_ID
		FROM C_AcctSchema_Element ase
		WHERE ase.ElementType='U4'
		AND ase.AD_Client_ID=1000001
	)
	AND C_ElementValue.C_ElementValue_ID=1000328
```

### Before this changes

```sql
SELECT
	C_ElementValue.C_ElementValue_ID,NULL,
	COALESCE(C_ElementValue.Name,'-1'),
	C_ElementValue.IsActive, C_ElementValue.UUID

FROM C_ElementValue 

WHERE
	1=1
	AND C_ElementValue.IsSummary='N' 
	AND C_ElementValue.C_Element_ID IN (
		SELECT C_Element_ID
		FROM C_AcctSchema_Element ase
		WHERE ase.ElementType='U4'
		AND ase.AD_Client_ID=1000001
	)
	AND C_ElementValue.C_ElementValue_ID=1000328
```

### Additional context
ref https://github.com/solop-develop/frontend-core/issues/2731


