### PR TITLE
fix: Infinity loop when `Node_ID` equal `0`.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 org.gradle.jvmargs=-Xmx4096M
 # systemProp.deploy.patchLibrary = com.solop:adempiere.solop_libs:3.9.4.001-1.3.0
-systemProp.deploy.patchLibrary = com.solop:adempiere.solop_libs:base-0.0.3-spuy-0.0.7
+systemProp.deploy.patchLibrary = com.solop:adempiere.solop_libs:base-0.0.4-spuy-0.0.1


### PR DESCRIPTION
![imagen](https://github.com/user-attachments/assets/2660ecb7-607c-4959-81a9-20177bbbd0b1)

```sql
SELECT tn.Node_ID, tn.SeqNo FROM AD_TreeNodeMM tn
WHERE tn.AD_Tree_ID = 1000035 AND COALESCE(tn.Parent_ID, 0) = 0
```


```sql
SELECT tn.Node_ID, tn.SeqNo FROM AD_TreeNodeMM tn
WHERE tn.Node_ID > 0 AND tn.AD_Tree_ID = 1000035 AND COALESCE(tn.Parent_ID, 0) = 0
```

#### Additional context
ref https://github.com/solop-develop/adempiere-solop/issues/147