### PR TITLE
fix: Send email with `userId` without account name.

### DIFF
--- a/src/main/java/org/spin/grpc/service/SendNotifications.java
+++ b/src/main/java/org/spin/grpc/service/SendNotifications.java
@@ -278,9 +278,23 @@ public class SendNotifications extends SendNotificationsImplBase{
 
 		// Add Recipient to Notification
 		request.getRecipientsList().forEach(recipients -> {
+			int contactId = -1;
+			String accountName = null;
+			if (recipients.getContactId() > 0) {
+				MUser user = MUser.get(Env.getCtx(), recipients.getContactId());
+				if (user != null) {
+					contactId = user.getAD_User_ID();
+					if (!Util.isEmpty(user.getEMail(), true)) {
+						accountName = user.getEMail();
+					}
+				}
+			}
+			if (Util.isEmpty(accountName, true)) {
+				accountName = recipients.getAccountName();
+			}
 			notifier.addRecipient(
-				recipients.getContactId(),
-				recipients.getAccountName()
+				contactId,
+				accountName
 			);
 		});
 


### PR DESCRIPTION

![imagen](https://github.com/user-attachments/assets/06e596c2-a292-4ce5-8614-2dac3f4344df)

the account name is not the user's email address.

```
NOT VALID - EMail[From:solop.notificaciones@gmail.com,To:null,Subject=Order Print]
```

ref https://github.com/solop-develop/frontend-core/issues/1198