### PR TITLE
Allow creating Payment Processor Batch Lines manually

### DIFF
--- a/src/patches/org/compiere/model/MPPBatchLine.java
+++ b/src/patches/org/compiere/model/MPPBatchLine.java
@@ -1,0 +1,37 @@
+package org.compiere.model;
+import org.adempiere.core.domains.models.X_C_PPBatchLine;
+
+import java.sql.ResultSet;
+import java.util.Properties;
+
+/**
+ *  @author Yamel Senih, yamel.senih@solopsoftware.com, Solop <a href="http://www.solopsoftware.com">solopsoftware.com</a>
+ *	<a href="https://github.com/solop-develop/adempiere-base/issues/338">https://github.com/solop-develop/adempiere-base/issues/338</a>
+ */
+public class MPPBatchLine extends X_C_PPBatchLine {
+
+    public MPPBatchLine(Properties ctx, int C_PPBatchLine_ID, String trxName) {
+        super(ctx, C_PPBatchLine_ID, trxName);
+    }
+
+    public MPPBatchLine(Properties ctx, ResultSet rs, String trxName) {
+        super(ctx, rs, trxName);
+    }
+
+    @Override
+    protected boolean beforeSave(boolean newRecord) {
+        setTotalAmt(getPayAmt().subtract(getDiscountAmt().add(getTaxAmt()).add(getFeeAmt())));
+        if (getWithdrawal_ID() <= 0) {
+            MPaymentProcessorBatch batch = new MPaymentProcessorBatch(getCtx(), getC_PaymentProcessorBatch_ID(), get_TrxName());
+            batch.updateTotals();
+        }
+        return super.beforeSave(newRecord);
+    }
+
+    @Override
+    protected boolean afterDelete(boolean success) {
+        MPaymentProcessorBatch batch = new MPaymentProcessorBatch(getCtx(), getC_PaymentProcessorBatch_ID(), get_TrxName());
+        batch.updateTotals();
+        return super.afterDelete(success);
+    }
+}


### PR DESCRIPTION

<img width="1571" height="541" alt="imagen" src="https://github.com/user-attachments/assets/16b4743b-1b3f-48e9-b9a9-fec4477894f1" />

### Additional Context
fixes: https://github.com/solop-develop/adempiere-solop/issues/2224