### PR TITLE
Fix Electronic invoicing Summary Line creation

### DIFF
--- a/src/main/java/com/solop/sp013/core/documents/FiscalDocumentLine.java
+++ b/src/main/java/com/solop/sp013/core/documents/FiscalDocumentLine.java
@@ -169,7 +169,7 @@ public class FiscalDocumentLine {
 		MProduct product = null;
 		MCharge charge = null;
 		MTax tax = null;
-		productValue = summaryLine.getValue();
+		productValue = summaryLine.getSP013_ElectronicProductType();
 		productName = summaryLine.getName();
 		productDescription = summaryLine.getDescription();
 		MUOM unitOfMeasure = (MUOM) summaryLine.getC_UOM();

--- a/src/main/java/com/solop/sp013/core/documents/FiscalDocumentLine.java
+++ b/src/main/java/com/solop/sp013/core/documents/FiscalDocumentLine.java
@@ -1,0 +1,527 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * Copyright (C) 2003-2020 E.R.P. Consultores y Asociados.                    *
+ * All Rights Reserved.                                                       *
+ * Contributor(s): Yamel Senih www.erpya.com                                  *
+ *****************************************************************************/
+package com.solop.sp013.core.documents;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.Properties;
+
+import com.solop.sp013.core.model.X_SP013_ElectronicLineSummary;
+import com.solop.sp013.core.util.ElectronicInvoicingChanges;
+import com.solop.sp013.core.util.ElectronicInvoicingUtil;
+import org.adempiere.exceptions.AdempiereException;
+import org.compiere.model.*;
+import org.compiere.util.Env;
+import org.compiere.util.Util;
+
+/**
+ * Use it for fiscal documents line
+ * @author Yamel Senih, yamel.senih@solopsoftware.com, Solop http://www.solopsoftware.com
+ */
+public class FiscalDocumentLine {
+
+	/**
+	 * Default constructor
+	 */
+	public FiscalDocumentLine(FiscalDocument document, MInvoiceLine documentLine) {
+		this.document = document;
+		if(documentLine == null) {
+			throw new AdempiereException("@C_InvoiceLine_ID@ @NotFound@");
+		}
+		//	Fill it
+		convertDocument(documentLine);
+	}
+
+	/**
+	 * Construct From Electronic Line Summary
+	 */
+	public FiscalDocumentLine(FiscalDocument document, X_SP013_ElectronicLineSummary documentLine) {
+		this.document = document;
+		if(documentLine == null) {
+			throw new AdempiereException("@SP013_ElectronicLineSummary_ID@ @NotFound@");
+		}
+		//	Fill it
+		convertDocument(documentLine);
+	}
+
+	/**
+	 * Convert document like invoice, credit memo or debit memo
+	 * @param invoiceLine
+	 * @return void
+	 */
+	private void convertDocument(MInvoiceLine invoiceLine) {
+		String productValue = null;
+		String productName = null;
+		String productDescription = null;
+		String productBarcode = null;
+		BigDecimal taxRate = Env.ZERO;
+		BigDecimal discount = Env.ZERO;
+		//	Get Product Attributes
+		MProduct product = null;
+		MCharge charge = null;
+		MTax tax = null;
+		if (invoiceLine.getM_Product_ID() != 0) {
+			product = MProduct.get(invoiceLine.getCtx(), invoiceLine.getM_Product_ID());
+			productValue = product.getValue();
+			productName = product.getName();
+			productDescription = product.getDescription();
+			productBarcode = product.getUPC();
+			MUOM unitOfMeasure = MUOM.get(invoiceLine.getCtx(), product.getC_UOM_ID());
+			withProductUnitOfMeasure(unitOfMeasure.getUOMSymbol());
+		} else if (invoiceLine.getC_Charge_ID() != 0) {
+			charge = MCharge.get(invoiceLine.getCtx(), invoiceLine.getC_Charge_ID());
+			productValue = String.valueOf(charge.getC_Charge_ID());
+			productName = charge.getName();
+			productDescription = charge.getDescription();
+			MUOM unitOfMeasure = MUOM.get(invoiceLine.getCtx(), 100);
+			withProductUnitOfMeasure(unitOfMeasure.getUOMSymbol());
+		}
+		//	Get tax Category
+		final int taxCategoryId = (product != null ? product.getC_TaxCategory_ID() : charge != null ? charge.getC_TaxCategory_ID() : 0);
+		//	Get Tax Rate
+		if (invoiceLine.getC_Tax_ID() != 0) {
+			tax = MTax.get(invoiceLine.getCtx(), invoiceLine.getC_Tax_ID());
+			taxRate = tax.getRate();
+		} else {
+			Optional<MTax> optionalTax = Arrays.stream(MTax.getAll(invoiceLine.getCtx()))
+					.filter(taxValue -> taxValue.getC_TaxCategory_ID() == taxCategoryId)
+					.sorted(Comparator.comparing(MTax::isDefault).reversed())
+					.findFirst();
+			if (!optionalTax.isPresent()) {
+				throw new AdempiereException("@C_Tax_ID@ @NotFound@: " + invoiceLine);
+			}
+			tax = optionalTax.get();
+			taxRate = tax.getRate();
+		}
+		if (tax.get_ValueAsInt(ElectronicInvoicingChanges.SP013_TaxType_ID) > 0) {
+			taxIndicator = ElectronicInvoicingUtil.getTaxIndicatorFromTax(invoiceLine.getCtx(), tax.get_ValueAsInt(ElectronicInvoicingChanges.SP013_TaxType_ID));
+		}
+		//	Get Withholding Info
+		if (invoiceLine.get_ValueAsInt("WH_Definition_ID") > 0) {
+			MTable withholdingTable = MTable.get(Env.getCtx(), "WH_Definition");
+			if (withholdingTable != null) {
+				PO withholdingDefinition = withholdingTable.getPO(invoiceLine.get_ValueAsInt("WH_Definition_ID"), invoiceLine.get_TrxName());
+				if (withholdingDefinition != null) {
+					String code = withholdingDefinition.get_ValueAsString("Value");
+					BigDecimal percentage = (BigDecimal) withholdingDefinition.get_Value("Percentage");
+					withWithholdingCode(code);
+					withWithholdingRate(Optional.ofNullable(percentage).orElse(Env.ZERO));
+				}
+			}
+		}
+		//	Discount
+		BigDecimal priceActual = Optional.ofNullable(invoiceLine.getPriceActual()).orElse(Env.ZERO);
+		BigDecimal priceList = Optional.ofNullable(invoiceLine.getPriceList()).orElse(Env.ZERO);
+		if (priceActual.compareTo(Env.ZERO) > 0
+				&& priceList.compareTo(Env.ZERO) > 0) {
+			discount = invoiceLine.getPriceList().subtract(invoiceLine.getPriceActual());
+			discount = discount.divide(invoiceLine.getPriceList(), MathContext.DECIMAL128);
+			discount = discount.multiply(Env.ONEHUNDRED);
+		}
+		//	Set Attributes
+		withDocumentLineUuid(invoiceLine.getUUID())
+				.withProductValue(productValue)
+				.withProductName(productName)
+				.withProductDescription(productDescription)
+				.withProductBarCode(productBarcode)
+				.withProductPrice(invoiceLine.getPriceActual())
+				.withProductPriceList(invoiceLine.getPriceList())
+				.withLineDescription(invoiceLine.getDescription())
+				.withQuantity(invoiceLine.getQtyInvoiced())
+				.withTaxRate(taxRate)
+				.withTaxIndicator(taxIndicator)
+				.withLineNetAmount(invoiceLine.getLineNetAmt())
+				.withLineTotalAmount(invoiceLine.getLineTotalAmt())
+				.withDiscount(discount);
+	}
+
+	/**
+	 * Convert document like invoice, credit memo or debit memo
+	 * @param summaryLine
+	 * @return void
+	 */
+	private void convertDocument(X_SP013_ElectronicLineSummary summaryLine) {
+		String productValue = null;
+		String productName = null;
+		String productDescription = null;
+		String productBarcode = null;
+		BigDecimal taxRate = Env.ZERO;
+		BigDecimal discount = Env.ZERO;
+		//	Get Product Attributes
+		MProduct product = null;
+		MCharge charge = null;
+		MTax tax = null;
+		productValue = summaryLine.getValue();
+		productName = summaryLine.getName();
+		productDescription = summaryLine.getDescription();
+		MUOM unitOfMeasure = (MUOM) summaryLine.getC_UOM();
+
+		if (summaryLine.getM_Product_ID() != 0) {
+			product = MProduct.get(summaryLine.getCtx(), summaryLine.getM_Product_ID());
+			productBarcode = product.getUPC();
+			if (unitOfMeasure == null) {
+				unitOfMeasure = MUOM.get(summaryLine.getCtx(), product.getC_UOM_ID());
+			}
+			if(Util.isEmpty(productValue)) {
+				productValue = product.getValue();
+			}
+			if (Util.isEmpty(productName)) {
+				productName = product.getName();
+			}
+		} else if (summaryLine.getC_Charge_ID() != 0) {
+			charge = MCharge.get(summaryLine.getCtx(), summaryLine.getC_Charge_ID());
+
+			if(Util.isEmpty(productValue)) {
+				productValue = String.valueOf(charge.getC_Charge_ID());
+			}
+			if (Util.isEmpty(productName)) {
+				productName = charge.getName();
+			}
+		}
+		if (unitOfMeasure == null) {
+			unitOfMeasure = MUOM.get(summaryLine.getCtx(), 100);
+		}
+		withProductUnitOfMeasure(unitOfMeasure.getUOMSymbol());
+		//	Get tax Category
+		final int taxCategoryId = (product != null ? product.getC_TaxCategory_ID() : charge != null ? charge.getC_TaxCategory_ID() : 0);
+		//	Get Tax Rate
+		if (summaryLine.getC_Tax_ID() != 0) {
+			tax = MTax.get(summaryLine.getCtx(), summaryLine.getC_Tax_ID());
+			taxRate = tax.getRate();
+		} else {
+			Optional<MTax> optionalTax = Arrays.stream(MTax.getAll(summaryLine.getCtx()))
+					.filter(taxValue -> taxValue.getC_TaxCategory_ID() == taxCategoryId)
+					.sorted(Comparator.comparing(MTax::isDefault).reversed())
+					.findFirst();
+			if (!optionalTax.isPresent()) {
+				throw new AdempiereException("@C_Tax_ID@ @NotFound@: " + summaryLine);
+			}
+			tax = optionalTax.get();
+			taxRate = tax.getRate();
+		}
+		if (tax.get_ValueAsInt(ElectronicInvoicingChanges.SP013_TaxType_ID) > 0) {
+			taxIndicator = ElectronicInvoicingUtil.getTaxIndicatorFromTax(summaryLine.getCtx(), tax.get_ValueAsInt(ElectronicInvoicingChanges.SP013_TaxType_ID));
+		}
+
+		//	Set Attributes
+
+		BigDecimal multiplier = BigDecimal.ONE.add(
+				taxRate.divide(Env.ONEHUNDRED,
+						10, RoundingMode.HALF_UP));
+		BigDecimal totalAmount = summaryLine.getLineTotalAmt().multiply(multiplier)
+				.setScale(2, RoundingMode.HALF_UP);
+
+		withDocumentLineUuid(summaryLine.getUUID())
+				.withProductValue(productValue)
+				.withProductName(productName)
+				.withProductDescription(productDescription)
+				.withProductBarCode(productBarcode)
+				.withProductPrice(summaryLine.getPriceEntered())
+				.withProductPriceList(summaryLine.getPriceEntered())
+				.withLineDescription(summaryLine.getDescription())
+				.withQuantity(summaryLine.getQty())
+				.withTaxRate(taxRate)
+				.withTaxIndicator(taxIndicator)
+				.withLineNetAmount(summaryLine.getLineTotalAmt())
+				.withLineTotalAmount(totalAmount)
+				.withDiscount(discount);
+	}
+
+	/**	Parent Document	*/
+	private FiscalDocument document;
+	/**	Document Line UUID	*/
+	private String documentLineUuid = null;
+	/**	Product Value	*/
+	private String productValue = null;
+	/**	Business Partner Tax ID	*/
+	private String productName = null;
+	/**	Document productDescription	*/
+	private String productDescription = null;
+	/**	Document Note	*/
+	private String productBarCode = null;
+	/**	Line Description	*/
+	private String lineDescription = null;
+	/**	Product UOM	*/
+	private String productUnitOfMeasure = null;
+	/**	Quantity	*/
+	private BigDecimal quantity = null;
+	/**	Product Price List	*/
+	private BigDecimal productPriceList = null;
+	/**	Product Price	*/
+	private BigDecimal productPrice = null;
+	/**	Tax Rate	*/
+	private BigDecimal taxRate = null;
+	/**	Tax Indicator	*/
+	private String taxIndicator = null;
+	/**	Discount	*/
+	private BigDecimal discount = null;
+	/**	Invoice	*/
+	private MInvoice invoice = null;
+	/**	Line Net Amount	*/
+	private BigDecimal lineNetAmount = null;
+	/**	Line Net Amount	*/
+	private BigDecimal lineTotalAmount = null;
+	/**	Product Value	*/
+	private String withholdingCode = null;
+	/**	Wihholding Rate	*/
+	private BigDecimal withholdingRate = Env.ZERO;
+	/**	Base Amount	*/
+	private BigDecimal withholdingBaseAmount = null;
+
+	/**
+	 * Document Type Definition
+	 */
+	enum DocumentType {
+		INVOICE, CREDIT_MEMO, DEBIT_MEMO
+	}
+
+	/**
+	 * @param documentLineUuid the documentLineUuid to set
+	 */
+	public final FiscalDocumentLine withDocumentLineUuid(String documentLineUuid) {
+		this.documentLineUuid = documentLineUuid;
+		return this;
+	}
+
+	/**
+	 * @param productValue the productValue to set
+	 */
+	public final FiscalDocumentLine withProductValue(String productValue) {
+		this.productValue = productValue;
+		return this;
+	}
+
+	/**
+	 * @param productName the productName to set
+	 */
+	public final FiscalDocumentLine withProductName(String productName) {
+		this.productName = productName;
+		return this;
+	}
+
+	/**
+	 * @param productDescription the productDescription to set
+	 */
+	public final FiscalDocumentLine withProductDescription(String productDescription) {
+		this.productDescription = productDescription;
+		return this;
+	}
+
+	/**
+	 * @param productBarCode the productBarCode to set
+	 */
+	public final FiscalDocumentLine withProductBarCode(String productBarCode) {
+		this.productBarCode = productBarCode;
+		return this;
+	}
+
+	/**
+	 * @param lineDescription the lineDescription to set
+	 */
+	public final FiscalDocumentLine withLineDescription(String lineDescription) {
+		this.lineDescription = lineDescription;
+		return this;
+	}
+
+	/**
+	 * @param quantity the quantity to set
+	 */
+	public final FiscalDocumentLine withQuantity(BigDecimal quantity) {
+		this.quantity = quantity;
+		return this;
+	}
+
+	/**
+	 * @param productPrice the productPrice to set
+	 */
+	public final FiscalDocumentLine withProductPrice(BigDecimal productPrice) {
+		this.productPrice = productPrice;
+		return this;
+	}
+
+	/**
+	 * @param productPriceList the productPriceList to set
+	 */
+	public final FiscalDocumentLine withProductPriceList(BigDecimal productPriceList) {
+		this.productPriceList = productPriceList;
+		return this;
+	}
+
+	/**
+	 * @param taxRate the taxRate to set
+	 */
+	public final FiscalDocumentLine withTaxRate(BigDecimal taxRate) {
+		this.taxRate = taxRate;
+		return this;
+	}
+
+	/**
+	 * @param discount the discount to set
+	 */
+	public final FiscalDocumentLine withDiscount(BigDecimal discount) {
+		this.discount = discount;
+		return this;
+	}
+
+	/**
+	 * @return the documentLineUuid
+	 */
+	public final String getdocumentLineUuid() {
+		return documentLineUuid;
+	}
+
+	/**
+	 * @return the productValue
+	 */
+	public final String getProductValue() {
+		return productValue;
+	}
+
+	/**
+	 * @return the productName
+	 */
+	public final String getProductName() {
+		return productName;
+	}
+
+	/**
+	 * @return the productDescription
+	 */
+	public final String getProductDescription() {
+		return productDescription;
+	}
+
+	/**
+	 * @return the productBarCode
+	 */
+	public final String getProductBarCode() {
+		return productBarCode;
+	}
+
+	/**
+	 * @return the lineDescription
+	 */
+	public final String getLineDescription() {
+		return lineDescription;
+	}
+
+	/**
+	 * @return the quantity
+	 */
+	public final BigDecimal getQuantity() {
+		return quantity;
+	}
+
+	/**
+	 * @return the productPriceList
+	 */
+	public final BigDecimal getProductPriceList() {
+		return productPriceList;
+	}
+
+	/**
+	 * @return the productPrice
+	 */
+	public final BigDecimal getProductPrice() {
+		return productPrice;
+	}
+
+	/**
+	 * @return the taxRate
+	 */
+	public final BigDecimal getTaxRate() {
+		return taxRate;
+	}
+
+	/**
+	 * @return the discount
+	 */
+	public final BigDecimal getDiscount() {
+		return discount;
+	}
+
+	public final BigDecimal getDiscountAmount() {
+		return getProductPriceList().subtract(getProductPrice());
+	}
+
+	public String getTaxIndicator() {
+		return taxIndicator;
+	}
+
+	public FiscalDocumentLine withTaxIndicator(String taxIndicator) {
+		this.taxIndicator = taxIndicator;
+		return this;
+	}
+
+	public String getProductUnitOfMeasure() {
+		return productUnitOfMeasure;
+	}
+
+	public FiscalDocumentLine withProductUnitOfMeasure(String productUnitOfMeasure) {
+		this.productUnitOfMeasure = productUnitOfMeasure;
+		return this;
+	}
+
+	public BigDecimal getLineNetAmount() {
+		return lineNetAmount;
+	}
+
+	public FiscalDocumentLine withLineNetAmount(BigDecimal lineNetAmount) {
+		this.lineNetAmount = lineNetAmount;
+		return this;
+	}
+
+	public BigDecimal getLineTotalAmount() {
+		return lineTotalAmount;
+	}
+
+	public FiscalDocumentLine withLineTotalAmount(BigDecimal lineTotalAmount) {
+		this.lineTotalAmount = lineTotalAmount;
+		return this;
+	}
+
+	public String getWithholdingCode() {
+		return withholdingCode;
+	}
+
+	public FiscalDocumentLine withWithholdingCode(String withholdingCode) {
+		this.withholdingCode = withholdingCode;
+		return this;
+	}
+
+	public BigDecimal getWithholdingRate() {
+		return withholdingRate;
+	}
+
+	public FiscalDocumentLine withWithholdingRate(BigDecimal withholdingRate) {
+		this.withholdingRate = withholdingRate;
+		return this;
+	}
+
+	public BigDecimal getWithholdingBaseAmount() {
+		return withholdingBaseAmount;
+	}
+
+	public FiscalDocumentLine withWithholdingBaseAmount(BigDecimal withholdingBaseAmount) {
+		this.withholdingBaseAmount = withholdingBaseAmount;
+		return this;
+	}
+}

--- a/src/main/java/com/solop/sp013/core/model/validator/ElectronicInvoicing.java
+++ b/src/main/java/com/solop/sp013/core/model/validator/ElectronicInvoicing.java
@@ -1,0 +1,220 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * Copyright (C) 2003-2016 E.R.P. Consultores y Asociados.                    *
+ * All Rights Reserved.                                                       *
+ * Contributor(s): Yamel Senih www.erpcya.com                                 *
+ *****************************************************************************/
+package com.solop.sp013.core.model.validator;
+
+import com.solop.sp013.core.process.SendInvoice;
+import com.solop.sp013.core.queue.ElectronicDocument;
+import com.solop.sp013.core.util.ElectronicInvoicingChanges;
+import com.solop.sp013.core.util.ElectronicInvoicingSummaryGrouping;
+import com.solop.sp013.core.util.ElectronicInvoicingUtil;
+import org.adempiere.core.domains.models.I_C_Invoice;
+import org.adempiere.exceptions.AdempiereException;
+import org.compiere.model.*;
+import org.compiere.process.ProcessInfo;
+import org.compiere.util.CLogger;
+import org.compiere.util.Env;
+import org.compiere.util.Msg;
+import org.compiere.util.Util;
+import org.spin.queue.util.QueueLoader;
+
+/**
+ * Document Builder
+ * @author Yamel Senih, yamel.senih@solopsoftware.com, Solop <a href="http://www.solopsoftware.com">solopsoftware.com</a>
+ */
+public class ElectronicInvoicing implements ModelValidator {
+
+	public ElectronicInvoicing() {
+		super();
+	}
+
+	/** Logger 			*/
+	private static CLogger log = CLogger
+			.getCLogger(ElectronicInvoicing.class);
+	/**	Client			*/
+	private int clientId = 0;
+
+	@Override
+	public void initialize(ModelValidationEngine engine, MClient client) {
+		// client = null for global validator
+		if (client != null) {
+			clientId = client.getAD_Client_ID();
+		} else {
+			log.info("Initializing global validator: " + toString());
+		}
+		//
+		engine.addDocValidate(I_C_Invoice.Table_Name, this);
+		engine.addModelChange(I_C_Invoice.Table_Name, this);
+	}
+
+	@Override
+	public int getAD_Client_ID() {
+		return clientId;
+	}
+
+	@Override
+	public String login(int AD_Org_ID, int AD_Role_ID, int AD_User_ID) {
+		return null;
+	}
+
+	@Override
+	public String modelChange(PO po, int type) throws Exception {
+		if(type == TYPE_BEFORE_NEW
+				|| type == TYPE_BEFORE_CHANGE) {
+			log.fine(" TYPE_BEFORE_NEW || TYPE_BEFORE_CHANGE");
+			if (po.get_TableName().equals(MInvoice.Table_Name)) {
+				MInvoice invoice = (MInvoice) po;
+				if(invoice.isSOTrx()) {
+					if(type == TYPE_BEFORE_NEW || invoice.is_ValueChanged(I_C_Invoice.COLUMNNAME_C_BPartner_ID)) {
+						MBPartner customer = MBPartner.get(invoice.getCtx(), invoice.getC_BPartner_ID());
+						MDocType documentType = MDocType.get(invoice.getCtx(), invoice.getC_DocTypeTarget_ID());
+						String fiscalDocumentType = ElectronicInvoicingChanges.SP013_FiscalDocumentType_Invoice;
+						if(documentType != null) {
+							fiscalDocumentType = documentType.get_ValueAsString(ElectronicInvoicingChanges.SP013_FiscalDocumentType);
+							if(fiscalDocumentType == null) {
+								fiscalDocumentType = ElectronicInvoicingChanges.SP013_FiscalDocumentType_Invoice;
+							}
+						}
+						int documentTypeId = ElectronicInvoicingUtil.getDocumentTypeFromTaxGroup(invoice.getCtx(), fiscalDocumentType, customer.getC_TaxGroup_ID());
+						if(documentTypeId > 0) {
+							invoice.setC_DocTypeTarget_ID(documentTypeId);
+						}
+
+						MBPartner mbPartner = (MBPartner) invoice.getC_BPartner();
+						String electronicBillingCriteria = mbPartner.get_ValueAsString("SP013_BillingCriteria");
+						if (!Util.isEmpty(electronicBillingCriteria, true)) {
+							invoice.set_ValueOfColumn("SP013_BillingCriteria", mbPartner.get_ValueAsString("SP013_BillingCriteria"));
+						}
+					}
+					if(type == TYPE_BEFORE_NEW || invoice.is_ValueChanged(I_C_Invoice.COLUMNNAME_C_DocTypeTarget_ID)) {
+						MDocType documentType = MDocType.get(invoice.getCtx(), invoice.getC_DocTypeTarget_ID());
+						invoice.set_ValueOfColumn(ElectronicInvoicingChanges.SP013_IsElectronicDocument, documentType.get_ValueAsBoolean(ElectronicInvoicingChanges.SP013_IsElectronicDocument));
+						invoice.set_ValueOfColumn(ElectronicInvoicingChanges.SP013_IsAllowsReverse, documentType.get_ValueAsBoolean(ElectronicInvoicingChanges.SP013_IsAllowsReverse));
+					}
+				}
+				//	Set Allocated Document
+				if(type == TYPE_BEFORE_NEW) {
+					if(invoice.getC_POS_ID() <= 0 || invoice.getC_Order_ID() <= 0) {
+						return null;
+					}
+					MOrder returnOrder = new MOrder(Env.getCtx(), invoice.getC_Order_ID(), invoice.get_TrxName());
+					if(returnOrder.get_ValueAsInt("ECA14_Source_Order_ID") <= 0) {
+						return null;
+					}
+					MOrder sourceOrder = new MOrder(Env.getCtx(), returnOrder.get_ValueAsInt("ECA14_Source_Order_ID"), invoice.get_TrxName());
+					int sourceInvoiceId = sourceOrder.getC_Invoice_ID();
+					if(sourceInvoiceId <= 0) {
+						return null;
+					}
+					invoice.set_ValueOfColumn(ElectronicInvoicingChanges.ReferenceDocument_ID, sourceInvoiceId);
+				}
+			}
+		} else if(type == TYPE_AFTER_NEW) {
+			log.fine(" TYPE_BEFORE_NEW || TYPE_BEFORE_CHANGE");
+			if (po.get_TableName().equals(MInvoice.Table_Name)) {
+
+			}
+		} else if (type == TYPE_AFTER_CHANGE) {
+			if(po.get_TableName().equals(I_C_Invoice.Table_Name)) {
+				MInvoice invoice = (MInvoice) po;
+				if (invoice.is_ValueChanged("SP013_BillingCriteria")){
+					ElectronicInvoicingSummaryGrouping grouping = ElectronicInvoicingSummaryGrouping.newInstance(invoice);
+					grouping.process();
+				}
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public String docValidate(PO po, int timing) {
+		if(timing == TIMING_BEFORE_PREPARE) {
+			/*if(po.get_TableName().equals(I_C_Invoice.Table_Name)) {
+				MInvoice invoice = (MInvoice) po;
+				ElectronicInvoicingSummaryGrouping grouping = ElectronicInvoicingSummaryGrouping.newInstance(invoice);
+				grouping.process();
+			}*/
+		}
+		if(timing == TIMING_BEFORE_REVERSECORRECT
+				|| timing == TIMING_BEFORE_VOID) {
+			log.fine(" TIMING_BEFORE_REVERSECORRECT || TIMING_BEFORE_VOID");
+			if(po.get_TableName().equals(I_C_Invoice.Table_Name)) {
+				MInvoice invoice = (MInvoice) po;
+				if(invoice.get_ValueAsBoolean(ElectronicInvoicingChanges.SP013_IsElectronicDocument)
+						&& !invoice.get_ValueAsBoolean(ElectronicInvoicingChanges.SP013_IsAllowsReverse)) {
+					return Msg.parseTranslation(Env.getCtx(), "@SP013.ReverseNotAllowed@");
+				}
+			}
+		} else if(timing == TIMING_BEFORE_COMPLETE) {
+			log.fine(" TIMING_BEFORE_COMPLETE");
+			if(po.get_TableName().equals(I_C_Invoice.Table_Name)) {
+				MInvoice invoice = (MInvoice) po;
+				if(!invoice.isReversal()
+						&& invoice.isSOTrx()) {
+					int posId = invoice.getC_POS_ID();
+					if(posId == 0) {
+						if(invoice.getC_Order_ID() != 0) {
+							posId = invoice.getC_Order().getC_POS_ID();
+						}
+					}
+					if(posId != 0) {
+						MDocType documentType = MDocType.get(invoice.getCtx(), invoice.getC_DocTypeTarget_ID());
+						if(documentType.get_ValueAsBoolean(ElectronicInvoicingChanges.SP013_IsElectronicDocument)) {
+							MPOS posConfiguration = MPOS.get(invoice.getCtx(), posId);
+							int fiscalSenderId = MOrgInfo.get(invoice.getCtx(), posConfiguration.getAD_Org_ID(), null).get_ValueAsInt(ElectronicInvoicingChanges.SP013_FiscalSender_ID);
+							if(fiscalSenderId != 0) {
+								invoice.set_ValueOfColumn(ElectronicInvoicingChanges.SP013_FiscalSender_ID, fiscalSenderId);
+								invoice.setC_POS_ID(posId);
+								invoice.saveEx();
+							}
+						}
+					}
+				}
+			}
+		} else if(timing == TIMING_AFTER_COMPLETE) {
+			log.fine(" TIMING_AFTER_COMPLETE");
+			if(po.get_TableName().equals(I_C_Invoice.Table_Name)) {
+				MInvoice invoice = (MInvoice) po;
+				MDocType documentType = MDocType.get(invoice.getCtx(), invoice.getC_DocTypeTarget_ID());
+				if((!invoice.isReversal() || documentType.get_ValueAsBoolean(ElectronicInvoicingChanges.SP013_IsAllowsReverse))
+						&& invoice.isSOTrx()) {
+					if(!invoice.get_ValueAsBoolean(ElectronicInvoicingChanges.SP013_IsSent)) {
+						if(documentType.get_ValueAsBoolean(ElectronicInvoicingChanges.SP013_IsElectronicDocument)) {
+							if(documentType.get_ValueAsBoolean(ElectronicInvoicingChanges.SP013_IsSendAfterComplete)) {
+								ProcessInfo info = org.eevolution.services.dsl.ProcessBuilder.create(invoice.getCtx())
+										.process(SendInvoice.getProcessId())
+										.withRecordId(I_C_Invoice.Table_ID, invoice.getC_Invoice_ID())
+										.withParameter(SendInvoice.C_INVOICE_ID, invoice.getC_Invoice_ID())
+										.withoutTransactionClose()
+										.execute(invoice.get_TrxName());
+								if(info.isError()) {
+									return info.getSummary();
+								}
+							} else {
+								QueueLoader.getInstance().getQueueManager(ElectronicDocument.QueueType_ElectronicDocument)
+										.withContext(invoice.getCtx())
+										.withTransactionName(invoice.get_TrxName())
+										.withEntity(invoice)
+										.addToQueue();
+							}
+						}
+					}
+				}
+			}
+		}
+		return null;
+	}
+}

--- a/src/main/java/com/solop/sp013/core/util/ElectronicInvoicingSummaryGrouping.java
+++ b/src/main/java/com/solop/sp013/core/util/ElectronicInvoicingSummaryGrouping.java
@@ -1,0 +1,225 @@
+package com.solop.sp013.core.util;
+
+import com.solop.sp013.core.model.X_SP013_ElectronicLineSummary;
+import org.adempiere.core.domains.models.X_S_Contract;
+import org.adempiere.core.domains.models.X_S_ContractLine;
+import org.adempiere.exceptions.AdempiereException;
+import org.compiere.model.MCharge;
+import org.compiere.model.MInvoice;
+import org.compiere.model.MInvoiceLine;
+import org.compiere.model.MOrderLine;
+import org.compiere.model.MPriceList;
+import org.compiere.model.MProduct;
+import org.compiere.model.MProject;
+import org.compiere.model.MProjectLine;
+import org.compiere.model.Query;
+import org.compiere.util.Env;
+import org.compiere.util.Util;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class ElectronicInvoicingSummaryGrouping {
+
+    private final MInvoice invoice;
+    public static ElectronicInvoicingSummaryGrouping newInstance(MInvoice newInvoice) {
+        return new ElectronicInvoicingSummaryGrouping(newInvoice);
+    }
+
+    public ElectronicInvoicingSummaryGrouping(MInvoice newInvoice) {
+        invoice = newInvoice;
+        invoiceLineGroups = new HashMap<>();
+        groupDescription = new HashMap<>();
+        seqNo = new AtomicInteger(0);
+    }
+    private final Map<String, List<MInvoiceLine>> invoiceLineGroups;
+    private final Map<String, String> groupDescription;
+    private final AtomicInteger seqNo;
+
+    public void process() {
+        List<MInvoiceLine> invoiceLines = Arrays.asList(invoice.getLines());
+        String billingCriteria = invoice.get_ValueAsString("SP013_BillingCriteria");
+        if (Util.isEmpty(billingCriteria) || billingCriteria.equals("M")) {
+            return; //TODO: Validate if it can be null and just return
+        }
+        new Query(invoice.getCtx(), X_SP013_ElectronicLineSummary.Table_Name, X_SP013_ElectronicLineSummary.COLUMNNAME_C_Invoice_ID + "=?", invoice.get_TrxName())
+                .setParameters(invoice.get_ID())
+                .list()
+                .forEach(po -> po.deleteEx(false));
+        AtomicBoolean isTaxIncluded = new AtomicBoolean(false);
+        MPriceList priceList = (MPriceList) invoice.getM_PriceList();
+        if (priceList != null && priceList.get_ValueAsBoolean("isTaxIncluded")) {
+            isTaxIncluded.set(true);
+        }
+
+        invoiceLines.forEach(invoiceLine -> {
+            String description = null;
+            String key = "";
+            if (billingCriteria.equals("L")){
+                key = String.valueOf(invoiceLine.get_ID());
+                key += String.valueOf(invoiceLine.getC_Tax_ID());
+                description = groupDescription.get(key);
+                if (description == null) {
+                    MProduct product = invoiceLine.getProduct();
+                    MCharge charge = invoiceLine.getCharge();
+                    if (product != null && product.get_ID() > 0) {
+                        description = Optional.ofNullable(product.getName()).orElse("") + " " + Optional.ofNullable(product.getDescription()).orElse("");
+                    } else if (charge != null && charge.get_ID() > 0) {
+                        description = Optional.ofNullable(charge.getName()).orElse("") + " " + Optional.ofNullable(charge.getDescription()).orElse("");
+                    } else {
+                        throw new AdempiereException("@M_Product@ - @C_Charge@ @not.found@");
+                    }
+                    groupDescription.put(key, description);
+                }
+
+
+            } else if (billingCriteria.equals("P")){
+                int projectId = invoiceLine.getC_Project_ID();
+                if (projectId <= 0) {
+                    int projectLineId = invoiceLine.get_ValueAsInt(MProjectLine.COLUMNNAME_C_ProjectLine_ID);
+                    if (projectLineId <= 0 && invoiceLine.getC_OrderLine_ID() >0) {
+
+                        MOrderLine orderLine = (MOrderLine) invoiceLine.getC_OrderLine();
+                        projectLineId = orderLine.get_ValueAsInt(MProjectLine.COLUMNNAME_C_ProjectLine_ID);
+                    }
+                    if (projectLineId > 0) {
+                        MProjectLine projectLine = new MProjectLine(invoice.getCtx(), projectLineId, invoice.get_TrxName());
+                        projectId = projectLine.getC_Project_ID();
+                    }
+                }
+                key = String.valueOf(projectId);
+                key += String.valueOf(invoiceLine.getC_Tax_ID());
+                description = groupDescription.get(key);
+                if (description == null && projectId > 0) {
+                    MProject project = MProject.getById(invoice.getCtx(), projectId, invoice.get_TrxName());
+                    description = Optional.ofNullable(project.getDescription()).orElse("");
+                    groupDescription.put(key, description);
+                }
+            } else if (billingCriteria.equals("PP")){
+                int projectLineId = invoiceLine.get_ValueAsInt(MProjectLine.COLUMNNAME_C_ProjectLine_ID);
+                if (projectLineId <= 0 && invoiceLine.getC_OrderLine_ID() > 0) {
+                    MOrderLine orderLine = (MOrderLine)invoiceLine.getC_OrderLine();
+                    projectLineId = orderLine.get_ValueAsInt(MProjectLine.COLUMNNAME_C_ProjectLine_ID);
+                }
+                if (projectLineId > 0) {
+                    MProjectLine projectLine = new MProjectLine(invoice.getCtx(), projectLineId, invoice.get_TrxName());
+                    String projectLineType = projectLine.get_ValueAsString("ProjectLineType");
+                    if (!Util.isEmpty(projectLineType) && projectLineType.equals("T")) {
+                        projectLine = (MProjectLine) projectLine.getParent();
+                    }
+                    key = String.valueOf(projectLine.get_ID());
+                    key += String.valueOf(invoiceLine.getC_Tax_ID());
+                    description = groupDescription.get(key);
+                    if (description == null) {
+                        description = Optional.ofNullable(projectLine.getDescription()).orElse("");
+                        groupDescription.put(key, description);
+                    }
+                }
+            } else if (billingCriteria.equals("T")){
+                int projectLineId = invoiceLine.get_ValueAsInt(MProjectLine.COLUMNNAME_C_ProjectLine_ID);
+                if (projectLineId <= 0) {
+                    MOrderLine orderLine = (MOrderLine)invoiceLine.getC_OrderLine();
+                    if (orderLine != null) {
+                        projectLineId = orderLine.get_ValueAsInt(MProjectLine.COLUMNNAME_C_ProjectLine_ID);
+                    }
+                }
+                if (projectLineId > 0) {
+                    MProjectLine projectLine = new MProjectLine(invoice.getCtx(), projectLineId, invoice.get_TrxName());
+                    String projectLineType = projectLine.get_ValueAsString("ProjectLineType");
+                    if (!Util.isEmpty(projectLineType) && projectLineType.equals("T")) {
+                        key = String.valueOf(projectLineId);
+                        key += String.valueOf(invoiceLine.getC_Tax_ID());
+                        description = groupDescription.get(key);
+                        if (description == null) {
+                            description = Optional.ofNullable(projectLine.getDescription()).orElse("");
+                            groupDescription.put(key, description);
+                        }
+                    }
+                }
+            } else if (billingCriteria.equals("I")){
+                key = String.valueOf(invoice.get_ID());
+                key += String.valueOf(invoiceLine.getC_Tax_ID());
+            } else if (billingCriteria.equals("C")){
+                int contractLineId = invoiceLine.get_ValueAsInt(X_S_ContractLine.COLUMNNAME_S_ContractLine_ID);
+                if (contractLineId <= 0 && invoiceLine.getC_OrderLine_ID() >0) {
+                    MOrderLine orderLine = (MOrderLine)invoiceLine.getC_OrderLine();
+                    if (orderLine != null) {
+                        contractLineId = orderLine.get_ValueAsInt(X_S_ContractLine.COLUMNNAME_S_ContractLine_ID);
+                    }
+                }
+                if (contractLineId > 0) {
+                    X_S_ContractLine contractLine = new X_S_ContractLine(invoice.getCtx(), contractLineId, invoice.get_TrxName());
+                    X_S_Contract contract = (X_S_Contract) contractLine.getS_Contract();
+                    key = String.valueOf(contract.get_ID());
+                    key += String.valueOf(invoiceLine.getC_Tax_ID());
+                    description = groupDescription.get(key);
+                    if (description == null) {
+                        description = Optional.ofNullable(contract.getDescription()).orElse("");//TODO: They Used Name but it does not have Centralized ID
+                        groupDescription.put(key, description);
+                    }
+                }
+            }
+            updateLineGroupStorage(key, invoiceLine);
+        });
+        generateSummaryLines(isTaxIncluded.get());
+
+    }
+
+    private void generateSummaryLines(boolean isTaxIncluded){
+        invoiceLineGroups.forEach((key, invoiceLineList) -> {
+            X_SP013_ElectronicLineSummary summary = new X_SP013_ElectronicLineSummary(invoice.getCtx(), 0, invoice.get_TrxName());
+            AtomicReference<BigDecimal> lineTotalAmt = new AtomicReference<>(BigDecimal.ZERO);
+            AtomicBoolean isSameProduct = new AtomicBoolean(true);
+            AtomicInteger maybeProductId = new AtomicInteger(0);
+            invoiceLineList.forEach(invoiceLine -> {
+                BigDecimal amount = isTaxIncluded ? invoiceLine.getLineTotalAmt() : invoiceLine.getLineNetAmt();
+
+                lineTotalAmt.getAndUpdate(newAmount -> newAmount.add(amount));
+                if (maybeProductId.get() <= 0) {
+                    maybeProductId.set(invoiceLine.getM_Product_ID());
+                }
+                if (isSameProduct.get()){
+                    if (maybeProductId.get() != invoiceLine.getM_Product_ID()) {
+                        isSameProduct.set(false);
+                    }
+                }
+            });
+            summary.setC_Invoice_ID(invoice.get_ID());
+            summary.setSeqNo(seqNo.addAndGet(10));
+            if (isSameProduct.get()) {
+                MProduct product = new MProduct(invoice.getCtx(), maybeProductId.get(), invoice.get_TrxName());
+                String productValue = product.getValue();
+                summary.setValue(Util.isEmpty(productValue) ? productValue : product.getUPC());
+                summary.setSP013_ElectronicProductType(Util.isEmpty(productValue)
+                        ? X_SP013_ElectronicLineSummary.SP013_ELECTRONICPRODUCTTYPE_EANCode
+                        : X_SP013_ElectronicLineSummary.SP013_ELECTRONICPRODUCTTYPE_InternalCode);
+            }
+            summary.setQty(Env.ONE);
+            summary.setPriceEntered(lineTotalAmt.get());
+            summary.setLineTotalAmt(lineTotalAmt.get());
+            summary.setDescription(groupDescription.get(key));
+
+
+            summary.setC_Tax_ID(invoiceLineList.get(0).getC_Tax_ID());
+            summary.saveEx();
+
+        });
+    }
+
+    private void updateLineGroupStorage(String key, MInvoiceLine invoiceLine) {
+        List<MInvoiceLine> invoiceLineGroup = invoiceLineGroups.getOrDefault(key, new ArrayList<>());
+        if (invoiceLineGroup.isEmpty()){
+            invoiceLineGroups.put(key, invoiceLineGroup);
+        }
+        invoiceLineGroup.add(invoiceLine);
+
+    }
+}


### PR DESCRIPTION
Before it was setting the value 2 times, instead it sets the value and the ProductType
When processing Delete the existing Summary Line so it does not make duplicates

For Sending Summary Lines to Invoicy
 * Sets the Value, Name and Description from the summary line, not from the Product or Charge because they can be null
 * Only try to set the Info from Product or Charge if the Info is Null
 * Description is only set from the Summary Line, not from product

### Additional Context
Ref: https://github.com/solop-develop/adempiere-solop/issues/1019