### PR TITLE
fix: NPE on field definition without read only logic.

### DIFF
--- a/src/main/java/org/spin/grpc/service/display_definition/DisplayDefinitionConvertUtil.java
+++ b/src/main/java/org/spin/grpc/service/display_definition/DisplayDefinitionConvertUtil.java
@@ -893,13 +893,17 @@ public class DisplayDefinitionConvertUtil {
 			)
 			.setIsDisplayed(true)
 			.setReadOnlyLogic(
-				column.getReadOnlyLogic()
+				StringManager.getValidString(
+					column.getReadOnlyLogic()
+				)
 			)
 			.setIsMandatory(
 				column.isMandatory()
 			)
 			.setMandatoryLogic(
-				column.getMandatoryLogic()
+				StringManager.getValidString(
+					column.getMandatoryLogic()
+				)
 			)
 			.setDefaultValue(
 				StringManager.getValidString(
@@ -915,6 +919,28 @@ public class DisplayDefinitionConvertUtil {
 			.setIsInsertRecord(true)
 			.setIsUpdateRecord(true)
 		;
+
+		// overwrite display type `Button` to `List`, example `PaymentRule` or `Posted`
+		int displayTypeId = ReferenceUtil.overwriteDisplayType(
+			column.getAD_Reference_ID(),
+			column.getAD_Reference_Value_ID()
+		);
+		if (ReferenceUtil.validateReference(displayTypeId)) {
+			MLookupInfo info = ReferenceUtil.getReferenceLookupInfo(
+				displayTypeId, column.getAD_Reference_Value_ID(), column.getColumnName(), column.getAD_Val_Rule_ID()
+			);
+			if (info != null) {
+				Reference.Builder referenceBuilder = convertReference(column.getCtx(), info);
+				builder.setReference(referenceBuilder.build());
+			} else {
+				builder.setDisplayType(DisplayType.String);
+			}
+		} else if (DisplayType.Button == displayTypeId) {
+			if (column.getColumnName().equals(I_AD_ChangeLog.COLUMNNAME_Record_ID)) {
+				// To load default value
+				builder.addContextColumnNames(I_AD_Table.COLUMNNAME_AD_Table_ID);
+			}
+		}
 
 		return builder;
 	}


### PR DESCRIPTION
```log
===========> DisplayDefinition.listDisplayDefinitionsMetadata: null [25]
java.lang.NullPointerException
        at org.spin.backend.grpc.display_definition.FieldDefinition$Builder.setReadOnlyLogic(FieldDefinition.java:2762)
        at org.spin.grpc.service.display_definition.DisplayDefinitionConvertUtil.convertFieldDefinitionByColumn(DisplayDefinitionConvertUtil.java:895)
        at org.spin.grpc.service.display_definition.DisplayDefinitionConvertUtil.convertDefinitionMetadata(DisplayDefinitionConvertUtil.java:301)
        at org.spin.grpc.service.display_definition.DisplayDefinitionServiceLogic.lambda$0(DisplayDefinitionServiceLogic.java:247)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
        at org.spin.grpc.service.display_definition.DisplayDefinitionServiceLogic.listDisplayDefinitionsMetadata(DisplayDefinitionServiceLogic.java:238)
        at org.spin.grpc.service.display_definition.DisplayDefinition.listDisplayDefinitionsMetadata(DisplayDefinition.java:87)
        at org.spin.backend.grpc.display_definition.DisplayDefinitionGrpc$MethodHandlers.invoke(DisplayDefinitionGrpc.java:1722)
        at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
        at io.grpc.Contexts$ContextualizedServerCallListener.onHalfClose(Contexts.java:86)
        at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:356)
        at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:861)
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
```