### PR TITLE
feat: Add additional fields on display definition.

### DIFF
--- a/src/main/java/org/spin/grpc/service/display_definition/DisplayDefinitionServiceLogic.java
+++ b/src/main/java/org/spin/grpc/service/display_definition/DisplayDefinitionServiceLogic.java
@@ -83,6 +83,7 @@ import com.google.protobuf.Empty;
 import com.google.protobuf.Value;
 import com.solop.sp010.controller.DisplayBuilder;
 import com.solop.sp010.data.calendar.CalendarData;
+import com.solop.sp010.data.generic.GenericItem;
 import com.solop.sp010.data.kanban.KanbanData;
 import com.solop.sp010.data.resource.ResourceData;
 import com.solop.sp010.data.resource.ResourceItem;
@@ -717,9 +718,16 @@ public class DisplayDefinitionServiceLogic {
 		//	Save entity
 		currentEntity.saveEx();
 
+		GenericItem recordItem = (GenericItem) DisplayBuilder.newInstance(
+				displayDefinition.get_ID()
+			)
+			.run(
+				currentEntity.get_ID()
+			)
+		;
 		DataEntry.Builder builder = DisplayDefinitionConvertUtil.convertDataEntry(
 			displayDefinition,
-			currentEntity
+			recordItem
 		);
 
 		return builder;
@@ -743,9 +751,16 @@ public class DisplayDefinitionServiceLogic {
 			throw new AdempiereException("@Record_ID@ @NotFound@");
 		}
 
+		GenericItem recordItem = (GenericItem) DisplayBuilder.newInstance(
+				displayDefinition.get_ID()
+			)
+			.run(
+				entity.get_ID()
+			)
+		;
 		DataEntry.Builder builder = DisplayDefinitionConvertUtil.convertDataEntry(
 			displayDefinition,
-			entity
+			recordItem
 		);
 
 		return builder;
@@ -803,9 +818,16 @@ public class DisplayDefinitionServiceLogic {
 		//	Save entity
 		currentEntity.saveEx();
 
+		GenericItem recordItem = (GenericItem) DisplayBuilder.newInstance(
+				displayDefinition.get_ID()
+			)
+			.run(
+				currentEntity.get_ID()
+			)
+		;
 		DataEntry.Builder builder = DisplayDefinitionConvertUtil.convertDataEntry(
 			displayDefinition,
-			currentEntity
+			recordItem
 		);
 
 		return builder;


### PR DESCRIPTION

#### Request
```curl
curl --location --request GET 'http://192.168.5.102/api/display-definition/1000027/entries/1000307' \
--header 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIzMDEwMzM4IiwiQURfQ2xpZW50X0lEIjoxMDAwMDAxLCJBRF9PcmdfSUQiOjAsIkFEX1JvbGVfSUQiOjEwMDAwMDIsIkFEX1VzZXJfSUQiOjEwMDEyMTIsIk1fV2FyZWhvdXNlX0lEIjowLCJBRF9MYW5ndWFnZSI6ImVzX01YIiwiaWF0IjoxNzM4MDgwMjQ0LCJleHAiOjE3MzgxNjY2NDR9.kzapmliqMNx3Qa6XgCYPS4Mg_HNwdNCs-qrvRMPl9sM'
```

#### Response
```json
{
    "id": 1000307,
    "uuid": "21d8cf86-9f79-11ea-9e44-c6ad1fcc20e4",
    "title": "Prueba Medios",
    "description": "",
    "is_active": true,
    "is_read_only": false,
    "fields": {
        "IsApproved": {
            "value": false,
            "display_value": "No"
        },
        "Value": {
            "value": "1204b",
            "display_value": null
        },
        "PlannedQty": {
            "value": {
                "type": "decimal",
                "value": "100.00"
            },
            "display_value": "100"
        },
        "Note": {
            "value": null,
            "display_value": null
        },
        "DueType": {
            "value": null,
            "display_value": null
        },
        "PlannedAmt": {
            "value": {
                "type": "decimal",
                "value": "40000.000"
            },
            "display_value": "40,000.00"
        },
        "DateStart": {
            "value": {
                "type": "date",
                "value": "2020-05-26 14:33:34"
            },
            "display_value": "26/05/2020"
        },
        "C_BPartner_ID": {
            "value": 1000058,
            "display_value": "Toyota S.A."
        }
    }
}
```

#### Additional context
fixes https://github.com/solop-develop/adempiere-solop/issues/185
