### PR TITLE
fix: Display definition delete entity.

### DIFF
--- a/src/main/java/org/spin/grpc/service/display_definition/DisplayDefinitionServiceLogic.java
+++ b/src/main/java/org/spin/grpc/service/display_definition/DisplayDefinitionServiceLogic.java
@@ -850,7 +850,7 @@ public class DisplayDefinitionServiceLogic {
 		if (entity == null || entity.get_ID() <= 0) {
 			throw new AdempiereException("@Record_ID@ @NotFound@");
 		}
-		entity.saveEx();
+		entity.deleteEx(false);
 
 		return Empty.newBuilder();
 	}


### PR DESCRIPTION
### Request
```bash
curl --location --request DELETE 'http://0.0.0.0/api/display-definition/1000008/entries/1001005' \
--header 'accept: application/json, text/plain, */*' \
--header 'accept-language: es-419,es;q=0.9' \
--header 'authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIzMDEwMzQ4IiwiQURfQ2xpZW50X0lEIjoxMDAwMDAxLCJBRF9PcmdfSUQiOjEwMDAwMTAsIkFEX1JvbGVfSUQiOjEwMDAwMDIsIkFEX1VzZXJfSUQiOjEwMDEyMTIsIk1fV2FyZWhvdXNlX0lEIjoxMDAwMDgwLCJBRF9MYW5ndWFnZSI6ImVzX01YIiwiaWF0IjoxNzM4MTg0Mjk4LCJleHAiOjE3MzgyNzA2OTh9.GpAeLMCguldPeYbt683yizpBsoiqztrZuQJKICOheB0' \
--header 'origin: http://localhost:9527' \
--header 'priority: u=1, i' \
--header 'referer: http://localhost:9527/' \
--header 'sec-ch-ua: "Google Chrome";v="131", "Chromium";v="131", "Not_A Brand";v="24"' \
--header 'sec-ch-ua-mobile: ?0' \
--header 'sec-ch-ua-platform: "Linux"' \
--header 'sec-fetch-dest: empty' \
--header 'sec-fetch-mode: cors' \
--header 'sec-fetch-site: cross-site' \
--header 'user-agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
```


### First Response
```json
{}
```

### Second Responde
```json
{
    "code": 13,
    "message": "ID de Registro * No encontrado *",
    "details": []
}
```
