### PR TITLE
Finds PrintFormat by ReportView Table

### DIFF
--- a/src/main/java/org/spin/grpc/service/ReportManagement.java
+++ b/src/main/java/org/spin/grpc/service/ReportManagement.java
@@ -815,7 +815,14 @@ public class ReportManagement extends ReportManagementImplBase {
 			if (table == null || table.getAD_Table_ID() <= 0) {
 				throw new AdempiereException("@TableName@ @NotFound@");
 			}
-			whereClause = "AD_Table_ID = ?";
+			whereClause = "(AD_Table_ID = ? " +
+					" OR EXISTS (SELECT 1 FROM AD_PrintFormat pf " +
+						" INNER JOIN AD_ReportView rv ON (rv.AD_ReportView_ID = pf.AD_ReportView_ID) " +
+						" WHERE rv.AD_Table_ID = ? " +
+						" AND pf.AD_PrintFormat_ID = AD_PrintFormat.AD_PrintFormat_ID " +
+						" AND rv.IsActive = 'Y') " +
+					")";
+			parameters.add(table.getAD_Table_ID());
 			parameters.add(table.getAD_Table_ID());
 		} else if(request.getReportId() > 0) {
 			whereClause = "EXISTS("


### PR DESCRIPTION
Checks for any PrintFormat that has the table to print or for any PrintFormat that has a ReportView that uses the same table to print

### Test information

Report view "Report View with AD_Table C_Invoice":

![imagen](https://github.com/user-attachments/assets/3e7fd65c-4f36-4a77-a04c-cffcea92d406)

PrintFormat "Print Format with C_Invoice ReportView" With the same Report View and does not have C_Invoice as Table:

![imagen](https://github.com/user-attachments/assets/b535056f-4ebf-45b2-95f0-0b51164ea106)

When Listing the Print Formats in Invoice (Customer) it finds a normal print format and the new Print format that does not have the C_Invoice Table:

![imagen](https://github.com/user-attachments/assets/d8378619-9936-4682-a8f6-4e231d4662af)

