### PR TITLE
fix: NPE when field is null.

### DIFF
--- a/src/main/java/org/spin/base/db/QueryUtil.java
+++ b/src/main/java/org/spin/base/db/QueryUtil.java
@@ -70,6 +70,9 @@ public class QueryUtil {
 		final Language language = Language.getLanguage(Env.getAD_Language(table.getCtx()));
 		final List<MColumn> columnsList = table.getColumnsAsList();
 		for (MColumn column : columnsList) {
+			if (column == null) {
+				continue;
+			}
 			if (!column.isActive()) {
 				// key column on table
 				if (!column.isKey()) {
@@ -169,6 +172,9 @@ public class QueryUtil {
 		final Language language = Language.getLanguage(Env.getAD_Language(context));
 		final MField[] fieldsList = tab.getFields(false, null);
 		for (MField field : fieldsList) {
+			if (field == null) {
+				continue;
+			}
 			MColumn column = MColumn.get(context, field.getAD_Column_ID());
 			if (!column.isActive() || !field.isActive() || !field.isDisplayed()) {
 				// key column on table
@@ -257,6 +263,9 @@ public class QueryUtil {
 		AtomicBoolean isAddFirstColumn = new AtomicBoolean(false);
 		final List<MBrowseField> browseFieldsList = browser.getFields();
 		for (MBrowseField browseField : browseFieldsList) {
+			if (browseField == null) {
+				continue;
+			}
 			if (!browseField.isActive()) {
 				// key column on table
 				if (!browseField.isKey()) {
@@ -308,6 +317,9 @@ public class QueryUtil {
 		final Language language = Language.getLanguage(Env.getAD_Language(browser.getCtx()));
 		final List<MBrowseField> browseFieldsList = browser.getFields();
 		for (MBrowseField browseField : browseFieldsList) {
+			if (browseField == null) {
+				continue;
+			}
 			if (!browseField.isActive()) {
 				// key column on table
 				if (!browseField.isKey()) {


### PR DESCRIPTION
### Request
```bash
curl 'http://0.0.0.0/api/user-interface/entities/54808?search_value=&context_attributes=%7B%22C_Project_ID%22:1007938%7D&page_token=1&page_size=100&sort_by=' -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:135.0) Gecko/20100101 Firefox/135.0' -H 'Accept: application/json, text/plain, */*' -H 'Accept-Language: es-MX,es;q=0.8,en-US;q=0.5,en;q=0.3' -H 'Accept-Encoding: gzip, deflate' -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIzMDE5MTMzIiwiQURfQ2xpZW50X0lEIjoxMDAwMDAxLCJBRF9PcmdfSUQiOjEwMDAwMTAsIkFEX1JvbGVfSUQiOjEwMDAwMDIsIkFEX1VzZXJfSUQiOjEwMDEyMTIsIk1fV2FyZWhvdXNlX0lEIjoxMDAwMDgwLCJBRF9MYW5ndWFnZSI6ImVzX01YIiwiaWF0IjoxNzQwNTI5NjI0LCJleHAiOjE3NDA2MTYwMjR9.aFdQjNGlg8xQKqVZybvJ0voZPMw4dZO710BaZUUMZpc' -H 'Origin: http://0.0.0.0:9527' -H 'Connection: keep-alive' -H 'Referer: http://0.0.0.0:9527/' -H 'Priority: u=0'
```

### Response
```json
{
 "code": 13,
 "message": "Cannot invoke \"org.compiere.model.MField.getAD_Column_ID()\" because \"field\" is null",
 "details": []
}
```