### PR TITLE
Bugfix Don't show display definition if role does not have access to window

### DIFF
--- a/src/main/java/org/spin/base/util/AccessUtil.java
+++ b/src/main/java/org/spin/base/util/AccessUtil.java
@@ -69,15 +69,19 @@ public class AccessUtil {
 		Properties ctx = Env.getCtx();
 		MTable tableInstance = MTable.get(ctx, tableId);
 		int windowId = tableInstance.getAD_Window_ID();
-		Boolean isRoleAccess = role.getWindowAccess(windowId);
-		if (isRoleAccess != null && isRoleAccess.booleanValue()) {
-			return true;
+		Boolean isRoleAccess = null;
+		if (windowId > 0) {
+			isRoleAccess = role.getWindowAccess(windowId);
+			if (isRoleAccess != null && isRoleAccess.booleanValue()) {
+				return true;
+			}
 		}
-
-		isRoleAccess = role.getWindowAccess(tableInstance.getPO_Window_ID());
-		if (isRoleAccess != null && isRoleAccess.booleanValue()) {
-			return true;
-
+		windowId = tableInstance.getPO_Window_ID();
+		if (windowId > 0) {
+			isRoleAccess = role.getWindowAccess(windowId);
+			if (isRoleAccess != null && isRoleAccess.booleanValue()) {
+				return true;
+			}
 		}
 		String whereClause = "EXISTS (SELECT 1 FROM AD_Window w " +
 				"INNER JOIN AD_Tab t ON (t.AD_Window_ID = w.AD_Window_ID) " +

--- a/src/main/java/org/spin/base/util/AccessUtil.java
+++ b/src/main/java/org/spin/base/util/AccessUtil.java
@@ -2,6 +2,12 @@ package org.spin.base.util;
 
 import org.adempiere.core.domains.models.I_AD_Process;
 import org.compiere.model.MRole;
+import org.compiere.model.MTable;
+import org.compiere.model.MWindowAccess;
+import org.compiere.model.Query;
+import org.compiere.util.Env;
+
+import java.util.Properties;
 
 public class AccessUtil {
 
@@ -37,5 +43,58 @@ public class AccessUtil {
 		);
 		return isRecordAccess;
 	}
+
+
+	/**
+	 * Window is Access by Role
+	 * @param tableId
+	 * @return true if has access, false otherwise
+	 */
+	public static boolean isWindowAccessByTableID(int tableId) {
+		return isWindowAccessByTableID(
+				MRole.getDefault(),
+				tableId
+		);
+	}
+	/**
+	 * Window is Access by Role
+	 * @param role
+	 * @param tableId
+	 * @return true if has access, false otherwise
+	 */
+	public static boolean isWindowAccessByTableID(MRole role, int tableId) {
+		if (tableId <= 0) {
+			return false;
+		}
+		Properties ctx = Env.getCtx();
+		MTable tableInstance = MTable.get(ctx, tableId);
+		int windowId = tableInstance.getAD_Window_ID();
+		Boolean isRoleAccess = role.getWindowAccess(windowId);
+		if (isRoleAccess != null && isRoleAccess.booleanValue()) {
+			return true;
+		}
+
+		isRoleAccess = role.getWindowAccess(tableInstance.getPO_Window_ID());
+		if (isRoleAccess != null && isRoleAccess.booleanValue()) {
+			return true;
+
+		}
+		String whereClause = "EXISTS (SELECT 1 FROM AD_Window w " +
+				"INNER JOIN AD_Tab t ON (t.AD_Window_ID = w.AD_Window_ID) " +
+				"WHERE w.AD_Window_ID = AD_Window_Access.AD_Window_ID " +
+				"AND t.AD_Table_ID = ?) " +
+				"AND AD_Window_Access.AD_Role_ID = ? ";
+		int count = new Query (ctx, MWindowAccess.Table_Name, whereClause, null)
+				.setParameters(tableId, role.getAD_Role_ID())
+				.setOnlyActiveRecords(true)
+				.setApplyAccessFilter(MRole.SQL_FULLYQUALIFIED,
+						MRole.SQL_RO)
+				.count();
+		if (count > 0) {
+			return true;
+		}
+		return false;
+	}
+
 
 }

--- a/src/main/java/org/spin/grpc/service/display_definition/DisplayDefinitionServiceLogic.java
+++ b/src/main/java/org/spin/grpc/service/display_definition/DisplayDefinitionServiceLogic.java
@@ -105,6 +105,7 @@ import org.spin.backend.grpc.display_definition.UpdateBusinessPartnerRequest;
 import org.spin.backend.grpc.display_definition.UpdateDataEntryRequest;
 import org.spin.backend.grpc.display_definition.WorkflowEntry;
 import org.spin.backend.grpc.display_definition.WorkflowStep;
+import org.spin.base.util.AccessUtil;
 import org.spin.base.util.ContextManager;
 import org.spin.base.util.LookupUtil;
 import org.spin.base.util.RecordUtil;
@@ -276,6 +277,12 @@ public class DisplayDefinitionServiceLogic {
 				.getIDsAsList()
 				.forEach(recordId -> {
 					PO display = referenceTable.getPO(recordId, null);
+					int targetTableID = display.get_ValueAsInt(MTable.COLUMNNAME_AD_Table_ID);
+					if (targetTableID > 0) {
+						if (!AccessUtil.isWindowAccessByTableID(targetTableID)) {
+							return;
+						}
+					}
 					DefinitionMetadata.Builder builder = DisplayDefinitionConvertUtil.convertDefinitionMetadata(display, true);
 					builderList.addRecords(builder);
 				})


### PR DESCRIPTION
If role does not have access to a window of the table of Display Definition then don't show it

### configuration

Role with access to:

-  "Business Partner" window
- "Sales Order" or any window that has c_BPartner_ID field
-  "Product" window

The Role should NOT have access to "Product Classification" window

With this configuration the role shows Display Definition for "Business Partner" but not for "Product Classification"

Tested locally:

https://www.loom.com/share/81ac9d417c3b4fcd804875dd6d6ce848?sid=0ea3c378-fcc5-47ae-86a5-c5d7d2831171

### Additional context

Ref: https://github.com/solop-develop/frontend-core/issues/802