### PR TITLE
fix: Display Definition Isert/Edit field attributes.

### DIFF
--- a/src/main/java/org/spin/grpc/service/display_definition/DisplayDefinitionConvertUtil.java
+++ b/src/main/java/org/spin/grpc/service/display_definition/DisplayDefinitionConvertUtil.java
@@ -18,6 +18,7 @@ import org.adempiere.core.domains.models.I_AD_Column;
 import org.adempiere.core.domains.models.I_AD_Element;
 import org.adempiere.core.domains.models.I_AD_Field;
 import org.adempiere.core.domains.models.I_AD_FieldGroup;
+import org.adempiere.core.domains.models.I_AD_Tab;
 import org.adempiere.core.domains.models.I_AD_Table;
 import org.adempiere.core.domains.models.X_AD_FieldGroup;
 import org.compiere.model.MColumn;
@@ -386,6 +387,16 @@ public class DisplayDefinitionConvertUtil {
 			.setIsDisplayedGrid(
 				fieldDefinitionItem.get_ValueAsBoolean(
 					I_AD_Column.COLUMNNAME_SeqNo
+				)
+			)
+			.setIsInsertRecord(
+				fieldDefinitionItem.get_ValueAsBoolean(
+					I_AD_Tab.COLUMNNAME_IsInsertRecord
+				)
+			)
+			.setIsUpdateRecord(
+				fieldDefinitionItem.get_ValueAsBoolean(
+					"SP010_IsUpdateRecord"
 				)
 			)
 		;

--- a/src/main/java/org/spin/grpc/service/display_definition/DisplayDefinitionServiceLogic.java
+++ b/src/main/java/org/spin/grpc/service/display_definition/DisplayDefinitionServiceLogic.java
@@ -200,6 +200,10 @@ public class DisplayDefinitionServiceLogic {
 			throw new AdempiereException("@FillMandatory@ @SP010_DisplayDefinition_ID@");
 		}
 
+		MTable table =RecordUtil.validateAndGetTable(
+			"SP010_Field"
+		);
+
 		PO displayDefinition = new Query(
 			Env.getCtx(),
 			Changes.SP010_DisplayDefinition,
@@ -228,8 +232,9 @@ public class DisplayDefinitionServiceLogic {
 				query.count()
 			)
 		;
-		query.list()
-			.forEach(field -> {
+		query.getIDsAsList()
+			.forEach(fieldId -> {
+				PO field = table.getPO(fieldId, null);
 				FieldDefinition.Builder fieldBuilder = DisplayDefinitionConvertUtil.convertFieldDefinition(field);
 				builderList.addFieldDefinitions2(
 					fieldBuilder.build()


### PR DESCRIPTION
### Request

```bash
curl --location --request GET 'http://0.0.0.0/api/display-definition/definitions/1000006/fields' \
--header 'User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:134.0) Gecko/20100101 Firefox/134.0' \
--header 'Accept: application/json, text/plain, */*' \
--header 'Accept-Language: es-MX,es;q=0.8,en-US;q=0.5,en;q=0.3' \
--header 'Accept-Encoding: gzip, deflate, br, zstd' \
--header 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIzMDA5NDYxIiwiQURfQ2xpZW50X0lEIjoxMDAwMDAxLCJBRF9PcmdfSUQiOjEwMDAwMDMsIkFEX1JvbGVfSUQiOjEwMDAwMTcsIkFEX1VzZXJfSUQiOjEwMDEyMTIsIk1fV2FyZWhvdXNlX0lEIjoxMDAwMDQ1LCJBRF9MYW5ndWFnZSI6ImVzX01YIiwiaWF0IjoxNzM3NzQ1OTQ3LCJleHAiOjE3Mzc4MzIzNDd9.TjIP2SLgDAPkWejctYrXDykiZiOtxV_-mpzSLwLTaSM' \
--header 'Connection: keep-alive' \
--header 'Referer: https://patches.dev.solopcloud.com/vue' \
--header 'Sec-Fetch-Dest: empty' \
--header 'Sec-Fetch-Mode: cors' \
--header 'Sec-Fetch-Site: same-origin' \
--header 'Sec-GPC: 1' \
--header 'TE: trailers'
```

### Response
```json
{
    "field_definitions_count": "1",
    "field_definitions": [
        {
            "id": "fbd99dcf-09ea-4255-8a21-86ad77bc474a",
            "uuid": "fbd99dcf-09ea-4255-8a21-86ad77bc474a",
            "internal_id": 1000000,
            "display_definition_id": 1000006,
            "column_name": "DocumentNo",
            "name": "Document No",
            "description": "Document sequence number of the document",
            "help": "The document number is usually automatically generated by the system and determined by the document type of the document. If the document is not saved, the preliminary number is displayed in \"<>\".\n\nIf the document type of your document has no automatic document sequence defined, the field is empty if you create a new document. This is for documents which usually have an external number (like vendor invoice).  If you leave the field empty, the system will generate a document number for you. The document sequence used for this fallback number is defined in the \"Maintain Sequence\" window with the name \"DocumentNo_<TableName>\", where TableName is the actual name of the table (e.g. C_Order).",
            "display_type": 0,
            "sequence": 0,
            "is_displayed": true,
            "display_logic": "",
            "is_read_only": false,
            "is_mandatory": false,
            "default_value": "",
            "is_displayed_grid": false,
            "is_heading": false,
            "is_field_only": false,
            "is_encrypted": false,
            "is_quick_entry": false,
            "sort_no": 0,
            "is_insert_record": true,
            "is_update_record": true,
            "seq_no_grid": 10
        }
    ]
}
```

![imagen](https://github.com/user-attachments/assets/ff460478-9f3e-4dc2-b0cc-b34aa67964b2)
