### PR TITLE
Add bankStatmenteLoader Classes so it loads the modified classes

### DIFF
--- a/src/patches/org/openup/core/utils/BBVA_BankStatementLoader.java
+++ b/src/patches/org/openup/core/utils/BBVA_BankStatementLoader.java
@@ -1,0 +1,16 @@
+package org.openup.core.utils;
+
+import org.spin.util.impexp.BankStatementHandler;
+import org.spin.util.impexp.BankTransactionAbstract;
+
+/**
+ * Created by nicolas on 05/02/2020.
+ */
+public class BBVA_BankStatementLoader extends BankStatementHandler {
+
+    @Override
+    protected BankTransactionAbstract getBankTransactionInstance() {
+        return new BBVA_BankTransaction();
+    }
+
+}

--- a/src/patches/org/openup/core/utils/HSBC_BankStatementLoader.java
+++ b/src/patches/org/openup/core/utils/HSBC_BankStatementLoader.java
@@ -1,0 +1,16 @@
+package org.openup.core.utils;
+
+import org.spin.util.impexp.BankStatementHandler;
+import org.spin.util.impexp.BankTransactionAbstract;
+
+/**
+ * Created by nicolas on 05/02/2020.
+ */
+public class HSBC_BankStatementLoader extends BankStatementHandler {
+
+    @Override
+    protected BankTransactionAbstract getBankTransactionInstance() {
+        return new HSBC_BankTransaction();
+    }
+
+}


### PR DESCRIPTION
there are no code changes, only used so it calls the patched classes instead of the original classes
### Additional Context
fixes: https://github.com/solop-develop/adempiere-solop/issues/2344