### PR TITLE
feat: Update adempiere-solop libs to `3.9.4.001-spuy-0.0.4`.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 org.gradle.jvmargs=-Xmx4096M
 # systemProp.deploy.patchLibrary = com.solop:adempiere.solop_libs:3.9.4.001-1.3.0
-systemProp.deploy.patchLibrary = com.solop:adempiere.solop_libs:3.9.4.001-spuy-0.0.3
+systemProp.deploy.patchLibrary = com.solop:adempiere.solop_libs:3.9.4.001-spuy-0.0.4


### PR DESCRIPTION
Add support to import `Imports`

#### Additinal context
ref https://github.com/solop-develop/adempiere-solop/issues/66
closes https://github.com/solop-develop/adempiere-grpc-server/pull/963