### PR TITLE
Add support for new Product_PO current Vendor by Org Validation

### DIFF
--- a/src/patches/org/adempiere/engine/CostEngine.java
+++ b/src/patches/org/adempiere/engine/CostEngine.java
@@ -1,0 +1,841 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * Copyright (C) 2003-2007 e-Evolution,SC. All Rights Reserved.               *
+ * Contributor(s): victor.perez@e-evolution.com http://www.e-evolution.com    *
+ *****************************************************************************/
+
+package org.adempiere.engine;
+
+import org.adempiere.core.domains.models.I_C_InvoiceLine;
+import org.adempiere.core.domains.models.I_C_OrderLine;
+import org.adempiere.core.domains.models.I_C_ProjectIssue;
+import org.adempiere.core.domains.models.I_M_CostElement;
+import org.adempiere.core.domains.models.I_M_CostType;
+import org.adempiere.core.domains.models.I_M_InOut;
+import org.adempiere.core.domains.models.I_M_Inventory;
+import org.adempiere.core.domains.models.I_M_MatchInv;
+import org.adempiere.core.domains.models.I_M_MatchPO;
+import org.adempiere.core.domains.models.I_M_Movement;
+import org.adempiere.core.domains.models.I_M_Product;
+import org.adempiere.core.domains.models.I_M_Production;
+import org.adempiere.core.domains.models.I_M_Transaction;
+import org.adempiere.core.domains.models.I_PP_Cost_Collector;
+import org.adempiere.core.domains.models.X_M_Product;
+import org.adempiere.core.domains.models.X_PP_Cost_Collector;
+import org.compiere.model.MAcctSchema;
+import org.compiere.model.MClient;
+import org.compiere.model.MConversionRate;
+import org.compiere.model.MConversionType;
+import org.compiere.model.MCost;
+import org.compiere.model.MCostDetail;
+import org.compiere.model.MCostElement;
+import org.compiere.model.MCostType;
+import org.compiere.model.MDocType;
+import org.compiere.model.MInOutLine;
+import org.compiere.model.MInventoryLine;
+import org.compiere.model.MLandedCostAllocation;
+import org.compiere.model.MMatchInv;
+import org.compiere.model.MMatchPO;
+import org.compiere.model.MMovementLine;
+import org.compiere.model.MPeriod;
+import org.compiere.model.MPeriodControl;
+import org.compiere.model.MProduct;
+import org.compiere.model.MProductCategoryAcct;
+import org.compiere.model.MProductPO;
+import org.compiere.model.MProduction;
+import org.compiere.model.MProductionLine;
+import org.compiere.model.MProjectIssue;
+import org.compiere.model.MTransaction;
+import org.compiere.model.PO;
+import org.compiere.model.Query;
+import org.compiere.util.CLogger;
+import org.compiere.util.DB;
+import org.compiere.util.Env;
+import org.compiere.util.Util;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
+
+
+/**
+ * Cost Engine
+ * 
+ * @author victor.perez@e-evolution.com http://www.e-evolution.com
+ * 
+ */
+public class CostEngine {
+	/** Logger */
+	protected transient CLogger log = CLogger.getCLogger(getClass());
+
+    /** AD_Table_ID's of documents          */
+    public final static int[]  documentsTableID = {
+            I_M_InOut.Table_ID,
+            I_M_Inventory.Table_ID,
+            I_M_Movement.Table_ID,
+            I_M_Product.Table_ID,
+            I_C_ProjectIssue.Table_ID,
+            I_PP_Cost_Collector.Table_ID,
+            I_M_MatchPO.Table_ID,
+            I_M_MatchInv.Table_ID};
+
+    /** Table Names of documents          */
+    public final static String[]  documentsTableName = {
+            I_M_InOut.Table_Name,
+            I_M_Inventory.Table_Name,
+            I_M_Movement.Table_Name,
+            I_M_Production.Table_Name,
+            I_C_ProjectIssue.Table_Name,
+            I_PP_Cost_Collector.Table_Name,
+            I_M_MatchPO.Table_Name,
+            I_M_MatchInv.Table_Name};
+
+    /**
+     * get seed cost
+     * @param context
+     * @param productId
+     * @param trxName
+     * @return
+     */
+	public static BigDecimal getSeedCost(Properties context , int  productId , int orgId, String trxName)
+	{
+		BigDecimal costThisLevel = Env.ZERO;
+		for (MProductPO productPO : MProductPO.getOfProductAndOrg(context,productId, orgId, trxName))
+		 {
+			 if (productPO.isCurrentVendor())
+			 { 
+				 if (productPO.getPriceLastInv().signum() != 0)
+					 costThisLevel = productPO.getPriceLastInv();
+				 else if (productPO.getPriceLastPO().signum() != 0) 
+					 costThisLevel = productPO.getPriceLastPO();
+				 else if  (productPO.getPricePO().signum() != 0) 
+					 costThisLevel = productPO.getPricePO();
+				 else 
+					 costThisLevel = productPO.getPriceList();
+				 return costThisLevel;
+			 } 
+		 }
+		return costThisLevel;
+	}
+
+    /**
+     *  Get Actual Cost of Parent Product Based on Cost Type
+     * @param accountSchema
+     * @param costTypeId
+     * @param costElementId
+     * @param costCollector
+     * @return
+     */
+	public static BigDecimal getParentActualCostByCostType(MAcctSchema accountSchema, int costTypeId, int costElementId, X_PP_Cost_Collector costCollector) {
+		StringBuffer whereClause = new StringBuffer()
+		.append(MCostDetail.COLUMNNAME_C_AcctSchema_ID).append("=? AND ")
+		.append(MCostDetail.COLUMNNAME_M_CostType_ID + "=? AND ")
+		.append(MCostDetail.COLUMNNAME_M_CostElement_ID + "=? AND ")
+		.append(MCostDetail.COLUMNNAME_PP_Cost_Collector_ID)
+		.append(" IN (SELECT PP_Cost_Collector_ID FROM PP_Cost_Collector cc WHERE cc.PP_Order_ID=? AND ")
+		.append(" cc.CostCollectorType <> '").append(X_PP_Cost_Collector.COSTCOLLECTORTYPE_MaterialReceipt).append("')");
+
+		List<MCostDetail> componentsIssue= new Query(costCollector.getCtx(), MCostDetail.Table_Name, whereClause.toString(), costCollector.get_TrxName())
+				.setClient_ID()
+				.setParameters(accountSchema.getC_AcctSchema_ID() , costTypeId, costElementId, costCollector.getPP_Order_ID())
+				.list();
+
+		AtomicReference<BigDecimal> actualCostReference = new AtomicReference(BigDecimal.ZERO);
+		componentsIssue.stream().forEach( costDetail ->{
+			if (costDetail.getQty().signum() < 0)
+				actualCostReference.updateAndGet(cost -> cost.subtract(costDetail.getAmt().add(costDetail.getAmtLL())));
+			else
+				actualCostReference.updateAndGet(cost -> cost.add(costDetail.getAmt().add(costDetail.getAmtLL())));
+
+		});
+
+		BigDecimal actualCost = actualCostReference.get();
+		whereClause = new StringBuffer();
+		whereClause
+				.append(" EXISTS (SELECT 1 FROM PP_Cost_Collector cc ")
+				.append(" WHERE PP_Cost_Collector_ID=M_Transaction.PP_Cost_Collector_ID AND cc.PP_Order_ID=? AND cc.M_Product_ID=? )");
+		BigDecimal qtyDelivered = new Query(costCollector.getCtx(), I_M_Transaction.Table_Name, whereClause.toString(), costCollector.get_TrxName())
+				.setClient_ID()
+				.setParameters(costCollector.getPP_Order_ID(), costCollector.getM_Product_ID())
+				.sum(MTransaction.COLUMNNAME_MovementQty);
+
+		if (actualCost == null)
+			actualCost = Env.ZERO;
+
+		if (qtyDelivered.signum() != 0)
+			actualCost = actualCost.divide(qtyDelivered,
+					accountSchema.getCostingPrecision(), RoundingMode.HALF_DOWN);
+		int conversionTypeId = MConversionType.getDefault(costCollector.getAD_Client_ID());
+		MClient client  = MClient.get(costCollector.getCtx());
+		int currencyId = client.getC_Currency_ID();
+		BigDecimal rate = MConversionRate.getRate(
+				currencyId, currencyId,
+				costCollector.getDateAcct(), conversionTypeId,
+				costCollector.getAD_Client_ID(), costCollector.getAD_Org_ID());
+		if (rate != null) {
+			actualCost = actualCost.multiply(rate);
+			if (actualCost.scale() > accountSchema.getCostingPrecision())
+				actualCost = actualCost.setScale(accountSchema.getCostingPrecision(), RoundingMode.HALF_UP);
+		}
+
+		return actualCost;
+	}
+
+	public static BigDecimal getParentActualCostByCostType(MAcctSchema accountSchema, MCostType costType,
+			MCostElement costElement, I_M_Production production) {
+		//	Get BOM Cost - Sum of individual lines
+		BigDecimal totalCost = Env.ZERO;
+		for (MProductionLine productionLine : ((MProduction)production).getLines())
+		{
+			if (productionLine.isParent())
+				continue;
+
+			String productType = productionLine.getM_Product().getProductType();
+
+			BigDecimal cost = BigDecimal.ZERO;
+
+			if (X_M_Product.PRODUCTTYPE_Item.equals(productType)) {
+				cost = MCostDetail.getCostByModel(accountSchema.getC_AcctSchema_ID(), costType.getM_CostType_ID() , costElement.getM_CostElement_ID() , productionLine);
+			}
+			else if(X_M_Product.PRODUCTTYPE_Resource.equals(productType))
+			{
+				MCost costDimension = MCost.validateCostForCostType(accountSchema, costType, costElement,
+						productionLine.getM_Product_ID(), productionLine.getAD_Org_ID(), productionLine.getM_Locator().getM_Warehouse_ID(),
+						productionLine.getM_AttributeSetInstance_ID(), productionLine.get_TrxName());
+
+				if (costDimension != null && costDimension.getCurrentCostPrice().signum() != 0 )
+					cost = costDimension.getCurrentCostPrice().multiply(productionLine.getMovementQty().negate());
+			}
+
+
+			if (cost != null && cost.signum() != 0)
+				totalCost = totalCost.add(cost);
+
+		}
+
+		BigDecimal unitCost = Env.ZERO;
+		if (production.getProductionQty().signum() != 0 && totalCost.signum() != 0)
+			unitCost = totalCost.divide(production.getProductionQty(), accountSchema.getCostingPrecision(), RoundingMode.HALF_UP);
+
+		return unitCost;
+	}
+
+	public static BigDecimal roundCost(BigDecimal price, int accountSchemaId) {
+		// Fix Cost Precision
+		int precision = MAcctSchema.get(Env.getCtx(), accountSchemaId)
+				.getCostingPrecision();
+		BigDecimal priceRounded = price;
+		if (priceRounded.scale() > precision) {
+			priceRounded = priceRounded.setScale(precision,
+					RoundingMode.HALF_UP);
+		}
+		return priceRounded;
+	}
+
+	/**
+	 * Generate by transaction
+	 * @param transaction
+	 */
+	public void createCostDetail(MTransaction transaction, IDocumentLine model) {
+
+		StringBuilder description = new StringBuilder();
+		if (model != null && model.getDescription() != null && !Util.isEmpty(model.getDescription(), true))
+			description.append(model.getDescription());
+		if (model != null) {
+			description.append(model.isSOTrx() ? "(|->)" : "(|<-)");
+		}
+
+		List<MAcctSchema> acctSchemas = new ArrayList(Arrays.asList(MAcctSchema
+				.getClientAcctSchema(transaction.getCtx(), transaction.getAD_Client_ID(),
+						transaction.get_TrxName())));
+
+		List<MCostElement> costElements = MCostElement.getCostElement(transaction.getCtx(),
+				transaction.get_TrxName());
+		List<MCostType> costTypes = MCostType.get(transaction.getCtx(), transaction.get_TrxName());
+		for (MAcctSchema accountSchema : acctSchemas) {
+			for (MCostType costType : costTypes) {
+				if (!costType.isActive())
+					continue;
+				for (MCostElement costElement : costElements) {
+					createCostDetail(accountSchema, costType, costElement, transaction, model, true);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Create Cost Detail
+	 * @param accountSchema Account Schema
+	 * @param transaction Material Transaction
+	 * @param model IDocumentLine
+	 * @param costType Cost Type
+	 * @param costElement Cost Element
+	 */
+	public void createCostDetail(MAcctSchema accountSchema,MCostType costType, MCostElement costElement, MTransaction transaction , IDocumentLine model, boolean force) {
+
+		if (!force)
+			return;
+		
+		BigDecimal costThisLevel = Env.ZERO;
+		BigDecimal costLowLevel = Env.ZERO;
+		String costingLevel = MProduct.get(transaction.getCtx(),
+				transaction.getM_Product_ID()).getCostingLevel(accountSchema,
+				transaction.getAD_Org_ID());
+		
+		// The Change of price in the Invoice Line is not generated cost
+		// adjustment for Average PO Costing method
+		if (model instanceof MMatchInv
+				&& MCostType.COSTINGMETHOD_AveragePO.equals(costType
+                .getCostingMethod()))
+			return;
+
+		// The Change of price in the Invoice Line is not generated cost
+		// adjustment for Average PO Costing method
+		if (model instanceof MMatchPO
+				&& MCostType.COSTINGMETHOD_AverageInvoice.equals(costType
+						.getCostingMethod()))
+			return;
+
+		if (model instanceof MLandedCostAllocation) {
+			MLandedCostAllocation allocation = (MLandedCostAllocation) model;
+			costThisLevel = convertCostToSchemaCurrency(accountSchema, model , model.getPriceActualCurrency());
+		}
+
+		MCost cost = MCost.validateCostForCostType(accountSchema, costType, costElement,
+				transaction.getM_Product_ID(), transaction.getAD_Org_ID(), transaction.getM_Warehouse_ID(),
+				transaction.getM_AttributeSetInstance_ID(), transaction.get_TrxName());
+
+		// get the cost for positive transaction
+		if ((MCostElement.COSTELEMENTTYPE_Material.equals(costElement
+				.getCostElementType()) || MCostElement.COSTELEMENTTYPE_LandedCost
+				.equals(costElement.getCostElementType()))
+				&& transaction.getMovementType().contains("+")
+				&& !MCostType.COSTINGMETHOD_StandardCosting.equals(costType
+						.getCostingMethod())) {
+			if 
+			(	model instanceof MMovementLine
+			||  model instanceof MInventoryLine
+			|| (model instanceof MInOutLine && MTransaction.MOVEMENTTYPE_CustomerReturns.equals(transaction.getMovementType()))
+			) 
+			{				
+				costThisLevel = getCostThisLevel(accountSchema, costType, costElement, transaction, model, costingLevel);
+				costLowLevel = getCostLowLevel(accountSchema, costType, costElement, transaction, model, costingLevel);
+				if (model instanceof MInventoryLine) {
+					MInventoryLine inventoryLine = (MInventoryLine) model;
+					// If cost this level is zero and is a physical inventory then
+					// try get cost from physical inventory
+					if (MCostElement.COSTELEMENTTYPE_Material.equals(costElement.getCostElementType())) {
+						// Use the current cost only for Physical Inventory
+						if (inventoryLine.getQtyInternalUse().signum() == 0 &&
+								inventoryLine.getCurrentCostPrice() != null &&
+								inventoryLine.getCurrentCostPrice().signum() > 0) {
+							costThisLevel = convertCostToSchemaCurrency(accountSchema, model, model.getPriceActualCurrency());
+						}
+						if (costThisLevel.signum() == 0)
+							costThisLevel = getCostThisLevel(accountSchema, costType, costElement, transaction, model, costingLevel);
+					}
+
+					// If cost Low level is zero and is a physical inventory then
+					// try get cost low level from physical inventory
+					if (costLowLevel.signum() == 0 && MCostElement.COSTELEMENTTYPE_Material.equals(costElement.getCostElementType())) {
+						// Use the current cost only for Physical Inventory
+						if (inventoryLine.getQtyInternalUse().signum() == 0 &&
+								inventoryLine.getCurrentCostPriceLL() != null &&
+								inventoryLine.getCurrentCostPriceLL().signum() > 0) {
+							costLowLevel = convertCostToSchemaCurrency(accountSchema, model, inventoryLine.getCurrentCostPriceLL());
+						}
+						if (costLowLevel.signum() == 0)
+							costLowLevel = getCostLowLevel(accountSchema, costType, costElement, transaction, model, costingLevel);
+					}
+				}
+
+
+				//Get cost from movement from if it > that zero replace cost This Level
+				if (model instanceof MMovementLine) {
+					MTransaction transactionFrom = MTransaction.getByDocumentLine(model, MTransaction.MOVEMENTTYPE_MovementFrom);
+					BigDecimal costMovementFrom = getCostThisLevel(accountSchema, costType, costElement, transactionFrom == null ? transaction : transactionFrom, model,costingLevel);
+					if (costMovementFrom.signum() > 0 )
+						costThisLevel = costMovementFrom;
+
+					BigDecimal costMovementFromLL = getCostLowLevel(accountSchema, costType, costElement, transactionFrom == null ? transaction : transactionFrom, model,costingLevel);
+					if (costMovementFromLL.signum() > 0 )
+						costLowLevel = costMovementFromLL;
+				}
+			} else if (MCostElement.COSTELEMENTTYPE_Material.equals(costElement.getCostElementType())) {
+					costThisLevel = convertCostToSchemaCurrency(accountSchema , model , model.getPriceActualCurrency());
+			}
+		}else if ((MCostElement.COSTELEMENTTYPE_Material.equals(costElement
+				.getCostElementType()))
+				&& transaction.getMovementType().equals(MTransaction.MOVEMENTTYPE_VendorReturns)
+				&& !MCostType.COSTINGMETHOD_StandardCosting.equals(costType
+						.getCostingMethod())) {
+			costThisLevel = convertCostToSchemaCurrency(accountSchema , model , model.getPriceActualCurrency());
+		}
+
+		if (!MCostType.COSTINGMETHOD_StandardCosting.equals(costType.getCostingMethod())) {
+			if(model.get_TableName().equals(I_PP_Cost_Collector.Table_Name)) {
+				X_PP_Cost_Collector costCollector = (X_PP_Cost_Collector) model;
+				if (X_PP_Cost_Collector.COSTCOLLECTORTYPE_MaterialReceipt.equals(costCollector.getCostCollectorType())) {
+					// get Actual Cost for Cost Type and Cost Element
+					costThisLevel = getCostThisLevel(accountSchema, costType, costElement, transaction, model, costingLevel);
+					costLowLevel = CostEngine.getParentActualCostByCostType(accountSchema, costType.getM_CostType_ID(), costElement.getM_CostElement_ID(), costCollector);
+				} 
+			}
+			if (model instanceof MProductionLine) {
+				
+				MProductionLine productionLine = (MProductionLine) model;
+				if (productionLine.isParent())
+						costThisLevel = CostEngine.getParentActualCostByCostType(
+								accountSchema, costType, costElement, productionLine.getM_Production());
+				
+				if(costThisLevel.signum() == 0)
+					costThisLevel = cost.getCurrentCostPrice();
+					if(costThisLevel.signum() == 0 
+					&& MCostElement.COSTELEMENTTYPE_Material.equals(costElement
+							.getCostElementType()))
+						costThisLevel = getSeedCost(
+                                transaction.getCtx(),
+                                transaction.getM_Product_ID(),
+								transaction.getAD_Org_ID(),
+                                transaction.get_TrxName());
+						
+				// Material Receipt for Production light
+				if (productionLine.isParent()) {
+					// get Actual Cost for Cost Type and Cost Element
+					// if the product is purchase then no use low level 
+					if (!productionLine.getM_Product().isPurchased())
+					{	
+						costLowLevel  = costThisLevel;
+						costThisLevel = Env.ZERO;
+					} 
+				} else if ( productionLine.getMovementQty().signum() < 0)
+					costLowLevel= Env.ZERO;
+			}
+		}
+        else if (MCostType.COSTINGMETHOD_StandardCosting.equals(costType.getCostingMethod())){
+			costThisLevel = cost.getCurrentCostPrice();
+			costLowLevel = cost.getCurrentCostPriceLL();
+			//Define Cost Inventory Line
+			if (model instanceof MInventoryLine) {
+				MInventoryLine inventoryLine = (MInventoryLine) model;
+				//Define Current Cost Level
+				if (costThisLevel.signum() == 0 && MCostElement.COSTELEMENTTYPE_Material.equals(costElement.getCostElementType())) {
+					// Use the current cost only for Physical Inventory
+					if (inventoryLine.getQtyInternalUse().signum() == 0 &&
+							inventoryLine.getCurrentCostPrice() != null &&
+							inventoryLine.getCurrentCostPrice().signum() > 0) {
+						costThisLevel = convertCostToSchemaCurrency(accountSchema, model, model.getPriceActualCurrency());
+						cost.setCurrentCostPrice(costThisLevel);
+						cost.saveEx();
+					}
+
+					if (costThisLevel.signum() == 0)
+						costThisLevel = getCostThisLevel(accountSchema, costType, costElement, transaction, model, costingLevel);
+				}
+				//Define Current Cost Low Level
+				if (costLowLevel.signum() == 0 && MCostElement.COSTELEMENTTYPE_Material.equals(costElement.getCostElementType())) {
+					// Use the cost only for Physical Inventory
+					if (inventoryLine.getQtyInternalUse().signum() == 0 &&
+							inventoryLine.getCurrentCostPriceLL() != null &&
+							inventoryLine.getCurrentCostPriceLL().signum() > 0) {
+						costLowLevel = convertCostToSchemaCurrency(accountSchema, model, inventoryLine.getCurrentCostPriceLL());
+
+						cost.setCurrentCostPriceLL(costLowLevel);
+						cost.saveEx();
+					}
+
+					if (costLowLevel.signum() == 0)
+						costLowLevel = getCostLowLevel(accountSchema, costType, costElement, transaction, model, costingLevel);
+				}
+			}
+
+			if (model instanceof  MMovementLine) {
+				MTransaction transactionFrom = MTransaction.getByDocumentLine(model, MTransaction.MOVEMENTTYPE_MovementFrom);
+				BigDecimal costMovementFrom = getCostThisLevel(accountSchema, costType, costElement, transactionFrom == null ? transaction : transactionFrom, model, costingLevel);
+				if (costThisLevel.signum() == 0 && MCostElement.COSTELEMENTTYPE_Material.equals(costElement.getCostElementType())) {
+					if (costMovementFrom.signum() > 0)
+						costThisLevel = costMovementFrom;
+				}
+				if (costLowLevel.signum() == 0 && MCostElement.COSTELEMENTTYPE_Material.equals(costElement.getCostElementType())) {
+					BigDecimal costMovementFromLL = getCostLowLevel(accountSchema, costType, costElement, transactionFrom == null ? transaction : transactionFrom, model, costingLevel);
+					if (costMovementFromLL.signum() > 0)
+						costLowLevel = costMovementFromLL;
+				}
+			}
+
+            if (costThisLevel.signum() == 0 &&  MCostElement.COSTELEMENTTYPE_Material.equals(costElement.getCostElementType())) {
+                costThisLevel = getSeedCost(transaction.getCtx(), transaction.getM_Product_ID(), transaction.getAD_Org_ID(), transaction.get_TrxName());
+                if (costThisLevel.signum() == 0)
+                    if (model instanceof  MInOutLine && !model.isSOTrx()) {
+							costThisLevel = convertCostToSchemaCurrency(accountSchema , model , model.getPriceActualCurrency());
+                    }
+                if (costThisLevel.signum() != 0) {
+                    cost.setCurrentCostPrice(costThisLevel);
+                    cost.saveEx();
+                }
+            }
+
+			if (costLowLevel.signum() != 0) {
+				cost.setCurrentCostPriceLL(costLowLevel);
+				cost.saveEx();
+			}
+        }
+
+		final ICostingMethod method = CostingMethodFactory.get()
+				.getCostingMethod(costType.getCostingMethod());
+		method.setCostingMethod(accountSchema, transaction, model, cost, costThisLevel,
+				costLowLevel, model.isSOTrx());
+        method.process();
+	}
+
+
+	/**
+	 * Convert Cost To Schema Currency
+	 * @param acctSchema
+	 * @param model
+	 * @param cost
+	 * @return
+	 */
+	private BigDecimal convertCostToSchemaCurrency(MAcctSchema acctSchema , IDocumentLine model , BigDecimal cost)
+	{
+		BigDecimal costThisLevel = BigDecimal.ZERO;
+		BigDecimal rate = MConversionRate.getRate(
+				model.getC_Currency_ID(), acctSchema.getC_Currency_ID() ,
+				model.getDateAcct(), model.getC_ConversionType_ID() ,
+				model.getAD_Client_ID(), model.getAD_Org_ID());
+		if (rate != null) {
+			if (rate.compareTo(BigDecimal.ONE) == 0)
+				costThisLevel = cost;
+			else {
+				costThisLevel = cost.multiply(rate);
+				if (costThisLevel.scale() > acctSchema.getCostingPrecision())
+					costThisLevel = costThisLevel.setScale(acctSchema.getCostingPrecision(), BigDecimal.ROUND_HALF_UP);
+			}
+		}
+		return costThisLevel;
+	}
+
+	//Create cost detail for by document
+	public void createCostDetailForLandedCostAllocation(
+			MLandedCostAllocation allocation) {
+		MInOutLine ioLine = (MInOutLine) allocation.getM_InOutLine();
+		
+		for (MTransaction transaction : MTransaction.getByInOutLine(ioLine)) {
+			for (MAcctSchema accountSchema : MAcctSchema.getClientAcctSchema(
+					allocation.getCtx(), allocation.getAD_Client_ID())) {
+				List<MCostType> costTypes = MCostType.get(allocation.getCtx(),
+						allocation.get_TrxName());
+
+				for (MCostType costType : costTypes) {
+					MCostElement costElement = (MCostElement) allocation
+							.getM_CostElement();
+					CostEngineFactory.getCostEngine(
+							allocation.getAD_Client_ID()).createCostDetail(accountSchema, costType, costElement, transaction, allocation, true);
+				}
+			}
+		}
+	}
+
+	public static boolean isActivityControlElement(I_M_CostElement element) {
+		String costElementType = element.getCostElementType();
+		return MCostElement.COSTELEMENTTYPE_Resource.equals(costElementType)
+				|| MCostElement.COSTELEMENTTYPE_Overhead.equals(costElementType)
+				|| MCostElement.COSTELEMENTTYPE_BurdenMOverhead.equals(costElementType)
+				|| MCostElement.COSTELEMENTTYPE_OutsideProcessing.equals(costElementType);
+	}
+
+	public static List<MAcctSchema> getAcctSchema(PO po) {
+		int AD_Org_ID = po.getAD_Org_ID();
+		MAcctSchema[] ass = MAcctSchema.getClientAcctSchema(po.getCtx(),
+				po.getAD_Client_ID());
+		ArrayList<MAcctSchema> list = new ArrayList<MAcctSchema>(ass.length);
+		for (MAcctSchema as : ass) {
+			if (!as.isSkipOrg(AD_Org_ID))
+				list.add(as);
+		}
+		return list;
+	}
+
+	static public String getIDColumnName(IDocumentLine model) {
+		String idColumnName = model.get_TableName() + "_ID";
+		if (model instanceof MMatchPO) {
+			idColumnName = I_C_OrderLine.COLUMNNAME_C_OrderLine_ID;
+		}
+		if (model instanceof MMatchInv) {
+			idColumnName = I_C_InvoiceLine.COLUMNNAME_C_InvoiceLine_ID;
+		}
+		return idColumnName;
+	}
+
+	static public int getIDColumn(IDocumentLine model) {
+		int id = model.get_ID();
+
+		if (model instanceof MMatchPO) {
+			id = ((MMatchPO) model).getC_OrderLine_ID();
+		}
+		if (model instanceof MMatchInv) {
+			id = ((MMatchInv) model).getC_InvoiceLine_ID();
+		}
+		return id;
+	}
+
+
+    /**
+     * get cost this level
+     * @param accountSchema
+     * @param costType
+     * @param costElement
+     * @param transaction
+     * @param model
+     * @param costingLevel
+     * @return
+     */
+	public static BigDecimal getCostThisLevel(MAcctSchema accountSchema, I_M_CostType costType, I_M_CostElement costElement, MTransaction transaction,
+                                              IDocumentLine model,
+                                              String costingLevel) {
+		BigDecimal costThisLevel = Env.ZERO;
+		MCostDetail lastCostDetail = MCostDetail.getLastTransaction(model,
+                transaction, accountSchema.getC_AcctSchema_ID(), costType.getM_CostType_ID(),
+                costElement.getM_CostElement_ID(), model.getDateAcct(), costingLevel);
+		if (lastCostDetail != null) {
+			
+				// Return of unit cost from last transaction 
+				// transaction quantity is different of zero
+				// then cost this level is equal that:
+				// (Total Cost transaction + cost adjustments) divide by transaction quantity
+				if (lastCostDetail.getQty().signum() != 0)
+				{
+					costThisLevel =  lastCostDetail.getCostAmt().add(
+							lastCostDetail.getCostAdjustment())
+							.divide(lastCostDetail.getQty(), accountSchema.getCostingPrecision(), RoundingMode.HALF_UP)
+							.abs();
+					if (lastCostDetail.getCurrentCostPrice().signum() != 0)
+						costThisLevel = costThisLevel.multiply(BigDecimal.valueOf(lastCostDetail.getCurrentCostPrice().signum()));
+				}
+				// return unit cost from last transaction
+				// transaction quantity is zero
+				// the cost this level is equal that:
+				// (Total Cost Transaction + cost adjustments + accumulate cost) divide between on hand quantity 
+				else if (lastCostDetail.getCumulatedQty().add( lastCostDetail.getQty()).signum() != 0)
+				{
+					costThisLevel =  lastCostDetail.getCostAmt().add(
+									 lastCostDetail.getCostAdjustment()).add(
+									 lastCostDetail.getCumulatedAmt())
+							.divide(
+									lastCostDetail.getCumulatedQty().add( lastCostDetail.getQty()),
+									accountSchema.getCostingPrecision(),
+									RoundingMode.HALF_UP
+							)
+							.abs();
+					
+					return costThisLevel;
+				}	
+				// Return of unit cost from inventory value
+				// Cumulated quantity is different of zero 
+				// then cost this level is equal that:
+				// (Total Cost transaction + cost adjustments + Cumulated amount) divide by On hand Quantity
+				else if (lastCostDetail.getCumulatedQty().signum() != 0)
+				{
+					costThisLevel = lastCostDetail.getCumulatedAmt()
+							.divide(
+									lastCostDetail.getCumulatedQty(),
+									accountSchema.getCostingPrecision(),
+									RoundingMode.HALF_UP
+							)
+							.abs();
+
+					return costThisLevel;
+				}	
+				
+			}
+
+		return costThisLevel;
+	}
+
+	/**
+	 * get cost this level
+	 * @param accountSchema
+	 * @param costType
+	 * @param costElement
+	 * @param transaction
+	 * @param model
+	 * @param costingLevel
+	 * @return
+	 */
+	public static BigDecimal getCostLowLevel(MAcctSchema accountSchema, I_M_CostType costType, I_M_CostElement costElement, MTransaction transaction,
+											  IDocumentLine model,
+											  String costingLevel) {
+		BigDecimal costLowLevel = Env.ZERO;
+		MCostDetail lastCostDetail = MCostDetail.getLastTransaction(model,
+				transaction, accountSchema.getC_AcctSchema_ID(), costType.getM_CostType_ID(),
+				costElement.getM_CostElement_ID(), model.getDateAcct(), costingLevel);
+		if (lastCostDetail != null) {
+
+			// Return of unit cost from last transaction
+			// transaction quantity is different of zero
+			// then cost this level is equal that:
+			// (Total Cost transaction + cost adjustments) divide by transaction quantity
+			if (lastCostDetail.getQty().signum() != 0)
+			{
+				costLowLevel =  lastCostDetail.getCostAmtLL().add(lastCostDetail.getCostAdjustmentLL())
+						.divide(lastCostDetail.getQty(), accountSchema.getCostingPrecision(), RoundingMode.HALF_UP)
+						.abs();
+			}
+			// return unit cost from last transaction
+			// transaction quantity is zero
+			// the cost this level is equal that:
+			// (Total Cost Transaction + cost adjustments + accumulate cost) divide between on hand quantity
+			else if (lastCostDetail.getCumulatedQty().add( lastCostDetail.getQty()).signum() != 0)
+			{
+				costLowLevel =  lastCostDetail.getCostAmtLL().add(lastCostDetail.getCostAdjustmentLL()).add(lastCostDetail.getCumulatedAmtLL())
+						.divide(
+							lastCostDetail.getCumulatedQty().add(lastCostDetail.getQty()),
+							accountSchema.getCostingPrecision(),
+							RoundingMode.HALF_UP
+						)
+						.abs();
+
+				return costLowLevel;
+			}
+			// Return of unit cost from inventory value
+			// Cumulated quantity is different of zero
+			// then cost this level is equal that:
+			// (Total Cost transaction + cost adjustments + Cumulated amount) divide by On hand Quantity
+			else if (lastCostDetail.getCumulatedQty().signum() != 0)
+			{
+				costLowLevel = lastCostDetail.getCumulatedAmtLL()
+						.divide(lastCostDetail.getCumulatedQty(), accountSchema.getCostingPrecision(), RoundingMode.HALF_UP)
+						.abs();
+				return costLowLevel;
+			}
+
+		}
+
+		return costLowLevel;
+	}
+
+    /**
+     * clear Accounting
+     * @param accountSchema
+     * @param transaction
+     */
+	public void clearAccounting(MAcctSchema accountSchema , MTransaction transaction) {
+
+			if (transaction.getM_InOutLine_ID() > 0) {
+				MInOutLine line = (MInOutLine) transaction.getM_InOutLine();
+				if (!clearAccounting(accountSchema, accountSchema.getM_CostType() , line.getParent() , transaction.getM_Product_ID() , line.getDateAcct()))
+					return;
+
+				// get Purchase matches
+				List<MMatchPO> orderMatches = MMatchPO.getInOutLine(line);
+				for (MMatchPO match : orderMatches) {
+					if (!clearAccounting(accountSchema, accountSchema.getM_CostType() , match,  transaction.getM_Product_ID() , line.getDateAcct()))
+							return;
+				}
+
+				// get invoice matches
+				List<MMatchInv> invoiceMatches = MMatchInv.getInOutLine(line);
+				for (MMatchInv match : invoiceMatches) {
+					if (!clearAccounting(accountSchema, accountSchema.getM_CostType() , match,  transaction.getM_Product_ID() , line.getDateAcct()))
+						return;
+				}
+
+			}
+			else if (transaction.getC_ProjectIssue_ID() > 0) {
+				MProjectIssue line = (MProjectIssue) transaction.getC_ProjectIssue();
+				if (!clearAccounting(accountSchema, accountSchema.getM_CostType() , line,  transaction.getM_Product_ID() , line.getMovementDate()))
+					return;
+			}
+
+			else if (transaction.getM_InventoryLine_ID() > 0) {
+				MInventoryLine line = (MInventoryLine) transaction.getM_InventoryLine();
+				if (!clearAccounting(accountSchema, accountSchema.getM_CostType() , line.getParent(),  transaction.getM_Product_ID() , line.getDateAcct()))
+					return;
+			}
+			else if (transaction.getM_MovementLine_ID() > 0) {
+				MMovementLine line = (MMovementLine) transaction.getM_MovementLine();
+				if (!clearAccounting(accountSchema, accountSchema.getM_CostType() , line.getParent(),  transaction.getM_Product_ID() , line.getDateAcct()))
+					return;
+			}
+			
+			else if (transaction.getM_ProductionLine_ID() > 0) {
+				MProductionLine line = (MProductionLine) transaction.getM_ProductionLine();
+				MProduction production = (MProduction) line.getM_ProductionPlan().getM_Production();
+				if (!clearAccounting(accountSchema, accountSchema.getM_CostType() , production,  transaction.getM_Product_ID()  , production.getMovementDate()))
+					return;
+
+			}
+			else if (transaction.getPP_Cost_Collector_ID() > 0)
+			{
+				X_PP_Cost_Collector costCollector = (X_PP_Cost_Collector) transaction.getPP_Cost_Collector();
+				if(!clearAccounting(accountSchema, accountSchema.getM_CostType() , costCollector , costCollector.getM_Product_ID() , costCollector.getDateAcct()));
+				return;
+			}
+			else
+			{
+				log.info("Document does not exist :" + transaction);
+			}	
+
+	}
+
+    /**
+     * Clear Accounting
+     * @param accountSchema
+     * @param costType
+     * @param model
+	 * @param productId
+     * @param dateAcct
+     * @return true clean
+     */
+	public boolean clearAccounting(MAcctSchema accountSchema, I_M_CostType costType, PO model, int productId , Timestamp dateAcct) {
+		// check if costing type need reset accounting 
+		if (!accountSchema.getCostingMethod().equals(costType.getCostingMethod())) {
+			MProduct product = MProduct.get(accountSchema.getCtx() , productId);
+			MProductCategoryAcct productCategoryAcct = MProductCategoryAcct.get(accountSchema.getCtx(), product.getM_Product_Category_ID(), accountSchema.get_ID(), model.get_TrxName());
+			if (productCategoryAcct == null || !costType.getCostingMethod().equals(productCategoryAcct.getCostingMethod()))
+				return false;
+		}
+		final String  docBaseType;
+		// check if account period is open
+		if(model instanceof MMatchInv)
+			docBaseType = MPeriodControl.DOCBASETYPE_MatchInvoice;
+		else if (model instanceof MMatchPO)
+			docBaseType = MPeriodControl.DOCBASETYPE_MatchPO;
+		else if (model instanceof MProduction)
+			docBaseType = MPeriodControl.DOCBASETYPE_MaterialProduction;
+		else
+		{		
+			MDocType docType = MDocType.get(model.getCtx(), model.get_ValueAsInt(MDocType.COLUMNNAME_C_DocType_ID));
+			docBaseType = docType.getDocBaseType();
+		}
+			
+		Boolean openPeriod = MPeriod.isOpen(model.getCtx(), dateAcct , docBaseType ,  model.getAD_Org_ID());
+		if (!openPeriod)
+		{	
+			System.out.println("Period closed.");
+			return false;
+		}	
+
+		final String sqlUpdate = "UPDATE " + model.get_TableName() + " SET Posted = 'N' WHERE "+ model.get_TableName() + "_ID=?";
+		DB.executeUpdate(sqlUpdate, new Object[] {model.get_ID()}, false , model.get_TrxName());
+		//Delete account
+		final String sqldelete = "DELETE FROM Fact_Acct WHERE Record_ID =? AND AD_Table_ID=?";		
+		DB.executeUpdate (sqldelete ,new Object[] { model.get_ID(), model.get_Table_ID() }, false , model.get_TrxName());
+		return true;
+	}
+}

--- a/src/patches/org/adempiere/production/process/CalculateReplenishPlan.java
+++ b/src/patches/org/adempiere/production/process/CalculateReplenishPlan.java
@@ -1,0 +1,2102 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * Copyright (C) 2016 ADempiere Foundation All Rights Reserved.               *
+ *****************************************************************************/
+
+package org.adempiere.production.process;
+
+import org.adempiere.core.domains.models.I_C_OrderLine;
+import org.adempiere.core.domains.models.I_M_Product_BOM;
+import org.adempiere.core.domains.models.I_M_Production;
+import org.adempiere.core.domains.models.I_M_Replenish;
+import org.adempiere.core.domains.models.X_M_Replenish;
+import org.adempiere.core.domains.models.X_M_ReplenishPlanLine;
+import org.adempiere.exceptions.AdempiereException;
+import org.compiere.model.MOrder;
+import org.compiere.model.MOrderLine;
+import org.compiere.model.MProduct;
+import org.compiere.model.MProductBOM;
+import org.compiere.model.MProductPO;
+import org.compiere.model.MProductPricing;
+import org.compiere.model.MProduction;
+import org.compiere.model.MReplenish;
+import org.compiere.model.MRequisition;
+import org.compiere.model.MRequisitionLine;
+import org.compiere.model.MStorage;
+import org.compiere.model.Query;
+import org.compiere.production.model.MReplenishPlan;
+import org.compiere.util.DB;
+import org.compiere.util.DisplayType;
+import org.compiere.util.Env;
+import org.compiere.util.Msg;
+import org.compiere.util.TimeUtil;
+import org.eevolution.manufacturing.model.MPPProductBOM;
+import org.eevolution.manufacturing.model.MPPProductBOMLine;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.logging.Level;
+
+/**
+ * CalculateReplenishPlan.Java
+ * 
+ * @author hitesh.panchani, www.logilite.com
+ * @author Yamel Senih, ysenih@erpcya.com, ERPCyA http://www.erpcya.com
+ * 		<a href="https://github.com/adempiere/adempiere/issues/789">
+ * 		@see FR [ 789 ] The Calculate Replenish Plan process not support SQL99</a>
+ */
+public class CalculateReplenishPlan extends CalculateReplenishPlanAbstract {
+	private static final String			TYPE_RQ									= "RQ";
+	private static final String			TYPE_PO									= "PO";
+	private static final String			TYPE_MO									= "MO";
+	private int							lineNo									= 10;
+	private int							countProd								= 0;
+	private int							countReq								= 0;
+	private int							docTypePlannedOrder;
+	private int							docTypeConfirmedOrder;
+	private int							docTypePurchaseOrder;
+	private int							docTypeMRPRequisition;
+	private int							priceListId;
+	private Calendar					calendar								= Calendar.getInstance();
+	
+	// Available Inventory - ProductID, Qty
+	private Map<Integer, BigDecimal>	availableInventory						= new TreeMap<Integer, BigDecimal>();
+
+	// Map Demand for SalesOrder_DatePromise, ProductID, RequiredQTY.
+	Map<Date, Map<Integer, BigDecimal>>	mapDemand								= new TreeMap<Date, Map<Integer, BigDecimal>>();
+
+	// map use for DatePromise for create planned Production, Product reference,
+	// planned qty [ProductID, RequiredDate, DemandQty]
+	Map<Integer, Map<Date, BigDecimal>>	mapRequirePlanningQty					= new TreeMap<Integer, Map<Date, BigDecimal>>();
+	Map<Date, MRequisition> 			mapRequisition = new TreeMap<Date, MRequisition>();
+
+	StringBuilder						infoMsg									= new StringBuilder();
+	StringBuilder						productionDocs							= new StringBuilder();
+	StringBuilder						requisitionDocs							= new StringBuilder();
+	//	MRP Model
+	private MReplenishPlan 				replenishPlan = null;
+	
+	@Override
+	protected void prepare() {
+		super.prepare();
+	}
+
+
+	@Override
+	protected String doIt() throws Exception {
+		replenishPlan = new MReplenishPlan(getCtx(), getRecord_ID(), get_TrxName());
+		//	For Date Start
+		if(getDateStart() == null) {
+			setDateStart(replenishPlan.getDateStart());
+		} else {
+			replenishPlan.setDateStart(getDateStart());
+		}
+		//	For Date Finish
+		if(getDateFinish() == null) {
+			setDateFinish(replenishPlan.getDateFinish());
+		} else {
+			replenishPlan.setDateFinish(getDateFinish());
+		}
+		//	
+		priceListId = replenishPlan.getM_PriceList_ID();
+
+		docTypePlannedOrder = replenishPlan.getC_DocType_PlannedOrder();
+		docTypeConfirmedOrder = replenishPlan.getC_DocType_ConfirmedOrder();
+		docTypePurchaseOrder = replenishPlan.getC_DocType_PO();
+		docTypeMRPRequisition = replenishPlan.getC_DocType_Requisition();
+		
+		//	Validate
+		StringBuilder error = new StringBuilder();
+		
+		if (docTypePlannedOrder <= 0)
+			error.append("@C_DocType_PlannedOrder@ @NotFound@\n");
+		if (docTypeConfirmedOrder <= 0)
+			error.append("@C_DocType_ConfirmedOrder@ @NotFound@\n");
+		if (docTypePurchaseOrder <= 0)
+			error.append("@C_DocType_PO@ @NotFound@\n");
+		if (docTypeMRPRequisition <= 0)
+			error.append("@C_DocType_Requisition@ @NotFound@\n");
+		//	
+		if (error.length() > 0) {
+			throw new Exception(Msg.parseTranslation(getCtx(), error.toString()));
+		}
+		//	Validate Dates
+		if (getDateStart() == null)
+			throw new IllegalArgumentException(Msg.parseTranslation(getCtx(), "@FillMandatory@ @DateStart@"));
+		if (getDateFinish() == null)
+			throw new IllegalArgumentException(Msg.parseTranslation(getCtx(), "@FillMandatory@ @DateFinish@"));
+		if (priceListId == 0)
+			throw new IllegalArgumentException(Msg.parseTranslation(getCtx(), "@FillMandatory@ @M_PriceList_ID@"));
+		//	Save changes
+		replenishPlan.saveEx();
+		//	Delete 
+		String sql = "DELETE FROM M_ReplenishPlanLine WHERE M_ReplenishPlan_ID=?";
+		int noOfLinesDeleted = DB.executeUpdateEx(sql, new Object[] {getRecord_ID()}, get_TrxName());
+		log.fine("No. of MRP lines deleted : " + noOfLinesDeleted);
+		//	
+		if (replenishPlan.isDeleteUnconfirmedProduction()) {
+			deleteUnconfirmedProduction();
+		}
+		//	
+		if (replenishPlan.isDeletePlannedPO()) {
+			deletePlannedPO();
+		}
+
+		Map<Integer, MiniMRPProduct> miniMrpProducts = new TreeMap<Integer, MiniMRPProduct>();
+		Set<Integer> productIds = new TreeSet<Integer>();
+
+		// Collect all the Products required to be processed.
+		generateProductInfo(miniMrpProducts, productIds);
+		// Process Demand
+		doRunProductsSO(miniMrpProducts, productIds);
+		// Creating Requisition Order and Planned Production Order
+		doRunCreatePOandProductionOrder(miniMrpProducts);
+		// Process Supply
+		//	For Orders
+		doRunOpenOrders(miniMrpProducts, productIds, TYPE_PO);
+		//	For Productions
+		doRunOpenOrders(miniMrpProducts, productIds, TYPE_MO);
+		//	For Requisition
+		doRunOpenOrders(miniMrpProducts, productIds, TYPE_RQ);
+		//	
+		renderPeggingReport(miniMrpProducts);
+		//	
+		updateHasSupplyDemand();
+		//	
+		return infoMsg.toString();
+	}
+	
+	/**
+	 * Delete unconfirmed productions
+	 */
+	private void deleteUnconfirmedProduction() {
+		String sql = "DELETE FROM M_ProductionLine "
+				+ "WHERE EXISTS(SELECT 1 FROM M_Production "
+				+ "					WHERE M_Production_ID = M_ProductionLine.M_Production_ID "
+				+ "					AND Processed='N' "
+				+ "					AND C_DocType_ID = ?)";
+		int noOfLinesDeleted = DB.executeUpdate(sql, docTypePlannedOrder, get_TrxName());
+		log.fine("No. of planned production line deleted : " + noOfLinesDeleted);
+
+		sql = "DELETE FROM M_Production	"
+				+ "WHERE Processed='N' "
+				+ "AND C_DocType_ID = ?";
+		noOfLinesDeleted = DB.executeUpdate(sql, docTypePlannedOrder, get_TrxName());
+		log.fine("No. of planned production deleted : " + noOfLinesDeleted);
+
+		sql = "DELETE FROM M_ProductionBatch b  " +
+				"WHERE b.C_DocType_ID = ? " +
+	            "AND NOT EXISTS(SELECT 1 " +
+	             "                  FROM M_Production " +
+	             "                  WHERE M_ProductionBatch_ID = b.M_ProductionBatch_ID)";
+		noOfLinesDeleted = DB.executeUpdate(sql, docTypePlannedOrder, get_TrxName());
+		log.fine("No. of Production Batch deleted " + noOfLinesDeleted);
+
+		sql = "DELETE FROM M_MovementLine ml "
+				+ "WHERE EXISTS(SELECT 1 FROM M_Movement m "
+				+ "				WHERE m.M_Movement_ID = ml.M_Movement_ID "
+				+ "				AND m.M_ProductionBatch_ID IS NOT NULL "
+				+ "				AND m.Processed = 'N' "
+				+ "					AND NOT EXISTS(SELECT 1 "
+				+ "							FROM M_ProductionBatch b "
+				+ "							WHERE b.M_ProductionBatch_ID = m.M_ProductionBatch_ID))";
+		noOfLinesDeleted = DB.executeUpdate(sql, get_TrxName());
+		log.fine("No. of Movement Lines cleaned : " + noOfLinesDeleted);
+
+		sql = "DELETE FROM M_Movement m "
+				+ "WHERE m.M_ProductionBatch_ID IS NOT NULL "
+				+ "AND m.Processed = 'N'"
+				+ "AND NOT EXISTS(SELECT 1 FROM M_ProductionBatch b "
+				+ "				WHERE b.M_ProductionBatch_ID = m.M_ProductionBatch_ID)";
+		noOfLinesDeleted = DB.executeUpdate(sql, get_TrxName());
+		log.fine("No. of Inventory Movements cleaned : " + noOfLinesDeleted);
+	}
+	
+	/**
+	 * Delete Planned PO
+	 */
+	private void deletePlannedPO() {
+		String sql = "DELETE FROM PP_MRP "
+				+ "WHERE EXISTS(SELECT 1 FROM M_Requisition "
+				+ "					WHERE M_Requisition_ID = PP_MRP.M_Requisition_ID"
+				+ "					AND DocStatus = 'DR' "
+				+ "					AND Processed='N' "
+				+ "					AND AD_Client_ID = ? "
+				+ "					AND C_DocType_ID = ?)";
+		int noOfLinesDeleted = DB.executeUpdateEx(sql, new Object[] {getAD_Client_ID(), docTypeMRPRequisition}, get_TrxName());
+		log.fine("No. of Material Requirement Planning (PP_MRP) Line deleted : " + noOfLinesDeleted);
+
+		sql = "DELETE FROM M_RequisitionLine "
+				+ "WHERE EXISTS(SELECT 1 FROM M_Requisition "
+				+ "					WHERE M_Requisition_ID = M_RequisitionLine.M_Requisition_ID"
+				+ "					AND DocStatus = 'DR' "
+				+ "					AND Processed='N' "
+				+ "					AND AD_Client_ID = ? "
+				+ "					AND C_DocType_ID = ?)";
+		noOfLinesDeleted = DB.executeUpdateEx(sql, new Object[] {getAD_Client_ID(), docTypeMRPRequisition }, get_TrxName());
+		log.fine("No. of MRP Requisition Line deleted : " + noOfLinesDeleted);
+		
+		sql = "DELETE FROM M_Requisition "
+				+ "WHERE DocStatus = 'DR' "
+				+ "AND Processed='N' "
+				+ "AND AD_Client_ID = ? "
+				+ "AND C_DocType_ID = ?";
+		noOfLinesDeleted = DB.executeUpdateEx(sql, new Object[] {getAD_Client_ID(), docTypeMRPRequisition}, get_TrxName());
+		log.fine("No. of MRP Requisition deleted : " + noOfLinesDeleted);
+	}
+
+	/**
+	 * Set flag to show products where demand and/or supply exists in the MRP
+	 * period, used to filter the MRP report to exclude products with no
+	 * movement
+	 */
+	private void updateHasSupplyDemand() {
+		String sql = new String("UPDATE M_ReplenishPlanLine SET HasSupplyDemand = 'Y' "
+				+ "WHERE M_ReplenishPlan_ID = ? "
+				+ "	AND EXISTS(SELECT 1 FROM M_ReplenishPlanLine rpl "
+				+ "				WHERE rpl.M_ReplenishPlan_ID = M_ReplenishPlanLine.M_ReplenishPlan_ID "
+				+ "				GROUP BY rpl.AD_Client_ID, rpl.M_ReplenishPlan_ID, rpl.M_Product_ID "
+				+ "				HAVING COUNT(rpl.M_Product_ID) > 2)");
+		int updated = DB.executeUpdateEx(sql, new Object[] {getRecord_ID()}, get_TrxName());
+		//	
+		log.fine("Lines with supply/demand updated: " + updated);
+	}
+
+	/**
+	 * This method will process to create Production Order and Purchase order as
+	 * per required quantity.
+	 * 
+	 * @author Sachin Bhimani
+	 * @param miniMrpProducts
+	 */
+	private void doRunCreatePOandProductionOrder(Map<Integer, MiniMRPProduct> miniMrpProducts) {
+		MRequisition requisition = null;
+
+		// Calculate Required and production QTY
+		runProcessCalculatePlannedQty(miniMrpProducts);
+
+		// Create Requisition Order with Lines
+		for (Integer productID : mapRequirePlanningQty.keySet()) {
+			MiniMRPProduct mrp = miniMrpProducts.get(productID);
+			Map<Date, BigDecimal> weeklyProductionQty = new TreeMap<Date, BigDecimal>(
+					mapRequirePlanningQty.get(productID));
+			for (Date date : weeklyProductionQty.keySet()) {
+				if (weeklyProductionQty.get(date).compareTo(Env.ZERO) == 0)
+					continue;
+
+				if (!mrp.isBOM() && mrp.isPurchased() && !mrp.isPhantom()) {
+					requisition = createRequisitionHeader(date);
+					createRequisitionLine(requisition, mrp, weeklyProductionQty.get(date));
+				} else if (mrp.isBOM() && !mrp.isPhantom()) {
+					createProductionOrder(mrp, weeklyProductionQty.get(date), new Timestamp(date.getTime()));
+				}
+			}
+		}
+		//	
+		infoMsg.append(" @M_Requisition_ID@ @Created@:" + countReq);
+		infoMsg.append(" @M_Production_ID@:" + countProd);
+		log.log(Level.INFO, infoMsg.toString());
+	}
+
+	private void runProcessCalculatePlannedQty(Map<Integer, MiniMRPProduct> miniMrpProducts) {
+		for (Date date : mapDemand.keySet()) {
+			Map<Integer, BigDecimal> mapOrderQty = mapDemand.get(date);
+			for (Integer productID : mapOrderQty.keySet()) {
+				MProduct product = new MProduct(getCtx(), productID, get_TrxName());
+				if (!product.isStocked())
+					return ;
+				BigDecimal demandQty = mapOrderQty.get(productID);
+				if (demandQty.compareTo(Env.ZERO) != 0) {
+					MiniMRPProduct mrp = miniMrpProducts.get(productID);
+					if (mrp == null) {
+						MProduct p = MProduct.get(getCtx(), productID);
+						String error = "Please check Product=" + p.getValue() + " replenishment parameters may not be setup properly.";
+						log.severe(error);
+						throw new AdempiereException(error);
+					}
+				
+					Integer nonPhantomProduct = (mrp.isPhantom() && mrp.isBOM() ? 0 : productID);
+					createPlannedQtyMap(miniMrpProducts, date, productID, demandQty, 0, nonPhantomProduct);
+				}
+			}
+		}
+	}
+
+	private void createPlannedQtyMap(Map<Integer, MiniMRPProduct> miniMrpProducts, Date date, Integer productID,
+			BigDecimal demandQty, int level, Integer nonPhantomProduct)
+	{
+		if (miniMrpProducts.containsKey(productID))
+		{
+			MiniMRPProduct mrp = miniMrpProducts.get(productID);
+
+			// check QtyOnHand
+			if (mrp.getQtyOnHand().compareTo(demandQty) >= 0)
+			{
+				mrp.setQtyOnHand(mrp.getQtyOnHand().subtract(demandQty));
+				demandQty = Env.ZERO;
+				return;
+			}
+			else if (mrp.getQtyOnHand().compareTo(Env.ZERO) != 0 && mrp.getQtyOnHand().compareTo(demandQty) < 0)
+			{
+				demandQty = demandQty.subtract(mrp.getQtyOnHand());
+				mrp.setQtyOnHand(Env.ZERO);
+			}
+
+			Map<Date, BigDecimal> confirmProductQty = mrp.getMapConfirmProductQty();
+
+			// Check Confirmed Production Order
+			if (demandQty.compareTo(Env.ZERO) > 0 && confirmProductQty != null && !confirmProductQty.isEmpty())
+			{
+				for (Date dateProduction : confirmProductQty.keySet())
+				{
+					BigDecimal confirmQty = confirmProductQty.get(dateProduction);
+					if (confirmQty.compareTo(Env.ZERO) > 0 && date.compareTo(dateProduction) >= 0)
+					{
+						if (confirmQty.compareTo(demandQty) >= 0)
+						{
+							confirmQty = confirmQty.subtract(demandQty);
+							confirmProductQty.put(dateProduction, confirmQty);
+							demandQty = Env.ZERO;
+							break;
+						}
+						else
+						{
+							demandQty = demandQty.subtract(confirmQty);
+							confirmProductQty.put(dateProduction, Env.ZERO);
+						}
+					}
+				}
+			}
+
+			if (mrp.isReplenishTypeMRPCalculated() && mrp.getExtraQtyPlanned().compareTo(Env.ZERO) != 0)
+			{
+				if (mrp.getExtraQtyPlanned().compareTo(demandQty) < 0)
+				{
+					demandQty = demandQty.subtract(mrp.getExtraQtyPlanned());
+					mrp.setExtraQtyPlanned(Env.ZERO);
+				}
+				else
+				{
+					mrp.setExtraQtyPlanned(mrp.getExtraQtyPlanned().subtract(demandQty));
+					demandQty = Env.ZERO;
+					return;
+				}
+			}
+
+			if (demandQty.compareTo(Env.ZERO) > 0)
+			{
+				if (!mrp.isPhantom() && mrp.isBOM())
+				{
+					level++;
+					nonPhantomProduct = mrp.getM_Product_ID();
+				}
+				else if (!mrp.isPhantom() && !mrp.isBOM() && nonPhantomProduct != 0)
+				{
+					level++;
+				}
+
+				calendar.setTimeInMillis(date.getTime());
+				calendar.add(Calendar.DAY_OF_MONTH, (level * -7));
+				calendar.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY);
+				Timestamp plannedDate = new Timestamp(calendar.getTimeInMillis());
+
+				if (plannedDate.compareTo(getDateStart()) < 0) {
+					plannedDate = getDateStart();
+				}
+
+				if (!mrp.isPhantom() && nonPhantomProduct != 0 && mrp.isBOM()) {
+					if (mrp.isReplenishTypeMRPCalculated()) {
+						demandQty = calculateBatchSizeWiseOrderCreation(mrp, demandQty, plannedDate);
+					} else {
+						setRequirePlanningQty(mrp, plannedDate, demandQty);
+					}
+				}
+
+				if (mrp.isBOM()) {
+					planBOMTree(miniMrpProducts, productID, date, demandQty, level, nonPhantomProduct);
+				} else if (!mrp.isPhantom()) {
+					if (mrp.isReplenishTypeMRPCalculated()) {
+						demandQty = calculateBatchSizeWiseOrderCreation(mrp, demandQty, plannedDate);
+					} else {
+						setRequirePlanningQty(mrp, plannedDate, demandQty);
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Create Planned Production Order
+	 * 
+	 * @param mrp
+	 * @param qty
+	 * @param date
+	 */
+	private void createProductionOrder(MiniMRPProduct mrp, BigDecimal qty, Timestamp date)
+	{
+		MProduction mProd = new MProduction(getCtx(), 0, get_TrxName());
+		//mProd.setAD_Client_ID(AD_Client_ID);
+		mProd.setAD_Org_ID(replenishPlan.getAD_Org_ID());
+		mProd.setM_Product_ID(mrp.getM_Product_ID());
+		mProd.setProductionQty(qty);
+		mProd.setM_Locator_ID(getLocatorId());
+		mProd.setC_DocType_ID(docTypePlannedOrder);
+		mProd.setName("Planned Production Order");
+		mProd.setDescription("Creating from MiniMRP");
+		mProd.setDatePromised(date);
+		mProd.setMovementDate(date);
+		mProd.setDocumentNo("<>");
+		mProd.saveEx();
+
+		mProd.createLines(false);
+		mProd.setIsCreated(true);
+		mProd.saveEx();
+
+		countProd++;
+		productionDocs.append(mProd.getDocumentNo()).append(",");
+	}
+
+	/**
+	 * Create Planned Production / Requisition Order as per QtyBatchSize on
+	 * Product.
+	 * 
+	 * @param mrp
+	 * @param qty
+	 * @param date
+	 * @return qtyForPlan
+	 */
+	private BigDecimal calculateBatchSizeWiseOrderCreation(MiniMRPProduct mrp, BigDecimal qty, Timestamp date)
+	{
+		int createNoOfOrder = 1;
+		BigDecimal QtyPlan = qty;
+
+		if (mrp.getQtyBatchSize().compareTo(Env.ZERO) == 0)
+		{
+			setRequirePlanningQty(mrp, date, qty);
+			return qty;
+		}
+		else
+		{
+			createNoOfOrder = qty.divide(mrp.getQtyBatchSize(), 0, RoundingMode.CEILING).intValue();
+			QtyPlan = mrp.getQtyBatchSize();
+		}
+
+		BigDecimal qtyPlanned = QtyPlan.multiply(new BigDecimal(createNoOfOrder));
+		mrp.setExtraQtyPlanned(mrp.getExtraQtyPlanned().add(qtyPlanned).subtract(qty));
+
+		for (int i = 0; i < createNoOfOrder; i++)
+		{
+			if (mrp.isBOM())
+				createProductionOrder(mrp, QtyPlan, date);
+			else
+			{
+//				MRequisition requisition = createRequisition(date);
+				MRequisition requisition = createRequisitionHeader(date);
+				createRequisitionLine(requisition, mrp, QtyPlan);
+			}
+		}
+
+		return qtyPlanned; 
+	}
+
+	private void setRequirePlanningQty(MiniMRPProduct mrp, Date date, BigDecimal demandQty)
+	{
+		if (mrp.isPhantom())
+			return;
+
+		if (mapRequirePlanningQty.containsKey(mrp.getM_Product_ID()))
+		{
+			Map<Date, BigDecimal> weekly = mapRequirePlanningQty.get(mrp.getM_Product_ID());
+			if (weekly.containsKey(date))
+				weekly.put(date, weekly.get(date).add(demandQty));
+			else
+				weekly.put(date, demandQty);
+		}
+		else
+		{
+			Map<Date, BigDecimal> weekly = new HashMap<Date, BigDecimal>();
+			weekly.put(date, demandQty);
+			mapRequirePlanningQty.put(mrp.getM_Product_ID(), weekly);
+		}
+	}
+	
+	private void planBOMTree(Map<Integer, MiniMRPProduct> miniMrpProducts, Integer productID, Date date,
+		BigDecimal demandQty, int level, Integer nonPhantomProduct) {
+		//	Get BOM
+		List<MProductBOM> bomList = new Query(getCtx(), I_M_Product_BOM.Table_Name, 
+				I_M_Product_BOM.COLUMNNAME_M_Product_ID + "= ?", get_TrxName())
+				.setParameters(productID)
+				.setClient_ID()
+				.list();
+		//	Iterate
+		bomList.stream()
+				.forEach(productBOM -> {
+					BigDecimal requiredQty = Env.ZERO;
+					if(productBOM.getBOMQty() != null
+							&& demandQty != null) {
+						demandQty.multiply(productBOM.getBOMQty());
+					}
+					//	
+					if(requiredQty.compareTo(Env.ZERO) > 0) {
+						createPlannedQtyMap(miniMrpProducts, date, 
+								productBOM.getM_ProductBOM_ID(), requiredQty, level, nonPhantomProduct);
+					}
+				});
+	}
+
+	/**
+	 * Create Requisition without implementation of QtyBatchSize logic
+	 * 
+	 * @param mapRequisition
+	 * @param date
+	 * @return
+	 */
+	private MRequisition createRequisitionHeader(Date date)
+	{
+		MRequisition requisition = null;
+		if (!mapRequisition.containsKey(date))
+		{
+			requisition = createRequisition(date);
+			mapRequisition.put(date, requisition);
+			log.severe("New Requisition Header created. " + requisition.toString());
+		}
+		else
+			requisition = mapRequisition.get(date);
+		return requisition;
+	}
+
+	/**
+	 * Create Requisition Order
+	 * 
+	 * @param date
+	 * @return
+	 */
+	private MRequisition createRequisition(Date date) {
+		MRequisition requisition;
+		requisition = new MRequisition(getCtx(), 0, get_TrxName());
+		//requisition.setAD_Client_ID(AD_Client_ID);
+		requisition.setM_Warehouse_ID(getWarehouseId());
+		requisition.setC_DocType_ID(docTypeMRPRequisition);
+		requisition.setAD_User_ID(getAD_User_ID());
+		requisition.setDescription(Msg.parseTranslation(getCtx(), "@Created@ @from@ @M_ReplenishPlan_ID@"));
+		requisition.setDateRequired(new Timestamp(date.getTime()));
+		requisition.setDateDoc(new Timestamp(date.getTime()));
+		requisition.setM_PriceList_ID(priceListId);
+		requisition.saveEx();
+
+		countReq++;
+		requisitionDocs.append(requisition.getDocumentNo()).append(",");
+
+		return requisition;
+	}
+
+	private void createRequisitionLine(MRequisition requisition, MiniMRPProduct mrp, BigDecimal qty) {
+		//requisition.addLinetoQueue(mrp.getM_Product_ID(), mrp.getC_BPartner_ID(), qty, mrp.getPriceActual());
+		MRequisitionLine rLine = new MRequisitionLine(requisition);
+		rLine.setM_Product_ID(mrp.getM_Product_ID());
+		rLine.setC_BPartner_ID(mrp.getC_BPartner_ID());
+		rLine.setPriceActual(mrp.getPriceActual());
+		rLine.setQty(qty);
+		rLine.saveEx();
+	}
+
+	/**
+	 * Product wise Get confirmed Qty. If Product is BOM then Production else
+	 * from PO.
+	 * 
+	 * @param mrp
+	 */
+	private void setConfirmProductQty(MiniMRPProduct mrp) {
+		int productID = mrp.getM_Product_ID();
+		Map<Date, BigDecimal> mapConfirmQty = new TreeMap<Date, BigDecimal>();
+		String sqlConfirmPORQ = new String(" SELECT DateRequired AS DatePromised, SUM(Qty) AS Qty "
+				+ "FROM ("
+				+ "(SELECT ol.DatePromised AS DateRequired, ol.QtyOrdered - QtyDelivered AS Qty	"
+				+ "		FROM C_Order o "
+				+ " 	INNER JOIN C_OrderLine ol ON (ol.C_Order_ID = o.C_Order_ID) "
+				+ " 	WHERE o.DocStatus IN ('CO', 'CL') "
+				+ "		AND o.IsSoTrx = 'N' "
+				+ "		AND ol.M_Product_ID = ? "
+				+ "		AND ol.QtyOrdered > ol.QtyDelivered "
+				+ "		AND o.DatePromised BETWEEN ? AND ? "
+				+ " ORDER BY o.DatePromised) "
+				+ "UNION ALL	"
+				+ "(SELECT r.DateRequired, SUM(rl.Qty) AS QtyOrdered "
+				+ "		FROM M_Requisition r "
+				+ " 	INNER JOIN M_RequisitionLine rl ON (r.M_Requisition_ID = rl.M_Requisition_ID) "
+				+ " 	INNER JOIN M_Product mp ON (mp.M_Product_ID = rl.M_Product_ID) "
+				+ " 	WHERE r.DocStatus = 'DR' "
+				+ "		AND rl.M_Product_ID = ? "
+				+ "		AND r.DateRequired BETWEEN ? AND ? "
+				+ "		AND rl.IsActive = 'Y' "
+				+ "		AND mp.AD_Client_ID = ? "
+				+ "		AND r.C_DocType_ID = ? "
+				+ "		AND mp.IsActive = 'Y' "
+				+ " GROUP BY mp.M_Product_ID, r.M_Requisition_ID "
+				+ "	ORDER BY mp.M_Product_ID, r.DateRequired)"
+				+ ") AS QtyOrdered	"
+				+ "GROUP BY DateRequired");
+		//	Product quantity
+		String sqlFromProduction = new String("SELECT DatePromised, ProductionQty AS Qty, M_Production_ID "
+				+ " FROM M_Production "
+				+ " WHERE Processed = 'N' "
+				+ "	AND M_Product_ID = ? "
+				+ "	AND DatePromised BETWEEN ? AND ? "
+				+ "	AND (C_DocType_ID IS NULL OR C_DocType_ID != ?)"
+				+ " ORDER BY DatePromised");
+		String sql = (mrp.isBOM() 
+				? sqlFromProduction 
+						: sqlConfirmPORQ);
+
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		//	
+		try {
+			pstmt = DB.prepareStatement(sql, get_TrxName());
+			pstmt.setInt(1, productID);
+			pstmt.setTimestamp(2, getDateStart());
+			pstmt.setTimestamp(3, getDateFinish());
+			//	BOM query
+			if (mrp.isBOM()) {
+				pstmt.setInt(4, docTypePlannedOrder);
+			} else {
+				pstmt.setInt(4, productID);
+				pstmt.setTimestamp(5, getDateStart());
+				pstmt.setTimestamp(6, getDateFinish());
+				pstmt.setInt(7, getAD_Client_ID());
+				pstmt.setInt(8, docTypeMRPRequisition);
+			}
+			//	Query
+			rs = pstmt.executeQuery();
+			//	
+			String productionsql = new String("SELECT p.M_Product_ID, SUM(QtyUsed) AS QtyUsed, mp.DatePromised "
+					+ "FROM M_Production mp "
+					+ "INNER JOIN M_ProductionLine pl ON (pl.M_Production_ID = mp.M_Production_ID) "
+					+ "INNER JOIN M_Product p ON (p.M_Product_ID = pl.M_Product_ID) "
+					+ "WHERE pl.IsActive='Y' "
+					+ "AND pl.M_Production_ID = ? "
+					+ "AND pl.IsEndProduct = 'N' "
+					+ "AND p.IsPhantom = 'N' "
+					+ "GROUP BY mp.M_Production_ID, p.M_Product_ID "
+					+ "ORDER BY p.M_Product_ID");
+			while (rs.next()) {
+				Date datePromised = rs.getDate("DatePromised");
+				BigDecimal qty = rs.getBigDecimal("Qty");
+
+				if (mapConfirmQty.containsKey(datePromised)) {
+					mapConfirmQty.put(datePromised, mapConfirmQty.get(datePromised).add(qty));
+				} else {
+					mapConfirmQty.put(datePromised, qty);
+				}
+				//	For BOM
+				if (mrp.isBOM()) {
+					PreparedStatement pstatement = null;
+					ResultSet rset = null;
+					try {
+						pstatement = DB.prepareStatement(productionsql, get_TrxName());
+						pstatement.setInt(1, rs.getInt("M_Production_ID"));
+						//	
+						rset = pstatement.executeQuery();
+						while (rset.next()) {
+							setQtyAsDemand(rset.getInt("M_Product_ID"), rset.getBigDecimal("QtyUsed"),
+									rset.getTimestamp("DatePromised"));
+						}
+					} catch (SQLException e) {
+						log.severe(e.getLocalizedMessage());
+					} finally {
+						DB.close(rset, pstatement);
+						rset = null;
+						pstatement = null;
+					}
+				}
+			}
+		} catch (SQLException e) {
+			log.severe(e.getLocalizedMessage());
+		} finally {
+			DB.close(rs, pstmt);
+			rs = null;
+			pstmt = null;
+		}
+		//	
+		mrp.setMapConfirmProductQty(mapConfirmQty);
+	}
+
+	public void addAvailableInventory(int mProductId, BigDecimal qty) {
+		availableInventory.put(mProductId, qty);
+	}
+
+	/**
+	 * @author Sachin Bhimani
+	 * @param miniMrpProduct
+	 * @param line
+	 * @param type
+	 * @return miniM_ReplenishPlanLine
+	 */
+	private X_M_ReplenishPlanLine getX_M_ReplenishPlanLine(MiniMRPProduct miniMrpProduct, int line, String type) {
+		X_M_ReplenishPlanLine miniMRP = new X_M_ReplenishPlanLine(getCtx(), 0, get_TrxName());
+		miniMRP.setM_Product_ID(miniMrpProduct.getM_Product_ID());
+		miniMRP.setM_Product_Category_ID(miniMrpProduct.getM_Product_Category_ID());
+		miniMRP.setProductName(miniMrpProduct.getName());
+		miniMRP.setLine(line);
+		miniMRP.setM_ReplenishPlan_ID(getRecord_ID());
+		miniMRP.setRecordType(type);
+		miniMRP.setDateStart(getDateStart());
+		miniMRP.setDateFinish(getDateFinish());
+		return miniMRP;
+	}
+
+
+	public void calculateSuggestedOrders(MiniMRPProduct miniMrpProduct, Map<Integer, BigDecimal> totalDemandLine,
+			Map<Integer, BigDecimal> totalSupplyLine, Map<Integer, BigDecimal> openingBalanceLine,
+			Map<Integer, BigDecimal> closingBalanceLine) {
+		//	
+		int horizon = TimeUtil.getWeeksBetween(getDateStart(), getDateFinish());
+		//	Loop
+		for (int week = 1; week <= horizon; week++) {
+			BigDecimal totalDemand = Env.ZERO;
+			BigDecimal totalSupply = Env.ZERO;
+			BigDecimal openingBalance = Env.ZERO;
+
+			if (totalDemandLine.containsKey(week)) {
+				totalDemand = totalDemandLine.get(week);
+				if (totalDemand == null) {
+					totalDemand = Env.ZERO;
+				}
+			}
+			if (totalSupplyLine.containsKey(week)) {
+				totalSupply = totalSupplyLine.get(week);
+				if (totalSupply == null) {
+					totalSupply = Env.ZERO;
+				}
+			}
+			if (openingBalanceLine.containsKey(week)) {
+				openingBalance = openingBalanceLine.get(week);
+				if (openingBalance == null) {
+					openingBalance = Env.ZERO;
+				}
+			}
+
+			BigDecimal sugQty = totalDemand.subtract((totalSupply.add(openingBalance)));
+
+			if (sugQty.compareTo(Env.ZERO) > 0) {
+				openingBalanceLine.put(week + 1, Env.ZERO);
+				closingBalanceLine.put(week, Env.ZERO);
+			} else {
+				openingBalanceLine.put(week + 1, (sugQty.negate()));
+				closingBalanceLine.put(week, (sugQty.negate()));
+			}
+		}
+	}
+
+	/**
+	 * Insert Order Demand
+	 * @param miniMrpProduct
+	 * @return
+	 */
+	public Map<Integer, BigDecimal> insertOrderDemands(MiniMRPProduct miniMrpProduct) {
+		Map<Integer, Map<Integer, BigDecimal>> orderDemands = miniMrpProduct.getDemand();
+		Map<Integer, BigDecimal> totalDemandLine = new HashMap<Integer, BigDecimal>();
+		SimpleDateFormat format = DisplayType.getDateFormat(DisplayType.Date);
+		// From MRP Demand MAP
+		if (!orderDemands.isEmpty()) {
+			for (Integer orderId : orderDemands.keySet()) {
+				Map<Integer, BigDecimal> weeklyDemand = orderDemands.get(orderId);
+				if (weeklyDemand.size() > 0) {
+					X_M_ReplenishPlanLine miniMRP = getX_M_ReplenishPlanLine(miniMrpProduct, lineNo, X_M_ReplenishPlanLine.RECORDTYPE_Demand);
+					miniMRP.setC_Order_ID(orderId);
+					MOrder order = new MOrder(getCtx(), orderId, get_TrxName());
+					//	
+					miniMRP.setOrderInfo(order.getDocumentNo() + " - " + format.format(order.getDatePromised()));
+					for (Integer week : weeklyDemand.keySet()) {
+						BigDecimal qty = weeklyDemand.get(week);
+						setWeeklyData(miniMRP, week, qty);
+						if (totalDemandLine.containsKey(week)) {
+							qty = qty.add(totalDemandLine.get(week));
+						}
+						totalDemandLine.put(week, qty);
+					}
+					miniMRP.saveEx();
+				}
+				lineNo += 10;
+			}
+		}
+		// Get Planned Production Demand as per product wise.
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		int paramCount = 1;
+		try {
+			String sql = new String("SELECT p.M_Production_ID, p.DocumentNo, p.DatePromised, SUM(QtyUsed) AS QtyUsed "
+					+ "FROM M_Production p "
+					+ "INNER JOIN M_ProductionLine pl ON (pl.M_Production_ID = p.M_Production_ID) "
+					+ "WHERE p.Processed='N' "
+					+ "AND pl.IsEndProduct = 'N' "
+					+ "AND pl.M_Product_ID = ?"
+					+ "AND p.C_DocType_ID=? "
+					+ "AND DatePromised BETWEEN ? AND ? "
+					+ "GROUP BY p.M_Production_ID, p.DocumentNo, p.DatePromised "
+					+ "ORDER BY p.DatePromised");
+			//	
+			pstmt = DB.prepareStatement(sql, get_TrxName());
+			pstmt.setInt(paramCount++, miniMrpProduct.getM_Product_ID());
+			pstmt.setInt(paramCount++, docTypePlannedOrder);
+			pstmt.setTimestamp(paramCount++, getDateStart());
+			pstmt.setTimestamp(paramCount++, getDateFinish());
+
+			rs = pstmt.executeQuery();
+			while (rs.next()) {
+				insertProductionDemand(miniMrpProduct, totalDemandLine, rs.getInt("M_Production_ID"),
+						rs.getString("DocumentNo"), rs.getTimestamp("DatePromised"), rs.getBigDecimal("QtyUsed"),
+						"Planned");
+			}
+		} catch (Exception e) {
+			log.severe(e.getLocalizedMessage());
+			throw new AdempiereException(e);
+		} finally {
+			DB.close(rs, pstmt);
+			rs = null;
+			pstmt = null;
+		}
+		//	
+		List <MProduction> productionList = new Query(getCtx(), I_M_Production.Table_Name, "Processed = 'N' "
+				+ "AND DatePromised BETWEEN ? AND ? "
+				+ "AND (C_DocType_ID IS NULL OR C_DocType_ID != ?) "
+				+ "AND EXISTS(SELECT 1 FROM M_ProductionLine pl "
+				+ "			WHERE pl.M_Production_ID = M_Production.M_Production_ID"
+				+ "			AND pl.IsEndProduct = 'N' "
+				+ "			AND pl.M_Product_ID = ?)", get_TrxName())
+				.setParameters(getDateStart(), getDateFinish(), docTypePlannedOrder, miniMrpProduct.getM_Product_ID())
+				.setClient_ID()
+				.list();
+		//	Loop it
+		productionList.stream().forEach(production -> {
+			BigDecimal qty = DB.getSQLValueBD(get_TrxName(),
+					"SELECT SUM(QtyUsed) "
+					+ "FROM M_ProductionLine "
+					+ "WHERE M_Production_ID = ? "
+					+ "AND M_Product_ID = ?",
+					production.getM_Product_ID(), miniMrpProduct.getM_Product_ID(), getAD_Client_ID());
+			if (qty == null) {
+				qty = Env.ZERO;
+			}
+			insertProductionDemand(miniMrpProduct, totalDemandLine, production.getM_Production_ID(),
+					production.getDocumentNo(), production.getDatePromised(), qty, "Confirm");
+		});
+		//	
+		if (!totalDemandLine.isEmpty())
+			insertTotalLine(miniMrpProduct, totalDemandLine, X_M_ReplenishPlanLine.RECORDTYPE_TotalDemand);
+
+		return totalDemandLine;
+	}
+
+	/**
+	 * @param miniMrpProduct
+	 * @param totalDemandLine
+	 * @param mProduction_ID
+	 * @param documentNo
+	 * @param promisedDate
+	 * @param qtyUsed
+	 * @param prodType
+	 */
+	private void insertProductionDemand(MiniMRPProduct miniMrpProduct, Map<Integer, BigDecimal> totalDemandLine,
+			int mProduction_ID, String documentNo, Timestamp promisedDate, BigDecimal qtyUsed, String prodType) {
+		X_M_ReplenishPlanLine miniMRP = getX_M_ReplenishPlanLine(miniMrpProduct, lineNo, X_M_ReplenishPlanLine.RECORDTYPE_Demand);
+		miniMRP.setM_Production_ID(mProduction_ID);
+		String datePromised = null;
+		int week = 0;
+
+		datePromised = DisplayType.getDateFormat(DisplayType.Date).format(promisedDate);
+		week = TimeUtil.getWeeksBetween(getDateStart(), promisedDate);
+		//	
+		miniMRP.setProductionInfo(documentNo + " - " + datePromised + " - " + prodType);
+
+		setWeeklyData(miniMRP, week, qtyUsed);
+		if (totalDemandLine.containsKey(week)) {
+			BigDecimal totalDemand = totalDemandLine.get(week);
+			if (totalDemand == null) {
+				totalDemand = Env.ZERO;
+			}
+			qtyUsed = qtyUsed.add(totalDemand);
+		}
+		totalDemandLine.put(week, qtyUsed);
+		miniMRP.saveEx();
+		lineNo += 10;
+	}
+
+	/**
+	 * Insert total line [Demand/Supply line]
+	 * 
+	 * @author Sachin Bhimani
+	 * @param miniMrpProduct
+	 * @param totalLine
+	 * @param lineType
+	 */
+	public void insertTotalLine(MiniMRPProduct miniMrpProduct, Map<Integer, BigDecimal> totalLine, String lineType) {
+		if (!totalLine.isEmpty()) {
+			X_M_ReplenishPlanLine miniMRP = getX_M_ReplenishPlanLine(miniMrpProduct, lineNo, lineType);
+			for (Integer week : totalLine.keySet()) {
+				BigDecimal qty = totalLine.get(week);
+				setWeeklyData(miniMRP, week, qty);
+			}
+			miniMRP.saveEx();
+		}
+		lineNo += 10;
+	}
+
+	/**
+	 * Insert all supply lines
+	 * 
+	 * @author Sachin Bhimani
+	 * @param miniMrpProduct
+	 * @return totalSupplyLine
+	 */
+	public Map<Integer, BigDecimal> insertSupplyLines(MiniMRPProduct miniMrpProduct) {
+		Map<Integer, BigDecimal> totalSupplyLine = new HashMap<Integer, BigDecimal>();
+		Map<Integer, BigDecimal> subTotalSupplyLine = new HashMap<Integer, BigDecimal>();
+
+		// Insert Production for Non Planned Orders (Confirmed) & Total Line
+		insertSupplyLineMO(miniMrpProduct, totalSupplyLine, subTotalSupplyLine, false);
+		insertTotalSupplyProductionLine(miniMrpProduct, subTotalSupplyLine, false);
+
+		// Insert Production Supply for Planned Orders & Total Line
+		subTotalSupplyLine.clear();
+		insertSupplyLineMO(miniMrpProduct, totalSupplyLine, subTotalSupplyLine, true);
+		insertTotalSupplyProductionLine(miniMrpProduct, subTotalSupplyLine, true);
+
+		// Insert Purchase Order Confirmed Lines
+		subTotalSupplyLine.clear();
+		insertSupplyLinePO(miniMrpProduct, totalSupplyLine, subTotalSupplyLine, true);
+		insertTotalSupplyLine(miniMrpProduct, subTotalSupplyLine, true);
+
+		// Insert Requisition Lines
+		subTotalSupplyLine.clear();
+		insertSupplyLinePO(miniMrpProduct, totalSupplyLine, subTotalSupplyLine, false);
+		insertTotalSupplyLine(miniMrpProduct, subTotalSupplyLine, false);
+
+		// Insert Total Supply Line
+		if (!totalSupplyLine.isEmpty()) {
+			insertTotalLine(miniMrpProduct, totalSupplyLine, X_M_ReplenishPlanLine.RECORDTYPE_TotalSupply);
+		}
+		//	
+		return totalSupplyLine;
+	}
+
+	/**
+	 * Insert Production for Non Planned Orders (Confirmed) and Planned Orders
+	 * 
+	 * @author Sachin Bhimani
+	 * @param miniMrpProduct
+	 * @param totalSupplyLine
+	 * @param subTotalSupplyLine
+	 * @param isPlannedOrder
+	 */
+	public void insertSupplyLineMO(MiniMRPProduct miniMrpProduct, Map<Integer, BigDecimal> totalSupplyLine,
+			Map<Integer, BigDecimal> subTotalSupplyLine, boolean isPlannedOrder) {
+		Map<Integer, Map<Integer, BigDecimal>> supplyLineMO = new TreeMap<Integer, Map<Integer, BigDecimal>>(
+				miniMrpProduct.getSupplyLineMO());
+		SimpleDateFormat format = DisplayType.getDateFormat(DisplayType.Date);
+		if (!supplyLineMO.isEmpty()) {
+			for (Integer M_Production_ID : supplyLineMO.keySet()) {
+				Map<Integer, BigDecimal> weeklyDemand = supplyLineMO.get(M_Production_ID);
+				MProduction production = new MProduction(getCtx(), M_Production_ID, get_TrxName());
+				if ((isPlannedOrder == false && production.getC_DocType_ID() != docTypePlannedOrder)
+						|| (isPlannedOrder && production.getC_DocType_ID() == docTypePlannedOrder)) {
+					if (weeklyDemand.size() > 0) {
+						X_M_ReplenishPlanLine miniMRP = getX_M_ReplenishPlanLine(miniMrpProduct, lineNo, isPlannedOrder
+								? X_M_ReplenishPlanLine.RECORDTYPE_PlannedProduction : X_M_ReplenishPlanLine.RECORDTYPE_ConfirmedProduction);
+						miniMRP.setM_Production_ID(M_Production_ID);
+						//	
+						miniMRP.setProductionInfo(production.getDocumentNo() + " - " + format.format(production.getDatePromised()));
+						for (Integer week : weeklyDemand.keySet()) {
+							BigDecimal qty = weeklyDemand.get(week);
+							setWeeklyData(miniMRP, week, qty);
+							if (totalSupplyLine.containsKey(week)) {
+								qty = qty.add(totalSupplyLine.get(week));
+							}
+							totalSupplyLine.put(week, qty);
+
+							BigDecimal qtyProd = weeklyDemand.get(week);
+							if (subTotalSupplyLine.containsKey(week)) {
+								qtyProd = qtyProd.add(subTotalSupplyLine.get(week));
+							}
+							subTotalSupplyLine.put(week, qtyProd);
+						}
+						miniMRP.saveEx();
+					}
+					lineNo += 10;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Insert Purchase Order and Requisition lines
+	 * 
+	 * @author Sachin Bhimani
+	 * @param miniMrpProduct
+	 * @param totalSupplyLine
+	 * @param subTotalSupplyLine
+	 * @param isPO
+	 */
+	public void insertSupplyLinePO(MiniMRPProduct miniMrpProduct, Map<Integer, BigDecimal> totalSupplyLine,
+			Map<Integer, BigDecimal> subTotalSupplyLine, boolean isPO) {
+		Map<Integer, Map<Integer, BigDecimal>> supplyLine;
+		String typeSupply;
+		if (isPO) {
+			supplyLine = miniMrpProduct.getSupplyLinePO();
+			typeSupply = X_M_ReplenishPlanLine.RECORDTYPE_Supply_Purchasing;
+		} else {
+			supplyLine = miniMrpProduct.getSupplyLineRQ();
+			typeSupply = X_M_ReplenishPlanLine.RECORDTYPE_Supply_Requisition;
+		}
+		SimpleDateFormat format = DisplayType.getDateFormat(DisplayType.Date);
+		if (!supplyLine.isEmpty()) {
+			// columnID is C_Order_ID or M_Requisition_ID
+			for (Integer columnID : supplyLine.keySet()) {
+				Map<Integer, BigDecimal> weeklyDemand = supplyLine.get(columnID);
+				if (weeklyDemand.size() > 0) {
+					X_M_ReplenishPlanLine miniMRP = getX_M_ReplenishPlanLine(miniMrpProduct, lineNo, typeSupply);
+					Timestamp datePromised;
+					String docNo = null;
+					if (isPO) {
+						miniMRP.setC_Order_ID(columnID);
+						MOrder order = new MOrder(getCtx(), columnID, get_TrxName());
+						datePromised = order.getDatePromised();
+						docNo = order.getDocumentNo();
+					} else {
+						miniMRP.setM_Requisition_ID(columnID);
+						MRequisition req = new MRequisition(getCtx(), columnID, get_TrxName());
+						datePromised = req.getDateRequired();
+						docNo = req.getDocumentNo();
+					}
+					//	
+					miniMRP.setOrderInfo(docNo + " - " + format.format(datePromised));
+					for (Integer week : weeklyDemand.keySet()) {
+						BigDecimal qty = weeklyDemand.get(week);
+						setWeeklyData(miniMRP, week, qty);
+						if (totalSupplyLine.containsKey(week)) {
+							qty = qty.add(totalSupplyLine.get(week));
+						}
+						totalSupplyLine.put(week, qty);
+
+						BigDecimal qtyProd = weeklyDemand.get(week);
+						if (subTotalSupplyLine.containsKey(week)) {
+							qtyProd = qtyProd.add(subTotalSupplyLine.get(week));
+						}
+						subTotalSupplyLine.put(week, qtyProd);
+					}
+					miniMRP.saveEx();
+				}
+				lineNo += 10;
+			}
+		}
+	}
+
+	/**
+	 * Insert total Supply line, summation of confirmed purchase order and
+	 * Requisition
+	 * 
+	 * @author Sachin Bhimani
+	 * @param miniMrpProduct
+	 * @param subTotalSupplyLine
+	 * @param isPO
+	 */
+	public void insertTotalSupplyLine(MiniMRPProduct miniMrpProduct, Map<Integer, BigDecimal> subTotalSupplyLine,
+			boolean isPO) {
+		if (!subTotalSupplyLine.isEmpty()) {
+			X_M_ReplenishPlanLine miniMRP = getX_M_ReplenishPlanLine(miniMrpProduct, lineNo, isPO 
+					? X_M_ReplenishPlanLine.RECORDTYPE_TotalSupply_PO
+					: X_M_ReplenishPlanLine.RECORDTYPE_TotalSupply_Requisition);
+
+			// Insert Total Supply line.
+			for (Integer week : subTotalSupplyLine.keySet()) {
+				BigDecimal qty = subTotalSupplyLine.get(week);
+				setWeeklyData(miniMRP, week, qty);
+			}
+			miniMRP.saveEx();
+		}
+		lineNo += 10;
+	}
+
+	/**
+	 * Insert total supply of production line
+	 * 
+	 * @author Sachin Bhimani
+	 * @param miniMrpProduct
+	 * @param subTotalSupplyLine
+	 * @param isPlanned
+	 */
+	public void insertTotalSupplyProductionLine(MiniMRPProduct miniMrpProduct,
+			Map<Integer, BigDecimal> subTotalSupplyLine, boolean isPlanned) {
+		if (!subTotalSupplyLine.isEmpty()) {
+			X_M_ReplenishPlanLine miniMRP = getX_M_ReplenishPlanLine(miniMrpProduct, lineNo, isPlanned ? X_M_ReplenishPlanLine.RECORDTYPE_TotalPlannedProduction
+					: X_M_ReplenishPlanLine.RECORDTYPE_TotalConfirmedProduction);
+
+			// Insert Total Supply Production as per docType.
+			for (Integer week : subTotalSupplyLine.keySet()) {
+				BigDecimal qty = subTotalSupplyLine.get(week);
+				setWeeklyData(miniMRP, week, qty);
+			}
+			miniMRP.saveEx();
+		}
+		lineNo += 10;
+	}
+
+	/**
+	 * Insert Opening Balance Line
+	 * 
+	 * @author Sachin Bhimani
+	 * @param miniMrpProduct
+	 * @param openingBalanceLine
+	 */
+	public void insertOpeningBalanceLine(MiniMRPProduct miniMrpProduct, Map<Integer, BigDecimal> openingBalanceLine) {
+		if (!openingBalanceLine.isEmpty()) {
+			X_M_ReplenishPlanLine miniMRP = getX_M_ReplenishPlanLine(miniMrpProduct, 10, X_M_ReplenishPlanLine.RECORDTYPE_OpeningBalance
+					+ (miniMrpProduct.isPhantom ? " - Phantom Product" : ""));
+			for (Integer week : openingBalanceLine.keySet()) {
+				setWeeklyData(miniMRP, week, openingBalanceLine.get(week));
+			}
+			miniMRP.saveEx();
+		}
+	}
+
+	/**
+	 * Insert closing Balance Line.
+	 * 
+	 * @author Sachin Bhimani
+	 * @param miniMrpProduct
+	 * @param closingBalanceLine
+	 */
+	public void insertClosingBalanceLine(MiniMRPProduct miniMrpProduct, Map<Integer, BigDecimal> closingBalanceLine) {
+		if (!closingBalanceLine.isEmpty()) {
+			X_M_ReplenishPlanLine miniMRP = getX_M_ReplenishPlanLine(miniMrpProduct, lineNo, X_M_ReplenishPlanLine.RECORDTYPE_ClosingBalance);
+			for (Integer week : closingBalanceLine.keySet()) {
+				setWeeklyData(miniMRP, week, closingBalanceLine.get(week));
+			}
+			miniMRP.saveEx();
+		}
+	}
+
+	/**
+	 * Create a MRP Lines as per product wise processing
+	 * 
+	 * @author Sachin Bhimani
+	 * @param miniMrpProducts
+	 */
+	private void renderPeggingReport(Map<Integer, MiniMRPProduct> miniMrpProducts) {
+		for (MiniMRPProduct miniMrpProduct : miniMrpProducts.values()) {
+			lineNo = 20;
+			Map<Integer, BigDecimal> openingBalanceLine = new HashMap<Integer, BigDecimal>();
+			Map<Integer, BigDecimal> closingBalanceLine = new HashMap<Integer, BigDecimal>();
+			if (availableInventory.containsKey(miniMrpProduct.getM_Product_ID())) {
+				BigDecimal qty = availableInventory.get(miniMrpProduct.getM_Product_ID());
+				openingBalanceLine.put(1, qty);// TODO view it
+			}
+
+			// Insert Demand lines & Calculate Total Demand line.
+			Map<Integer, BigDecimal> totalDemandLine = insertOrderDemands(miniMrpProduct);
+
+			// Insert SupplyLines - MO/PO & Total
+			Map<Integer, BigDecimal> totalSupplyLine = insertSupplyLines(miniMrpProduct);
+
+			calculateSuggestedOrders(miniMrpProduct, totalDemandLine, totalSupplyLine, openingBalanceLine,
+					closingBalanceLine);
+
+			// Insert Closing Balance Line
+			insertClosingBalanceLine(miniMrpProduct, closingBalanceLine);
+
+			// Insert Opening Balance Line
+			insertOpeningBalanceLine(miniMrpProduct, openingBalanceLine);
+		}
+	}
+
+	/**
+	 * For Production
+	 * @param miniMrpProducts
+	 * @param productIds
+	 */
+	private void forOpenMO(Map<Integer, MiniMRPProduct> miniMrpProducts, Set<Integer> productIds) {
+		//	SQL
+		String sql = new String(
+				"SELECT mprod.M_Production_ID, mprod.M_Product_ID, "
+				+ "SUM(mprod.ProductionQty) AS OrderedQty, mprod.DatePromised "
+				+ "FROM M_Production mprod "
+				+ "WHERE mprod.IsActive='Y' "
+				+ "AND mprod.Processed='N' "
+				+ "AND mprod.DatePromised BETWEEN ? AND ? "
+				+ "AND mprod.AD_Client_ID = ? "
+				+ "AND mprod.M_Product_ID IN" + productIds.toString().replace('[','(').replace(']',')') + " "
+				+ "GROUP BY mprod.M_Product_ID, mprod.M_Production_ID, mprod.DatePromised "
+				+ "ORDER BY mprod.M_Product_ID, mprod.DatePromised");
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		int paramCount = 1;
+		try {
+			pstmt = DB.prepareStatement(sql, get_TrxName());
+			pstmt.setTimestamp(paramCount++, getDateStart());
+			pstmt.setTimestamp(paramCount++, getDateFinish());
+			pstmt.setInt(paramCount++, getAD_Client_ID());
+			rs = pstmt.executeQuery();
+			while (rs.next()) {
+				int productionId = rs.getInt("M_Production_ID");
+				int productId = rs.getInt("M_Product_ID");
+				BigDecimal orderQty = rs.getBigDecimal("OrderedQty");
+				Timestamp datePromised = rs.getTimestamp("DatePromised");
+				//	
+				int weekPromised = TimeUtil.getWeeksBetween(getDateStart(), datePromised);
+				MiniMRPProduct product = miniMrpProducts.get(productId);
+				product.setSupplyLineMO(productionId, weekPromised, orderQty);
+			}
+		} catch (Exception e) {
+			log.log(Level.SEVERE, sql.toString(), e);
+		} finally {
+			DB.close(rs, pstmt);
+			rs = null;
+			pstmt = null;
+		}
+	}
+	
+	/**
+	 * For Orders
+	 * @param miniMrpProducts
+	 * @param productIds
+	 */
+	private void forOpenPO(Map<Integer, MiniMRPProduct> miniMrpProducts, Set<Integer> productIds) {
+		//	SQL
+		String sql = new String(
+				"SELECT co.C_Order_ID, col.M_Product_ID, SUM(col.QtyOrdered - col.QtyDelivered) AS OrderedQty, co.DatePromised "
+				+ "FROM C_Order co "
+				+ "INNER JOIN C_OrderLine col ON(co.C_Order_ID = col.C_Order_ID) "
+				+ "WHERE co.IsSOTrx='N' "
+				+ "AND co.DocStatus = 'CO' "
+				+ "AND col.QtyOrdered > col.QtyDelivered "
+				+ "AND col.DatePromised BETWEEN ? AND ? "
+				+ "AND co.AD_Client_ID = ? "
+				+ "AND col.M_Product_ID IN" + productIds.toString().replace('[','(').replace(']',')') + " "
+				+ "GROUP BY col.M_Product_ID, co.C_Order_ID, co.DatePromised "
+				+ "ORDER BY col.M_Product_ID, co.DatePromised");
+		//	
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		int paramCount = 1;
+		try {
+			pstmt = DB.prepareStatement(sql, get_TrxName());
+			pstmt.setTimestamp(paramCount++, getDateStart());
+			pstmt.setTimestamp(paramCount++, getDateFinish());
+			pstmt.setInt(paramCount++, getAD_Client_ID());
+			rs = pstmt.executeQuery();
+			while (rs.next()) {
+				int productId = rs.getInt("M_Product_ID");
+				BigDecimal orderQty = rs.getBigDecimal("OrderedQty");
+				Timestamp datePromised = rs.getTimestamp("DatePromised");
+				//	
+				int weekPromised = TimeUtil.getWeeksBetween(getDateStart(), datePromised);
+				MiniMRPProduct product = miniMrpProducts.get(productId);
+				int orderId = rs.getInt("C_Order_ID");
+				product.setSupplyLinePO(orderId, weekPromised, orderQty);
+			}
+		} catch (Exception e) {
+			log.log(Level.SEVERE, sql.toString(), e);
+		} finally {
+			DB.close(rs, pstmt);
+			rs = null;
+			pstmt = null;
+		}
+	}
+	
+	/**
+	 * For Requisition
+	 * @param miniMrpProducts
+	 * @param productIds
+	 */
+	private void forOpenRQ(Map<Integer, MiniMRPProduct> miniMrpProducts, Set<Integer> productIds) {
+		//	SQL
+		String sql = new String("SELECT r.M_Requisition_ID, rl.M_Product_ID, SUM(rl.Qty) AS OrderedQty, r.DateRequired "
+				+ "FROM M_Requisition r "
+				+ "INNER JOIN M_RequisitionLine rl ON (r.M_Requisition_ID = rl.M_Requisition_ID) "
+				+ "WHERE r.DocStatus = 'DR' "
+				+ "AND r.DateRequired BETWEEN ? AND ? "
+				+ "AND rl.IsActive = 'Y' "
+				+ "AND r.AD_Client_ID = ? "
+				+ "AND rl.M_Product_ID IN" + productIds.toString().replace('[','(').replace(']',')') + " "
+				+ "AND r.C_DocType_ID = ? "
+				+ "GROUP BY rl.M_Product_ID, r.M_Requisition_ID, r.DateRequired "
+				+ "ORDER BY rl.M_Product_ID, r.DateRequired");
+		//	
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		int paramCount = 1;
+		try {
+			pstmt = DB.prepareStatement(sql, get_TrxName());
+			pstmt.setTimestamp(paramCount++, getDateStart());
+			pstmt.setTimestamp(paramCount++, getDateFinish());
+			pstmt.setInt(paramCount++, getAD_Client_ID());
+			pstmt.setInt(paramCount++, docTypeMRPRequisition);
+			rs = pstmt.executeQuery();
+			while (rs.next()) {
+				int productId = rs.getInt("M_Product_ID");
+				BigDecimal orderQty = rs.getBigDecimal("OrderedQty");
+				Timestamp dateRequired = rs.getTimestamp("DateRequired");
+				//	
+				int weekPromised = TimeUtil.getWeeksBetween(getDateStart(), dateRequired);
+				MiniMRPProduct product = miniMrpProducts.get(productId);
+				int requisitionId = rs.getInt("M_Requisition_ID");
+				product.setSupplyLineRQ(requisitionId, weekPromised, orderQty);
+			}
+		} catch (Exception e) {
+			log.log(Level.SEVERE, sql.toString(), e);
+		} finally {
+			DB.close(rs, pstmt);
+			rs = null;
+			pstmt = null;
+		}
+	}
+	
+	/**
+	 * @author Sachin Bhimani
+	 * @param miniMrpProducts
+	 * @param productIds
+	 * @param type
+	 */
+	private void doRunOpenOrders(Map<Integer, MiniMRPProduct> miniMrpProducts, Set<Integer> productIds, String type) {
+		if (type.equals(TYPE_MO)) {
+			forOpenMO(miniMrpProducts, productIds);
+		} else if (type.equals(TYPE_PO)) {
+			forOpenPO(miniMrpProducts, productIds);
+		} else if (type.equals(TYPE_RQ)) {
+			forOpenRQ(miniMrpProducts, productIds);
+		}
+	}
+
+	/**
+	 * @param miniMrpProducts
+	 * @param productIds
+	 * @param productSO
+	 */
+	private void doRunProductsSO(Map<Integer, MiniMRPProduct> miniMrpProducts, Set<Integer> productIds) {
+		//	Get promised
+		List<MOrderLine> lines = new Query(getCtx(), I_C_OrderLine.Table_Name, "DatePromised BETWEEN ? AND ?"
+				+ " AND (COALESCE(QtyOrdered, 0) - COALESCE(QtyDelivered, 0)) > 0 "
+				+ " AND M_Product_ID IN" + productIds.toString().replace('[','(').replace(']',')')
+				+ " AND EXISTS(SELECT 1 FROM C_Order o "
+				+ "				WHERE o.C_Order_ID = C_OrderLine.C_Order_ID"
+				+ "				AND o.DocStatus = 'CO'"
+				+ "				AND o.IsSOTrx = 'Y')", get_TrxName())
+				.setParameters(getDateStart(), getDateFinish())
+				.setClient_ID()
+				.setOrderBy(I_C_OrderLine.COLUMNNAME_DatePromised)
+				.list();
+		//	Loop it
+		lines.stream()
+				.filter(orderLinePhantom -> !orderLinePhantom.getM_Product().isPhantom())
+				.forEach(orderLine -> {
+			if (miniMrpProducts.containsKey(orderLine.getM_Product_ID())) {
+				MiniMRPProduct mrpProduct = miniMrpProducts.get(orderLine.getM_Product_ID());
+				//	
+				setQtyAsDemand(orderLine.getM_Product_ID(), orderLine.getQtyReserved(), orderLine.getDatePromised());
+				int weekPromised = TimeUtil.getWeeksBetween(getDateStart(), orderLine.getDatePromised());
+				mrpProduct.explodeDemand(orderLine.getC_Order_ID(), orderLine.getQtyReserved(), weekPromised, miniMrpProducts);
+			} else {
+				log.log(Level.SEVERE, "Error in miniMrpProducts setup.");
+			}
+		});
+	}
+
+	/**
+	 * Create Product Demand map.
+	 * 
+	 * @param mProductID
+	 * @param qty
+	 * @param date
+	 */
+	private void setQtyAsDemand(int mProductID, BigDecimal qty, Date date)
+	{
+		if (mapDemand.containsKey(date))
+		{
+			Map<Integer, BigDecimal> mapOrderQty = mapDemand.get(date);
+			if (mapOrderQty.containsKey(mProductID))
+				mapOrderQty.put(mProductID, mapOrderQty.get(mProductID).add(qty));
+			else
+				mapOrderQty.put(mProductID, qty);
+		}
+		else
+		{
+			Map<Integer, BigDecimal> mapOrderQty = new HashMap<Integer, BigDecimal>();
+			mapOrderQty.put(mProductID, qty);
+			mapDemand.put(date, mapOrderQty);
+		}
+	}
+	
+	/**
+	 * Get Replenish
+	 * @param warehouseId
+	 * @param productId
+	 * @return
+	 */
+	private List<MReplenish> getReplenishList(int warehouseId, int productId) {
+		StringBuffer whereClause = new StringBuffer("AD_Client_ID = ?");
+		ArrayList<Object> param = new ArrayList<Object>();
+		param.add(getAD_Client_ID());
+		//	Warehouse
+		whereClause.append(" AND M_Warehouse_ID = ?");
+		param.add(warehouseId);
+		//	Add Optional
+		if(productId != 0) {
+			whereClause.append(" AND M_Product_ID = ?");
+			param.add(productId);
+		}
+		//	Add Exist for Replenish
+		whereClause.append(" AND EXISTS(SELECT 1 FROM M_Product p "
+				+ "WHERE p.M_Product_ID = M_Replenish.M_Product_ID "
+				+ "AND p.IsActive = ? "
+				+ "AND p.IsStocked = ?)");
+		//	Active
+		param.add("Y");
+		//	Stocked
+		param.add("Y");
+		//	
+		List<MReplenish> productReplenish = new Query(getCtx(), I_M_Replenish.Table_Name, whereClause.toString(), get_TrxName())
+				.setParameters(param)
+				.setOnlyActiveRecords(true)
+				.list();
+		//	Replenish
+		return productReplenish;
+	}
+
+	/**
+	 * This method will fetch all the products based on selected category or the
+	 * product. This will process BOMLine if product is finished good. It will
+	 * fill the miniMRPProducts list & id of each product(including BOMlines) in
+	 * productIds
+	 * 
+	 * @param miniMrpProducts
+	 * @param productIds
+	 */
+	private void generateProductInfo(Map<Integer, MiniMRPProduct> miniMrpProducts, Set<Integer> productIds) {
+		List<MReplenish> productReplenish = getReplenishList(getWarehouseId(), getProductId());
+		//	Validate Replenish
+		if(productReplenish.size() == 0) {
+			throw new AdempiereException("@M_Replenish_ID@ @NotFound@");
+		}
+		//	Add to list
+		productReplenish.stream().forEach(replenish -> {
+			if (!miniMrpProducts.containsKey(replenish.getM_Product_ID())) {
+				MiniMRPProduct miniMrpProduct = addProductToProcess(replenish, miniMrpProducts, productIds);
+				//	If Product is FG(Finished Goods) calculate it's BOMlines
+				if (miniMrpProduct.isBOM() && miniMrpProduct.isVerified()) {
+					processBOMLines(miniMrpProducts, productIds, miniMrpProduct.getM_Product_ID());
+				}
+			}
+		});
+	}
+
+	/**
+	 * @param replenish
+	 * @param miniMrpProducts
+	 * @return
+	 * @throws SQLException
+	 */
+	private MiniMRPProduct addProductToProcess(MReplenish replenish, Map<Integer, MiniMRPProduct> miniMrpProducts, Set<Integer> productIds) {
+		MProduct product = MProduct.get(getCtx(), replenish.getM_Product_ID());
+		//	Get current vendor
+		MProductPO[] productPO = MProductPO.getOfProductAndOrg(getCtx(), product.getM_Product_ID(), replenish.getM_Warehouse().getAD_Org_ID(), get_TrxName());
+		int bPartnerId = 0;
+		//	Get Business Partner
+		if(productPO.length > 0) {
+			bPartnerId = productPO[0].getC_BPartner_ID();
+		}
+		BigDecimal levelMin = replenish.getLevel_Min();
+		BigDecimal availableInventory = MStorage.getQtyAvailable(getWarehouseId(), 0, product.getM_Product_ID(), 0, get_TrxName());
+		if (availableInventory == null) {
+			availableInventory = Env.ZERO;
+		}
+		//	Phantom
+		if (product.isPhantom()) {
+			levelMin = Env.ZERO;
+			availableInventory = Env.ZERO;
+		}
+		//	Get Product Price
+		MProductPricing price = new MProductPricing(product.getM_Product_ID(), bPartnerId, levelMin, false, get_TrxName());
+		price.setM_PriceList_ID(priceListId);
+		price.calculatePrice();
+		//	
+		MiniMRPProduct miniMrpProduct = new MiniMRPProduct(product.getM_Product_ID());
+		miniMrpProduct.setAvailableQty(availableInventory);
+		miniMrpProduct.setName(product.getName());
+		miniMrpProduct.setM_Product_Category_ID(product.getM_Product_Category_ID());
+		miniMrpProduct.setProjectedLeadTime(0);
+		miniMrpProduct.setBOM(product.isBOM());
+		miniMrpProduct.setVerified(product.isVerified());
+		miniMrpProduct.setPurchased(product.isPurchased());
+		miniMrpProduct.setPhantom(product.isPhantom());
+		miniMrpProduct.setC_BPartner_ID(bPartnerId);
+		miniMrpProduct.setPriceActual(price.getPriceList());
+		miniMrpProduct.setQtyBatchSize(replenish.getQtyBatchSize());
+		miniMrpProduct.setLevel_Min(levelMin);
+		miniMrpProduct.setReplenishTypeMRPCalculated(replenish.getReplenishType()
+				.equals(X_M_Replenish.REPLENISHTYPE_ReplenishPlanCalculated));
+		if (miniMrpProduct.isReplenishTypeMRPCalculated())
+			miniMrpProduct.setQtyOnHand(availableInventory.subtract(levelMin));
+		else
+			miniMrpProduct.setQtyOnHand(availableInventory);
+
+		// Check product QTY is negative then create demand.
+		if (miniMrpProduct.getQtyOnHand().compareTo(Env.ZERO) < 0 && !product.isPhantom()) {
+			setQtyAsDemand(product.getM_Product_ID(), miniMrpProduct.getQtyOnHand().negate(), getDateStart());
+			miniMrpProduct.setQtyOnHand(Env.ZERO);
+		}
+
+		// Manage Inventory & ProductId blueprint here.
+		productIds.add(product.getM_Product_ID());
+		miniMrpProducts.put(product.getM_Product_ID(), miniMrpProduct);
+		addAvailableInventory(product.getM_Product_ID(), availableInventory);
+
+		// Retrieve Confirmed Product QTY. If non BOM product then retrieve all
+		// requisition data for docType is 'MRP Requisition'.
+		setConfirmProductQty(miniMrpProduct);
+
+		return miniMrpProduct;
+	}
+
+	/**
+	 * @param miniMrpProduct
+	 * @param parentProduct
+	 * @param qtyBom
+	 */
+	private void explodeRequiredMaterials(MiniMRPProduct miniMrpProduct, MiniMRPProduct parentProduct, BigDecimal qtyBom) {
+		Map<Integer, BigDecimal> requiredProdMaterials = miniMrpProduct.getRequiredProdMaterials();
+		for (Integer mProdId : requiredProdMaterials.keySet()) {
+			BigDecimal qty = requiredProdMaterials.get(mProdId);
+			parentProduct.addMaterials(mProdId, qtyBom.multiply(qty));
+		}
+	}
+
+	/**
+	 * Process of BOM Product lines
+	 * 
+	 * @author Sachin Bhimani
+	 * @param miniMrpProducts
+	 * @param productIds
+	 * @param M_Product_ID
+	 */
+	public void processBOMLines(Map<Integer, MiniMRPProduct> miniMrpProducts, Set<Integer> productIds, int M_Product_ID) {
+		MProduct product = MProduct.get(getCtx(), M_Product_ID);
+		//	
+		List<MPPProductBOM> boms = MPPProductBOM.getProductBOMs(product);
+		if(boms.size() > 0) {
+			for(MPPProductBOMLine line : boms.get(0).getLines()) {
+				List<MReplenish> productReplenish = getReplenishList(getWarehouseId(), getProductId());
+				//	Loop it
+				productReplenish.stream().forEach(replenish -> {
+					BigDecimal qtyBom = line.getQtyBOM();
+
+					MiniMRPProduct parentProduct = miniMrpProducts.get(M_Product_ID);
+					parentProduct.addMaterials(line.getM_Product_ID(), qtyBom);
+
+					MiniMRPProduct miniMrpProduct = null;
+
+					// If material is already exploded.
+					if (miniMrpProducts.containsKey(line.getM_Product_ID())) {
+						miniMrpProduct = miniMrpProducts.get(line.getM_Product_ID());
+						explodeRequiredMaterials(miniMrpProduct, parentProduct, qtyBom);
+					} else {
+						miniMrpProduct = addProductToProcess(replenish, miniMrpProducts, productIds);
+						if (miniMrpProduct.isBOM() && miniMrpProduct.isVerified())
+						{
+							processBOMLines(miniMrpProducts, productIds, line.getM_Product_ID());
+							explodeRequiredMaterials(miniMrpProduct, parentProduct, qtyBom);
+						}
+					}
+				});
+			}
+		}
+	}
+
+	class MiniMRPProduct
+	{
+		private MiniMRPProduct							parent;
+
+		private int										M_Product_ID;
+		private int										projectedLeadTimeInWeek	= 1;
+		private int										M_Product_Category_ID;
+		private int										projectedLeadTime;
+		private int										C_BPartner_ID;
+		private String									name;
+		private boolean									isBOM;
+		private boolean									isVerified;
+		private boolean									isPurchased;
+		private boolean									isPhantom;
+		private boolean									isReplenishTypeMRPCalculated;
+		private BigDecimal								availableQty;
+		private BigDecimal								qtyBal;
+		private BigDecimal								qtyOnHand				= Env.ZERO;
+		private BigDecimal								priceActual				= Env.ZERO;
+		private BigDecimal								qtyBatchSize			= Env.ZERO;
+		private BigDecimal								level_Min				= Env.ZERO;
+		private BigDecimal								extraQtyPlanned			= Env.ZERO;
+		private Map<Integer, BigDecimal>				requiredProdMaterials	= new HashMap<Integer, BigDecimal>();
+		private Map<Integer, Map<Integer, BigDecimal>>	supplyLinePO			= new TreeMap<Integer, Map<Integer, BigDecimal>>();
+		private Map<Integer, Map<Integer, BigDecimal>>	supplyLineMO			= new TreeMap<Integer, Map<Integer, BigDecimal>>();
+		private Map<Integer, Map<Integer, BigDecimal>>	supplyLineRQ			= new TreeMap<Integer, Map<Integer, BigDecimal>>();
+		private Map<Integer, Map<Integer, BigDecimal>>	demand					= new LinkedHashMap<Integer, Map<Integer, BigDecimal>>();
+		private Map<Date, BigDecimal>					mapConfirmedProductQty	= new HashMap<Date, BigDecimal>();
+
+		public String getName()
+		{
+			return name;
+		}
+
+		public void setName(String name)
+		{
+			this.name = name;
+		}
+
+		public Map<Integer, Map<Integer, BigDecimal>> getSupplyLinePO()
+		{
+			return supplyLinePO;
+		}
+
+		public Map<Integer, Map<Integer, BigDecimal>> getSupplyLineMO()
+		{
+			return supplyLineMO;
+		}
+
+		public Map<Integer, Map<Integer, BigDecimal>> getSupplyLineRQ()
+		{
+			return supplyLineRQ;
+		}
+
+		public boolean equals(Object obj)
+		{
+			if (!(obj instanceof MiniMRPProduct))
+				return false;
+			if (obj == this)
+				return true;
+
+			MiniMRPProduct rhs = (MiniMRPProduct) obj;
+			return M_Product_ID == rhs.M_Product_ID;
+		}
+
+		public void addMaterials(int productId, BigDecimal qty)
+		{
+			if (requiredProdMaterials.containsKey(productId))
+				qty = qty.add(requiredProdMaterials.get(productId));
+			requiredProdMaterials.put(productId, qty);
+		}
+
+		public void addDemand(int mOrderID, BigDecimal netRequiredQty, int projectdOrderWeek) {
+			Map<Integer, BigDecimal> weekDemand = getOrderDemand(mOrderID);
+			weekDemand.put(projectdOrderWeek, netRequiredQty);
+		}
+
+		public void explodeDemand(int mOrderID, BigDecimal orderQty, int weekPromised,
+				Map<Integer, MiniMRPProduct> miniMrpProducts) {
+			BigDecimal netRequiredQty = orderQty; // explod(orderQty);
+			// int projectdOrderWeek = getOrderProjectedWeek(weekPromised);
+			addDemand(mOrderID, netRequiredQty, weekPromised);
+			// explodMaterialDemand(mOrderID, orderQty, weekPromised,
+			// miniMrpProducts);
+		}
+
+		public Map<Integer, Map<Integer, BigDecimal>> getDemand() {
+			return demand;
+		}
+
+		public Map<Integer, BigDecimal> getOrderDemand(int mOrderID) {
+			Map<Integer, BigDecimal> weekDemand = null;
+			if (demand.containsKey(mOrderID)) {
+				weekDemand = demand.get(mOrderID);
+			} else {
+				weekDemand = new HashMap<Integer, BigDecimal>();
+				demand.put(mOrderID, weekDemand);
+			}
+			return weekDemand;
+		}
+		
+		public void setSupplyLinePO(int c_order_id, int week, BigDecimal openPOqty) {
+			Map<Integer, BigDecimal> weekDemand = null;
+			if (supplyLinePO.containsKey(c_order_id)) {
+				weekDemand = supplyLinePO.get(c_order_id);
+				openPOqty = openPOqty.add(weekDemand.get(week));
+				weekDemand.put(week, openPOqty);
+			} else {
+				weekDemand = new HashMap<Integer, BigDecimal>();
+				weekDemand.put(week, openPOqty);
+			}
+			supplyLinePO.put(c_order_id, weekDemand);
+		}
+
+		public void setSupplyLineMO(int m_production_id, int week, BigDecimal openMOqty) {
+			Map<Integer, BigDecimal> weekDemand = null;
+			if (supplyLineMO.containsKey(m_production_id)) {
+				weekDemand = supplyLineMO.get(m_production_id);
+				openMOqty = openMOqty.add(weekDemand.get(week));
+				weekDemand.put(week, openMOqty);
+			} else {
+				weekDemand = new HashMap<Integer, BigDecimal>();
+				weekDemand.put(week, openMOqty);
+			}
+			supplyLineMO.put(m_production_id, weekDemand);
+		}
+
+		public void setSupplyLineRQ(int m_requisition_id, int week, BigDecimal openRQqty)
+		{
+			Map<Integer, BigDecimal> weekDemand = null;
+			if (supplyLineRQ.containsKey(m_requisition_id))
+			{
+				weekDemand = supplyLineRQ.get(m_requisition_id);
+				openRQqty = openRQqty.add(weekDemand.get(week));
+				weekDemand.put(week, openRQqty);
+			}
+			else
+			{
+				weekDemand = new HashMap<Integer, BigDecimal>();
+				weekDemand.put(week, openRQqty);
+			}
+			supplyLineRQ.put(m_requisition_id, weekDemand);
+		}
+
+		public BigDecimal explod(BigDecimal totalRequiredQty)
+		{
+			if (getQtyBal().compareTo(Env.ZERO) != 0)
+			{
+				BigDecimal avaibleInventory = getAvailableQty();
+				if (avaibleInventory.compareTo(totalRequiredQty) > 0)
+				{
+					setAvailableQty(avaibleInventory.subtract(totalRequiredQty));
+					totalRequiredQty = Env.ZERO;
+				}
+				else
+				{
+					totalRequiredQty = totalRequiredQty.subtract(avaibleInventory);
+					setAvailableQty(Env.ZERO);
+				}
+			}
+			return totalRequiredQty;
+		}
+
+		public boolean hasParent()
+		{
+			return parent != null;
+		}
+
+		public int getM_Product_ID()
+		{
+			return M_Product_ID;
+		}
+
+		public MiniMRPProduct(int M_Product_ID)
+		{
+			this.M_Product_ID = M_Product_ID;
+		}
+
+		public boolean isVerified()
+		{
+			return isVerified;
+		}
+
+		public void setVerified(boolean isVerified)
+		{
+			this.isVerified = isVerified;
+		}
+
+		public int getProjectedLeadTime()
+		{
+			return projectedLeadTime;
+		}
+
+		public int getProjectedLeadTimeInWeek()
+		{
+			return projectedLeadTimeInWeek;
+		}
+
+		public void setProjectedLeadTime(int projectedLeadTime)
+		{
+			this.projectedLeadTime = projectedLeadTime;
+
+			if (!isBOM()) // For other "project Lead Time in Week" will be 1
+							// week flat.
+			{
+				if (projectedLeadTime > 0)
+				{
+					float projectedLTimeInWeek = projectedLeadTime / 7f;
+					if ((projectedLTimeInWeek - (int) projectedLTimeInWeek) > 0)
+					{
+						setProjectedLeadTimeInWeek(((int) projectedLTimeInWeek) + 1);
+					}
+					else
+					{
+						setProjectedLeadTimeInWeek(((int) projectedLTimeInWeek));
+					}
+				}
+			}
+		}
+
+		public void setProjectedLeadTimeInWeek(int projectedLeadTimeWeek)
+		{
+			this.projectedLeadTimeInWeek = projectedLeadTimeWeek;
+		}
+
+		public BigDecimal getAvailableQty()
+		{
+			return availableQty;
+		}
+
+		public void setAvailableQty(BigDecimal availableQty)
+		{
+			this.availableQty = availableQty;
+			setQtyBal(availableQty);
+		}
+
+		public int getM_Product_Category_ID()
+		{
+			return M_Product_Category_ID;
+		}
+
+		public void setM_Product_Category_ID(int m_Product_Category_ID)
+		{
+			M_Product_Category_ID = m_Product_Category_ID;
+		}
+
+		public Map<Integer, BigDecimal> getRequiredProdMaterials()
+		{
+			return requiredProdMaterials;
+		}
+
+		public boolean isBOM()
+		{
+			return isBOM;
+		}
+
+		public void setBOM(boolean isBOM)
+		{
+			this.isBOM = isBOM;
+		}
+
+		public BigDecimal getQtyBal()
+		{
+			return qtyBal;
+		}
+
+		public void setQtyBal(BigDecimal qtyBal)
+		{
+			this.qtyBal = qtyBal;
+		}
+
+		public BigDecimal getQtyOnHand()
+		{
+			return qtyOnHand;
+		}
+
+		public void setQtyOnHand(BigDecimal qtyOnHand)
+		{
+			this.qtyOnHand = qtyOnHand;
+		}
+
+		public Map<Date, BigDecimal> getMapConfirmProductQty()
+		{
+			return mapConfirmedProductQty;
+		}
+
+		public void setMapConfirmProductQty(Map<Date, BigDecimal> mapConfirmProductionQty)
+		{
+			this.mapConfirmedProductQty = mapConfirmProductionQty;
+		}
+
+		public void addConfirmProductionQty(Date date, BigDecimal qty)
+		{
+			if (mapConfirmedProductQty.containsKey(date))
+				qty = mapConfirmedProductQty.get(date).add(qty);
+			mapConfirmedProductQty.put(date, qty);
+		}
+
+		public boolean isPurchased()
+		{
+			return isPurchased;
+		}
+
+		public void setPurchased(boolean isPurchased)
+		{
+			this.isPurchased = isPurchased;
+		}
+
+		public int getC_BPartner_ID()
+		{
+			return C_BPartner_ID;
+		}
+
+		public void setC_BPartner_ID(int c_BPartner_ID)
+		{
+			C_BPartner_ID = c_BPartner_ID;
+		}
+
+		public BigDecimal getPriceActual()
+		{
+			return priceActual;
+		}
+
+		public void setPriceActual(BigDecimal priceActual)
+		{
+			this.priceActual = priceActual;
+		}
+
+		public boolean isPhantom()
+		{
+			return isPhantom;
+		}
+
+		public void setPhantom(boolean isPhantom)
+		{
+			this.isPhantom = isPhantom;
+		}
+
+		public BigDecimal getQtyBatchSize()
+		{
+			return qtyBatchSize;
+		}
+
+		public void setQtyBatchSize(BigDecimal qtyBatchSize)
+		{
+			this.qtyBatchSize = qtyBatchSize;
+		}
+
+		public BigDecimal getLevel_Min()
+		{
+			return level_Min;
+		}
+
+		public void setLevel_Min(BigDecimal level_Min)
+		{
+			this.level_Min = level_Min;
+		}
+
+		public BigDecimal getExtraQtyPlanned()
+		{
+			return extraQtyPlanned;
+		}
+
+		public void setExtraQtyPlanned(BigDecimal extraQtyPlanned)
+		{
+			this.extraQtyPlanned = extraQtyPlanned;
+		}
+
+		public boolean isReplenishTypeMRPCalculated()
+		{
+			return isReplenishTypeMRPCalculated;
+		}
+
+		public void setReplenishTypeMRPCalculated(boolean isReplenishTypeMRPCalculated)
+		{
+			this.isReplenishTypeMRPCalculated = isReplenishTypeMRPCalculated;
+		}
+	}
+
+	/**
+	 * @param week
+	 * @param qty
+	 */
+	public void setWeeklyData(X_M_ReplenishPlanLine miniMRP, int week, BigDecimal qty)
+	{
+		switch (week) {
+			case 0:
+				miniMRP.setWeek1(qty);
+				break;
+			case 1:
+				miniMRP.setWeek2(qty);
+				break;
+			case 2:
+				miniMRP.setWeek3(qty);
+				break;
+			case 3:
+				miniMRP.setWeek4(qty);
+				break;
+			case 4:
+				miniMRP.setWeek5(qty);
+				break;
+			case 5:
+				miniMRP.setWeek6(qty);
+				break;
+			case 6:
+				miniMRP.setWeek7(qty);
+				break;
+			case 7:
+				miniMRP.setWeek8(qty);
+				break;
+			case 8:
+				miniMRP.setWeek9(qty);
+				break;
+			case 9:
+				miniMRP.setWeek10(qty);
+				break;
+			case 10:
+				miniMRP.setWeek11(qty);
+				break;
+			case 11:
+				miniMRP.setWeek12(qty);
+				break;
+			case 12:
+				miniMRP.setWeek13(qty);
+				break;
+			case 13:
+				miniMRP.setWeek14(qty);
+				break;
+			case 14:
+				miniMRP.setWeek15(qty);
+				break;
+			case 15:
+				miniMRP.setWeek16(qty);
+				break;
+			case 16:
+				miniMRP.setWeek17(qty);
+				break;
+			case 17:
+				miniMRP.setWeek18(qty);
+				break;
+			case 18:
+				miniMRP.setWeek19(qty);
+				break;
+			case 19:
+				miniMRP.setWeek20(qty);
+				break;
+			case 20:
+				miniMRP.setWeek21(qty);
+				break;
+			case 21:
+				miniMRP.setWeek22(qty);
+				break;
+			case 22:
+				miniMRP.setWeek23(qty);
+				break;
+			case 23:
+				miniMRP.setWeek24(qty);
+				break;
+			default:
+				break;
+		}
+	}
+
+}

--- a/src/patches/org/compiere/acct/Doc_Invoice.java
+++ b/src/patches/org/compiere/acct/Doc_Invoice.java
@@ -1,0 +1,910 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 1999-2006 ComPiere, Inc. All Rights Reserved.                *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * ComPiere, Inc., 2620 Augustine Dr. #245, Santa Clara, CA 95054, USA        *
+ * or via info@compiere.org or http://www.compiere.org/license.html           *
+ *****************************************************************************/
+package org.compiere.acct;
+
+import org.compiere.model.MAccount;
+import org.compiere.model.MAcctSchema;
+import org.compiere.model.MCostDetail;
+import org.compiere.model.MCostType;
+import org.compiere.model.MCurrency;
+import org.compiere.model.MInvoice;
+import org.compiere.model.MInvoiceLine;
+import org.compiere.model.MLandedCostAllocation;
+import org.compiere.model.MRevenueRecognitionPlan;
+import org.compiere.model.MTax;
+import org.compiere.model.ProductCost;
+import org.compiere.util.DB;
+import org.compiere.util.Env;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.logging.Level;
+
+/**
+ *  Post Invoice Documents.
+ *  <pre>
+ *  Table:              C_Invoice (318)
+ *  Document Types:     ARI, ARC, ARF, API, APC
+ *  </pre>
+ *  @author Jorg Janke
+ *  @author Armen Rizal, Goodwill Consulting
+ *  	<li>BF: 2797257	Landed Cost Detail is not using allocation qty
+ *  
+ *  @version  $Id: Doc_Invoice.java,v 1.2 2006/07/30 00:53:33 jjanke Exp $
+ */
+public class Doc_Invoice extends Doc
+{
+	/**
+	 *  Constructor
+	 * 	@param ass accounting schemata
+	 * 	@param rs record
+	 * 	@param trxName trx
+	 */
+	public Doc_Invoice(MAcctSchema[] ass, ResultSet rs, String trxName)
+	{
+		super (ass, MInvoice.class, rs, null, trxName);
+	}	//	Doc_Invoice
+
+	/** Contained Optional Tax Lines    */
+	private DocTax[]        m_taxes = null;
+	/** Currency Precision				*/
+	private int				m_precision = -1;
+	/** All lines are Service			*/
+	private boolean			m_allLinesService = true;
+	/** All lines are product item		*/
+	private boolean			m_allLinesItem = true;
+
+	/**
+	 *  Load Specific Document Details
+	 *  @return error message or null
+	 */
+	public String loadDocumentDetails ()
+	{
+		MInvoice invoice = (MInvoice)getPO();
+		setDateDoc(invoice.getDateInvoiced());
+		setIsTaxIncluded(invoice.isTaxIncluded());
+		//	Amounts
+		setAmount(Doc.AMTTYPE_Gross, invoice.getGrandTotal());
+		setAmount(Doc.AMTTYPE_Net, invoice.getTotalLines());
+		setAmount(Doc.AMTTYPE_Charge, invoice.getChargeAmt());
+				
+		//	Contained Objects
+		m_taxes = loadTaxes();
+		p_lines = loadLines(invoice);
+		log.fine("Lines=" + p_lines.length + ", Taxes=" + m_taxes.length);
+		return null;
+	}   //  loadDocumentDetails
+
+	/**
+	 *	Load Invoice Taxes
+	 *  @return DocTax Array
+	 */
+	private DocTax[] loadTaxes()
+	{
+		ArrayList<DocTax> list = new ArrayList<DocTax>();
+		String sql = "SELECT it.C_Tax_ID, t.Name, t.Rate, it.TaxBaseAmt, it.TaxAmt, t.IsSalesTax "
+			+ "FROM C_Tax t, C_InvoiceTax it "
+			+ "WHERE t.C_Tax_ID=it.C_Tax_ID AND it.C_Invoice_ID=?";
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		try
+		{
+			pstmt = DB.prepareStatement(sql, getTrxName());
+			pstmt.setInt(1, get_ID());
+			rs = pstmt.executeQuery();
+			//
+			while (rs.next())
+			{
+				int C_Tax_ID = rs.getInt(1);
+				String name = rs.getString(2);
+				BigDecimal rate = rs.getBigDecimal(3);
+				BigDecimal taxBaseAmt = rs.getBigDecimal(4);
+				BigDecimal amount = rs.getBigDecimal(5);
+				boolean salesTax = "Y".equals(rs.getString(6));
+				//
+				DocTax taxLine = new DocTax(C_Tax_ID, name, rate, 
+					taxBaseAmt, amount, salesTax);
+				log.fine(taxLine.toString());
+				list.add(taxLine);
+			}
+		}
+		catch (SQLException e)
+		{
+			log.log(Level.SEVERE, sql, e);
+			return null;
+		}
+		finally {
+			DB.close(rs, pstmt);
+			rs = null; pstmt = null;
+		}
+
+		//	Return Array
+		DocTax[] tl = new DocTax[list.size()];
+		list.toArray(tl);
+		return tl;
+	}	//	loadTaxes
+
+	/**
+	 *	Load Invoice Line
+	 *	@param invoice invoice
+	 *  @return DocLine Array
+	 */
+	private DocLine[] loadLines (MInvoice invoice)
+	{
+		ArrayList<DocLine> list = new ArrayList<DocLine>();
+		//
+		MInvoiceLine[] lines = invoice.getLines(false);
+		for (int i = 0; i < lines.length; i++)
+		{
+			MInvoiceLine line = lines[i];
+			if (line.isDescription())
+				continue;
+			DocLine docLine = new DocLine(line, this);
+			//	Qty
+			BigDecimal Qty = line.getQtyInvoiced();
+			boolean cm = getDocumentType().equals(DOCTYPE_ARCredit) 
+				|| getDocumentType().equals(DOCTYPE_APCredit);
+			docLine.setQty(cm ? Qty.negate() : Qty, invoice.isSOTrx());
+			//
+			BigDecimal LineNetAmt = line.getLineNetAmt();
+			BigDecimal PriceList = line.getPriceList();
+			int C_Tax_ID = docLine.getC_Tax_ID();
+			//	Correct included Tax
+			if (isTaxIncluded() && C_Tax_ID != 0)
+			{
+				MTax tax = MTax.get(getCtx(), C_Tax_ID);
+				if (!tax.isZeroTax())
+				{
+					BigDecimal LineNetAmtTax = tax.calculateTax(LineNetAmt, true, getStdPrecision());
+					log.fine("LineNetAmt=" + LineNetAmt + " - Tax=" + LineNetAmtTax);
+					LineNetAmt = LineNetAmt.subtract(LineNetAmtTax);
+					for (int t = 0; t < m_taxes.length; t++)
+					{
+						if (m_taxes[t].getC_Tax_ID() == C_Tax_ID)
+						{
+							m_taxes[t].addIncludedTax(LineNetAmtTax);
+							break;
+						}
+					}
+					BigDecimal PriceListTax = tax.calculateTax(PriceList, true, getStdPrecision());
+					PriceList = PriceList.subtract(PriceListTax);
+				}
+			}	//	correct included Tax
+			
+			docLine.setAmount (LineNetAmt, PriceList, Qty);	//	qty for discount calc
+			if (docLine.isItem())
+				m_allLinesService = false;
+			else
+				m_allLinesItem = false;
+			//
+			log.fine(docLine.toString());
+			list.add(docLine);
+		}
+		
+		//	Convert to Array
+		DocLine[] dls = new DocLine[list.size()];
+		list.toArray(dls);
+
+		//	Included Tax - make sure that no difference
+		if (isTaxIncluded())
+		{
+			for (int i = 0; i < m_taxes.length; i++)
+			{
+				if (m_taxes[i].isIncludedTaxDifference())
+				{
+					BigDecimal diff = m_taxes[i].getIncludedTaxDifference(); 
+					for (int j = 0; j < dls.length; j++)
+					{
+						if (dls[j].getC_Tax_ID() == m_taxes[i].getC_Tax_ID())
+						{
+							dls[j].setLineNetAmtDifference(diff);
+							break;
+						}
+					}	//	for all lines
+				}	//	tax difference
+			}	//	for all taxes
+		}	//	Included Tax difference
+		
+		//	Return Array
+		return dls;
+	}	//	loadLines
+
+	/**
+	 * 	Get Currency Precision
+	 *	@return precision
+	 */
+	private int getStdPrecision()
+	{
+		if (m_precision == -1)
+			m_precision = MCurrency.getStdPrecision(getCtx(), getC_Currency_ID());
+		return m_precision;
+	}	//	getPrecision
+
+	
+	/**************************************************************************
+	 *  Get Source Currency Balance - subtracts line and tax amounts from total - no rounding
+	 *  @return positive amount, if total invoice is bigger than lines
+	 */
+	public BigDecimal getBalance()
+	{
+		BigDecimal retValue = Env.ZERO;
+		StringBuffer sb = new StringBuffer (" [");
+		//  Total
+		retValue = retValue.add(getAmount(Doc.AMTTYPE_Gross));
+		sb.append(getAmount(Doc.AMTTYPE_Gross));
+		//  - Header Charge
+		retValue = retValue.subtract(getAmount(Doc.AMTTYPE_Charge));
+		sb.append("-").append(getAmount(Doc.AMTTYPE_Charge));
+		//  - Tax
+		for (int i = 0; i < m_taxes.length; i++)
+		{
+			retValue = retValue.subtract(m_taxes[i].getAmount());
+			sb.append("-").append(m_taxes[i].getAmount());
+		}
+		//  - Lines
+		for (int i = 0; i < p_lines.length; i++)
+		{
+			retValue = retValue.subtract(p_lines[i].getAmtSource());
+			sb.append("-").append(p_lines[i].getAmtSource());
+		}
+		sb.append("]");
+		//
+		log.fine(toString() + " Balance=" + retValue + sb.toString());
+		return retValue;
+	}   //  getBalance
+
+	private MAccount getRevenueRecognitionAccount(MAcctSchema acctSchema, DocLine line, int accountType, List<MRevenueRecognitionPlan> revenueRecognitionPlans) {
+		int invoiceLineId = line.get_ID();
+		Optional<MRevenueRecognitionPlan> maybePlan = revenueRecognitionPlans.stream().filter(plan -> plan.getC_InvoiceLine_ID() == invoiceLineId).findFirst();
+		MAccount revenueAccount = line.getAccount(accountType, acctSchema);
+		if(maybePlan.isPresent()) {
+			revenueAccount = (MAccount) maybePlan.get().getUnEarnedRevenue_A();
+		}
+		return revenueAccount;
+	}
+
+	/**
+	 *  Create Facts (the accounting logic) for
+	 *  ARI, ARC, ARF, API, APC.
+	 *  <pre>
+	 *  ARI, ARF
+	 *      Receivables     DR
+	 *      Charge                  CR
+	 *      TaxDue                  CR
+	 *      Revenue                 CR
+	 *
+	 *  ARC
+	 *      Receivables             CR
+	 *      Charge          DR
+	 *      TaxDue          DR
+	 *      Revenue         RR
+	 *
+	 *  API
+	 *      Payables                CR
+	 *      Charge          DR
+	 *      TaxCredit       DR
+	 *      Expense         DR
+	 *
+	 *  APC
+	 *      Payables        DR
+	 *      Charge                  CR
+	 *      TaxCredit               CR
+	 *      Expense                 CR
+	 *  </pre>
+	 *  @param acctSchema accounting schema
+	 *  @return Fact
+	 */
+	public ArrayList<Fact> createFacts (MAcctSchema acctSchema)
+	{
+		//
+		ArrayList<Fact> facts = new ArrayList<Fact>();
+		//  create Fact Header
+		Fact fact = new Fact(this, acctSchema, Fact.POST_Actual);
+
+		//  Cash based accounting
+		if (!acctSchema.isAccrual())
+			return facts;
+		List<MRevenueRecognitionPlan> revenueRecognitionPlans = MRevenueRecognitionPlan.getPlansFromInvoiceAndSchema((MInvoice) getPO(), acctSchema.getC_AcctSchema_ID());
+		//  ** ARI, ARF
+		if (getDocumentType().equals(DOCTYPE_ARInvoice) 
+			|| getDocumentType().equals(DOCTYPE_ARProForma))
+		{
+			BigDecimal grossAmt = getAmount(Doc.AMTTYPE_Gross);
+			BigDecimal serviceAmt = Env.ZERO;
+			
+			//  Header Charge           CR
+			BigDecimal amt = getAmount(Doc.AMTTYPE_Charge);
+			if (amt != null && amt.signum() != 0)
+				fact.createLine(null, getAccount(Doc.ACCTTYPE_Charge, acctSchema),
+					getC_Currency_ID(), null, amt);
+			//  TaxDue                  CR
+			for (int i = 0; i < m_taxes.length; i++)
+			{
+				amt = m_taxes[i].getAmount();
+				if (amt != null)
+				{
+					FactLine tl = fact.createLine(null, m_taxes[i].getAccount(DocTax.ACCTTYPE_TaxDue, acctSchema),
+						getC_Currency_ID(), null, amt);
+					if (tl != null)
+						tl.setC_Tax_ID(m_taxes[i].getC_Tax_ID());
+				}
+			}
+			//  Revenue                 CR
+			for (int i = 0; i < p_lines.length; i++)
+			{
+				amt = p_lines[i].getAmtSource();
+				BigDecimal dAmt = null;
+				if (acctSchema.isTradeDiscountPosted())
+				{
+					BigDecimal discount = p_lines[i].getDiscount();
+					if (discount != null && discount.signum() != 0)
+					{
+						amt = amt.add(discount);
+						dAmt = discount;
+						fact.createLine (p_lines[i],
+								p_lines[i].getAccount(ProductCost.ACCTTYPE_P_TDiscountGrant, acctSchema),
+								getC_Currency_ID(), dAmt, null);
+					}
+				}
+				fact.createLine (p_lines[i],
+						getRevenueRecognitionAccount(acctSchema, p_lines[i], ProductCost.ACCTTYPE_P_Revenue, revenueRecognitionPlans),
+					getC_Currency_ID(), null, amt);
+				if (!p_lines[i].isItem())
+				{
+					grossAmt = grossAmt.subtract(amt);
+					serviceAmt = serviceAmt.add(amt);
+				}
+			}
+			//  Set Locations
+			FactLine[] fLines = fact.getLines();
+			for (int i = 0; i < fLines.length; i++)
+			{
+				if (fLines[i] != null)
+				{
+					fLines[i].setLocationFromOrg(fLines[i].getAD_Org_ID(), true);      //  from Loc
+					fLines[i].setLocationFromBPartner(getC_BPartner_Location_ID(), false);  //  to Loc
+				}
+			}
+			
+			//  Receivables     DR
+			int receivablesId = getValidCombinationId(Doc.ACCTTYPE_C_Receivable, acctSchema);
+			int receivablesServicesId = getValidCombinationId(Doc.ACCTTYPE_C_Receivable_Services, acctSchema);
+			if (m_allLinesItem || !acctSchema.isPostServices()
+				|| receivablesId == receivablesServicesId)
+			{
+				grossAmt = getAmount(Doc.AMTTYPE_Gross);
+				serviceAmt = Env.ZERO;
+			}
+			else if (m_allLinesService)
+			{
+				serviceAmt = getAmount(Doc.AMTTYPE_Gross);
+				grossAmt = Env.ZERO;
+			}
+			if (grossAmt.signum() != 0)
+				fact.createLine(null, MAccount.getValidCombination(getCtx(), receivablesId, getTrxName()),
+					getC_Currency_ID(), grossAmt, null);
+			if (serviceAmt.signum() != 0)
+				fact.createLine(null, MAccount.getValidCombination(getCtx(), receivablesServicesId , getTrxName()),
+					getC_Currency_ID(), serviceAmt, null);
+		}
+		//  ARC
+		else if (getDocumentType().equals(DOCTYPE_ARCredit))
+		{
+			BigDecimal grossAmt = getAmount(Doc.AMTTYPE_Gross);
+			BigDecimal serviceAmt = Env.ZERO;
+
+			//  Header Charge   DR
+			BigDecimal amt = getAmount(Doc.AMTTYPE_Charge);
+			if (amt != null && amt.signum() != 0)
+				fact.createLine(null, getAccount(Doc.ACCTTYPE_Charge, acctSchema),
+					getC_Currency_ID(), amt, null);
+			//  TaxDue          DR
+			for (int i = 0; i < m_taxes.length; i++)
+			{
+				amt = m_taxes[i].getAmount();
+				if (amt != null)
+				{
+					FactLine tl = fact.createLine(null, m_taxes[i].getAccount(DocTax.ACCTTYPE_TaxDue, acctSchema),
+						getC_Currency_ID(), amt, null);
+					if (tl != null)
+						tl.setC_Tax_ID(m_taxes[i].getC_Tax_ID());
+				}
+			}
+			//  Revenue         CR
+			for (int i = 0; i < p_lines.length; i++)
+			{
+				amt = p_lines[i].getAmtSource();
+				BigDecimal dAmt = null;
+				if (acctSchema.isTradeDiscountPosted())
+				{
+					BigDecimal discount = p_lines[i].getDiscount();
+					if (discount != null && discount.signum() != 0)
+					{
+						amt = amt.add(discount);
+						dAmt = discount;
+						fact.createLine (p_lines[i],
+								p_lines[i].getAccount (ProductCost.ACCTTYPE_P_TDiscountGrant, acctSchema),
+								getC_Currency_ID(), null, dAmt);
+					}
+				}
+				fact.createLine (p_lines[i],
+						getRevenueRecognitionAccount(acctSchema, p_lines[i], ProductCost.ACCTTYPE_P_Revenue, revenueRecognitionPlans),
+					getC_Currency_ID(), amt, null);
+				if (!p_lines[i].isItem())
+				{
+					grossAmt = grossAmt.subtract(amt);
+					serviceAmt = serviceAmt.add(amt);
+				}
+			}
+			//  Set Locations
+			FactLine[] fLines = fact.getLines();
+			for (int i = 0; i < fLines.length; i++)
+			{
+				if (fLines[i] != null)
+				{
+					fLines[i].setLocationFromOrg(fLines[i].getAD_Org_ID(), true);      //  from Loc
+					fLines[i].setLocationFromBPartner(getC_BPartner_Location_ID(), false);  //  to Loc
+				}
+			}
+			//  Receivables             CR
+			int receivablesId = getValidCombinationId(Doc.ACCTTYPE_C_Receivable, acctSchema);
+			int receivablesServicesId = getValidCombinationId(Doc.ACCTTYPE_C_Receivable_Services, acctSchema);
+			if (m_allLinesItem || !acctSchema.isPostServices()
+				|| receivablesId == receivablesServicesId)
+			{
+				grossAmt = getAmount(Doc.AMTTYPE_Gross);
+				serviceAmt = Env.ZERO;
+			}
+			else if (m_allLinesService)
+			{
+				serviceAmt = getAmount(Doc.AMTTYPE_Gross);
+				grossAmt = Env.ZERO;
+			}
+			if (grossAmt.signum() != 0)
+				fact.createLine(null, MAccount.getValidCombination(getCtx(), receivablesId , getTrxName()),
+					getC_Currency_ID(), null, grossAmt);
+			if (serviceAmt.signum() != 0)
+				fact.createLine(null, MAccount.getValidCombination(getCtx(), receivablesServicesId , getTrxName()),
+					getC_Currency_ID(), null, serviceAmt);
+		}
+		
+		//  ** API
+		else if (getDocumentType().equals(DOCTYPE_APInvoice))
+		{
+			BigDecimal grossAmt = getAmount(Doc.AMTTYPE_Gross);
+			BigDecimal serviceAmt = Env.ZERO;
+
+			//  Charge          DR
+			fact.createLine(null, getAccount(Doc.ACCTTYPE_Charge, acctSchema),
+				getC_Currency_ID(), getAmount(Doc.AMTTYPE_Charge), null);
+			//  TaxCredit       DR
+			for (int i = 0; i < m_taxes.length; i++)
+			{
+				FactLine tl;
+				if (m_taxes[i].getRate().signum() >= 0)
+					tl = fact.createLine(null, m_taxes[i].getAccount(m_taxes[i].getAPTaxType(), acctSchema), getC_Currency_ID(), m_taxes[i].getAmount(), null);
+				else
+					tl = fact.createLine(null, m_taxes[i].getAccount(m_taxes[i].getAPTaxType(), acctSchema), getC_Currency_ID(),  null , m_taxes[i].getAmount().negate());
+
+				if (tl != null)
+					tl.setC_Tax_ID(m_taxes[i].getC_Tax_ID());
+			}
+			//  Expense         DR
+			for (int i = 0; i < p_lines.length; i++)
+			{
+				DocLine line = p_lines[i];
+				boolean landedCost = landedCost(acctSchema, fact, line, true);
+				if (landedCost && acctSchema.isExplicitCostAdjustment())
+				{
+					fact.createLine (line, line.getAccount(ProductCost.ACCTTYPE_P_Expense, acctSchema),
+						getC_Currency_ID(), line.getAmtSource(), null);
+					//
+					FactLine fl = fact.createLine (line, line.getAccount(ProductCost.ACCTTYPE_P_Expense, acctSchema),
+						getC_Currency_ID(), null, line.getAmtSource());
+					String desc = line.getDescription();
+					if (desc == null)
+						desc = "100%";
+					else
+						desc += " 100%";
+					fl.setDescription(desc);
+				}
+				if (!landedCost)
+				{
+					MAccount expense = getRevenueRecognitionAccount(acctSchema, p_lines[i], ProductCost.ACCTTYPE_P_Expense, revenueRecognitionPlans);
+					if (line.isItem())
+						expense = getRevenueRecognitionAccount(acctSchema, p_lines[i], ProductCost.ACCTTYPE_P_InventoryClearing, revenueRecognitionPlans);
+					BigDecimal amt = line.getAmtSource();
+					BigDecimal dAmt = null;
+					if (acctSchema.isTradeDiscountPosted() && !line.isItem())
+					{
+						BigDecimal discount = line.getDiscount();
+						if (discount != null && discount.signum() != 0)
+						{
+							amt = amt.add(discount);
+							dAmt = discount;
+							MAccount tradeDiscountReceived = line.getAccount(ProductCost.ACCTTYPE_P_TDiscountRec, acctSchema);
+							fact.createLine (line, tradeDiscountReceived,
+									getC_Currency_ID(), null, dAmt);
+						}
+					}
+					fact.createLine (line, expense,
+						getC_Currency_ID(), amt, null);
+					if (!line.isItem())
+					{
+						grossAmt = grossAmt.subtract(amt);
+						serviceAmt = serviceAmt.add(amt);
+					}
+					//
+					/*if (line.getM_Product_ID() != 0
+						&& line.getProduct().isService())	//	otherwise Inv Matching
+						MCostDetail.createInvoice(as, line.getAD_Org_ID(), 
+							line.getM_Product_ID(), line.getM_AttributeSetInstance_ID(),
+							line.get_ID(), 0,		//	No Cost Element
+							line.getAmtSource(), line.getQty(),
+							line.getDescription(), getTrxName());*/
+				}
+			}
+			//  Set Locations
+			FactLine[] fLines = fact.getLines();
+			for (int i = 0; i < fLines.length; i++)
+			{
+				if (fLines[i] != null)
+				{
+					fLines[i].setLocationFromBPartner(getC_BPartner_Location_ID(), true);  //  from Loc
+ 						fLines[i].setLocationFromOrg(fLines[i].getAD_Org_ID(), false);    //  to Loc
+				}
+			}
+
+			//  Liability               CR
+			int payablesId = getValidCombinationId(Doc.ACCTTYPE_V_Liability, acctSchema);
+			int payablesServicesId = getValidCombinationId(Doc.ACCTTYPE_V_Liability_Services, acctSchema);
+			if (m_allLinesItem || !acctSchema.isPostServices()
+				|| payablesId == payablesServicesId)
+			{
+				grossAmt = getAmount(Doc.AMTTYPE_Gross);
+				serviceAmt = Env.ZERO;
+			}
+			else if (m_allLinesService)
+			{
+				serviceAmt = getAmount(Doc.AMTTYPE_Gross);
+				grossAmt = Env.ZERO;
+			}
+			if (grossAmt.signum() != 0)
+				fact.createLine(null, MAccount.getValidCombination(getCtx(), payablesId , getTrxName()),
+					getC_Currency_ID(), null, grossAmt);
+			if (serviceAmt.signum() != 0)
+				fact.createLine(null, MAccount.getValidCombination(getCtx(), payablesServicesId , getTrxName()),
+					getC_Currency_ID(), null, serviceAmt);
+		}
+		//  APC
+		else if (getDocumentType().equals(DOCTYPE_APCredit))
+		{
+			BigDecimal grossAmt = getAmount(Doc.AMTTYPE_Gross);
+			BigDecimal serviceAmt = Env.ZERO;
+			//  Charge                  CR
+			fact.createLine (null, getAccount(Doc.ACCTTYPE_Charge, acctSchema),
+				getC_Currency_ID(), null, getAmount(Doc.AMTTYPE_Charge));
+			//  TaxCredit               CR
+			for (int i = 0; i < m_taxes.length; i++)
+			{
+				FactLine tl;
+				if (m_taxes[i].getRate().signum() >= 0)
+					tl = fact.createLine (null, m_taxes[i].getAccount(m_taxes[i].getAPTaxType(), acctSchema), getC_Currency_ID(), null, m_taxes[i].getAmount());
+				else
+					tl = fact.createLine (null, m_taxes[i].getAccount(m_taxes[i].getAPTaxType(), acctSchema), getC_Currency_ID(), m_taxes[i].getAmount().negate(),null);
+
+				if (tl != null)
+					tl.setC_Tax_ID(m_taxes[i].getC_Tax_ID());
+			}
+			//  Expense                 CR
+			for (int i = 0; i < p_lines.length; i++)
+			{
+				DocLine line = p_lines[i];
+				boolean landedCost = landedCost(acctSchema, fact, line, false);
+				if (landedCost && acctSchema.isExplicitCostAdjustment())
+				{
+					fact.createLine (line, line.getAccount(ProductCost.ACCTTYPE_P_Expense, acctSchema),
+						getC_Currency_ID(), null, line.getAmtSource());
+					//
+					FactLine fl = fact.createLine (line, line.getAccount(ProductCost.ACCTTYPE_P_Expense, acctSchema),
+						getC_Currency_ID(), line.getAmtSource(), null);
+					String desc = line.getDescription();
+					if (desc == null)
+						desc = "100%";
+					else
+						desc += " 100%";
+					fl.setDescription(desc);
+				}
+				if (!landedCost)
+				{
+					MAccount expense = getRevenueRecognitionAccount(acctSchema, p_lines[i], ProductCost.ACCTTYPE_P_Expense, revenueRecognitionPlans);
+					if (line.isItem())
+						expense = getRevenueRecognitionAccount(acctSchema, p_lines[i], ProductCost.ACCTTYPE_P_InventoryClearing, revenueRecognitionPlans);
+					BigDecimal amt = line.getAmtSource();
+					BigDecimal dAmt = null;
+					if (acctSchema.isTradeDiscountPosted() && !line.isItem())
+					{
+						BigDecimal discount = line.getDiscount();
+						if (discount != null && discount.signum() != 0)
+						{
+							amt = amt.add(discount);
+							dAmt = discount;
+							MAccount tradeDiscountReceived = line.getAccount(ProductCost.ACCTTYPE_P_TDiscountRec, acctSchema);
+							fact.createLine (line, tradeDiscountReceived,
+									getC_Currency_ID(), dAmt, null);
+						}
+					}
+					fact.createLine (line, expense,
+						getC_Currency_ID(), null, amt);
+					if (!line.isItem())
+					{
+						grossAmt = grossAmt.subtract(amt);
+						serviceAmt = serviceAmt.add(amt);
+					}
+					//
+					/*if (line.getM_Product_ID() != 0
+						&& line.getProduct().isService())	//	otherwise Inv Matching
+						MCostDetail.createInvoice(as, line.getAD_Org_ID(), 
+							line.getM_Product_ID(), line.getM_AttributeSetInstance_ID(),
+							line.get_ID(), 0,		//	No Cost Element
+							line.getAmtSource().negate(), line.getQty(),
+							line.getDescription(), getTrxName());*/
+				}
+			}
+			//  Set Locations
+			FactLine[] fLines = fact.getLines();
+			for (int i = 0; i < fLines.length; i++)
+			{
+				if (fLines[i] != null)
+				{
+					fLines[i].setLocationFromBPartner(getC_BPartner_Location_ID(), true);  //  from Loc
+					fLines[i].setLocationFromOrg(fLines[i].getAD_Org_ID(), false);    //  to Loc
+				}
+			}
+			//  Liability       DR
+			int payablesId = getValidCombinationId(Doc.ACCTTYPE_V_Liability, acctSchema);
+			int payablesServicesId = getValidCombinationId(Doc.ACCTTYPE_V_Liability_Services, acctSchema);
+			if (m_allLinesItem || !acctSchema.isPostServices()
+				|| payablesId == payablesServicesId)
+			{
+				grossAmt = getAmount(Doc.AMTTYPE_Gross);
+				serviceAmt = Env.ZERO;
+			}
+			else if (m_allLinesService)
+			{
+				serviceAmt = getAmount(Doc.AMTTYPE_Gross);
+				grossAmt = Env.ZERO;
+			}
+			if (grossAmt.signum() != 0)
+				fact.createLine(null, MAccount.getValidCombination(getCtx(), payablesId , getTrxName()),
+					getC_Currency_ID(), grossAmt, null);
+			if (serviceAmt.signum() != 0)
+				fact.createLine(null, MAccount.getValidCombination(getCtx(), payablesServicesId , getTrxName()),
+					getC_Currency_ID(), serviceAmt, null);
+		}
+		else
+		{
+			p_Error = "DocumentType unknown: " + getDocumentType();
+			log.log(Level.SEVERE, p_Error);
+			fact = null;
+		}
+		//
+		facts.add(fact);
+		return facts;
+	}   //  createFact
+	
+	/**
+	 * 	Create Fact Cash Based (i.e. only revenue/expense)
+	 *	@param as accounting schema
+	 *	@param fact fact to add lines to
+	 *	@param multiplier source amount multiplier
+	 *	@return accounted amount
+	 */
+	public BigDecimal createFactCash (MAcctSchema as, Fact fact, BigDecimal multiplier)
+	{
+		boolean creditMemo = getDocumentType().equals(DOCTYPE_ARCredit)
+			|| getDocumentType().equals(DOCTYPE_APCredit);
+		boolean payables = getDocumentType().equals(DOCTYPE_APInvoice)
+			|| getDocumentType().equals(DOCTYPE_APCredit);
+		BigDecimal acctAmt = Env.ZERO;
+		FactLine fl = null;
+		//	Revenue/Cost
+		for (int i = 0; i < p_lines.length; i++)
+		{
+			DocLine line = p_lines[i];
+			boolean landedCost = false;
+			if  (payables)
+				landedCost = landedCost(as, fact, line, false);
+			if (landedCost && as.isExplicitCostAdjustment())
+			{
+				fact.createLine (line, line.getAccount(ProductCost.ACCTTYPE_P_Expense, as),
+					getC_Currency_ID(), null, line.getAmtSource());
+				//
+				fl = fact.createLine (line, line.getAccount(ProductCost.ACCTTYPE_P_Expense, as),
+					getC_Currency_ID(), line.getAmtSource(), null);
+				String desc = line.getDescription();
+				if (desc == null)
+					desc = "100%";
+				else
+					desc += " 100%";
+				fl.setDescription(desc);
+			}
+			if (!landedCost)
+			{
+				MAccount acct = line.getAccount(
+					payables ? ProductCost.ACCTTYPE_P_Expense : ProductCost.ACCTTYPE_P_Revenue, as);
+				if (payables)
+				{
+					//	if Fixed Asset
+					if (line.isItem())
+						acct = line.getAccount (ProductCost.ACCTTYPE_P_InventoryClearing, as);
+				}
+				BigDecimal amt = line.getAmtSource().multiply(multiplier);
+				BigDecimal amt2 = null;
+				if (creditMemo)
+				{
+					amt2 = amt;
+					amt = null;
+				}
+				if (payables)	//	Vendor = DR
+					fl = fact.createLine (line, acct,
+						getC_Currency_ID(), amt, amt2);
+				else			//	Customer = CR
+					fl = fact.createLine (line, acct,
+						getC_Currency_ID(), amt2, amt);
+				if (fl != null)
+					acctAmt = acctAmt.add(fl.getAcctBalance());
+			}
+		}
+		//  Tax
+		for (int i = 0; i < m_taxes.length; i++)
+		{
+			BigDecimal amt = m_taxes[i].getAmount();
+			BigDecimal amt2 = null;
+			if (creditMemo)
+			{
+				amt2 = amt;
+				amt = null;
+			}
+			FactLine tl = null;
+			if (payables)
+				tl = fact.createLine (null, m_taxes[i].getAccount(m_taxes[i].getAPTaxType(), as),
+					getC_Currency_ID(), amt, amt2);
+			else
+				tl = fact.createLine (null, m_taxes[i].getAccount(DocTax.ACCTTYPE_TaxDue, as),
+					getC_Currency_ID(), amt2, amt);
+			if (tl != null)
+				tl.setC_Tax_ID(m_taxes[i].getC_Tax_ID());
+		}
+		//  Set Locations
+		FactLine[] fLines = fact.getLines();
+		for (int i = 0; i < fLines.length; i++)
+		{
+			if (fLines[i] != null)
+			{
+				if (payables)
+				{
+					fLines[i].setLocationFromBPartner(getC_BPartner_Location_ID(), true);  //  from Loc
+					fLines[i].setLocationFromOrg(fLines[i].getAD_Org_ID(), false);    //  to Loc
+				}
+				else
+				{
+					fLines[i].setLocationFromOrg(fLines[i].getAD_Org_ID(), true);    //  from Loc
+					fLines[i].setLocationFromBPartner(getC_BPartner_Location_ID(), false);  //  to Loc
+				}
+			}
+		}
+		return acctAmt;
+	}	//	createFactCash
+	
+	
+	/**
+	 * 	Create Landed Cost accounting & Cost lines
+	 *	@param as accounting schema
+	 *	@param fact fact
+	 *	@param line document line
+	 *	@param isDebit DR entry (normal api)
+	 *	@return true if landed costs were created
+	 */
+	private boolean landedCost (MAcctSchema as, Fact fact, DocLine line, boolean isDebit)
+	{
+		int invoiceLineId = line.get_ID();
+		MLandedCostAllocation[] landedCostAllocations = MLandedCostAllocation.getOfInvoiceLine(
+			getCtx(), invoiceLineId, getTrxName());
+		if (landedCostAllocations.length == 0)
+			return false;
+
+		BigDecimal totalBase = Arrays.stream(landedCostAllocations)
+				.map(MLandedCostAllocation::getBase)
+				.reduce(BigDecimal.ZERO, BigDecimal::add);
+
+		//	Create New
+		MInvoiceLine invoiceLine = new MInvoiceLine (getCtx(), invoiceLineId, getTrxName());
+		Arrays.stream(landedCostAllocations)
+				.filter(landedCostAllocation -> landedCostAllocation.getBase().signum() != 0) // only cost allocation with base > 0
+				.forEach(landedCostAllocation -> {
+			BigDecimal percent = landedCostAllocation.getBase().divide(totalBase, RoundingMode.HALF_UP);
+			String desc = invoiceLine.getDescription();
+			if (desc == null)
+				desc = percent + "%";
+			else
+				desc += " - " + percent + "%";
+			if (line.getDescription() != null)
+				desc += " - " + line.getDescription();
+			
+			//	Accounting
+			ProductCost productCost = new ProductCost (Env.getCtx(),
+				landedCostAllocation.getM_Product_ID(), landedCostAllocation.getM_AttributeSetInstance_ID(), getTrxName());
+			BigDecimal debitAmount = BigDecimal.ZERO;
+			BigDecimal creditAmount = BigDecimal.ZERO;;
+			FactLine factLine = null;
+			MCostType costType = MCostType.get(as, landedCostAllocation.getM_Product_ID() , landedCostAllocation.getAD_Org_ID());
+			if(MCostType.COSTINGMETHOD_AverageInvoice.equals(costType.getCostingMethod()))
+			{
+				//Cost to inventory asset
+				BigDecimal assetAmount = Optional.ofNullable(MCostDetail.getByDocLineLandedCost(
+						landedCostAllocation,
+						as.getC_AcctSchema_ID(),
+						costType.get_ID())).orElseGet(() -> BigDecimal.ZERO);
+				if (assetAmount.signum() != 0)
+				{
+					if (isDebit)
+						debitAmount = assetAmount;
+					else
+						creditAmount = assetAmount.negate();
+
+					factLine = fact.createLine(line, productCost.getAccount(ProductCost.ACCTTYPE_P_Asset, as),
+							as.getC_Currency_ID(), debitAmount, creditAmount);
+					factLine.setDescription(desc + " " + landedCostAllocation.getM_CostElement().getName());
+					factLine.setM_Product_ID(landedCostAllocation.getM_Product_ID());
+				}
+				//cost to Cost Adjustment
+				BigDecimal costAllocation =  landedCostAllocation.getPriceActual().multiply(landedCostAllocation.getQty());
+				BigDecimal costAdjustment =  costAllocation.subtract(assetAmount);
+				setIsMultiCurrency(landedCostAllocation.getC_Currency_ID()!=as.getC_Currency_ID());
+				if (costAdjustment.signum() != 0) {
+					if (isDebit)
+						debitAmount = costAdjustment;
+					else
+						creditAmount = costAdjustment;
+
+					factLine = fact.createLine(line, productCost.getAccount(ProductCost.ACCTTYPE_P_CostAdjustment,as),
+							getC_Currency_ID(), debitAmount, creditAmount);
+				}
+			}	
+			else
+			{	
+				factLine = fact.createLine (line, productCost.getAccount(ProductCost.ACCTTYPE_P_CostAdjustment, as),
+						getC_Currency_ID(), debitAmount, creditAmount);
+			}	
+			
+			factLine.setDescription(desc + " " + landedCostAllocation.getM_CostElement().getName());
+			factLine.setM_Product_ID(landedCostAllocation.getM_Product_ID());
+		});
+		log.config("Created #" + landedCostAllocations.length);
+		return true;
+	}	//	landedCosts
+
+
+}   //  Doc_Invoice

--- a/src/patches/org/compiere/acct/Doc_Order.java
+++ b/src/patches/org/compiere/acct/Doc_Order.java
@@ -1,0 +1,697 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 1999-2006 ComPiere, Inc. All Rights Reserved.                *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * ComPiere, Inc., 2620 Augustine Dr. #245, Santa Clara, CA 95054, USA        *
+ * or via info@compiere.org or http://www.compiere.org/license.html           *
+ *****************************************************************************/
+package org.compiere.acct;
+
+import org.adempiere.core.domains.models.I_C_OrderLine;
+import org.compiere.model.MAccount;
+import org.compiere.model.MAcctSchema;
+import org.compiere.model.MCurrency;
+import org.compiere.model.MOrder;
+import org.compiere.model.MOrderLine;
+import org.compiere.model.MRequisitionLine;
+import org.compiere.model.MTax;
+import org.compiere.model.ProductCost;
+import org.compiere.model.Query;
+import org.compiere.util.DB;
+import org.compiere.util.Env;
+
+import java.math.BigDecimal;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.logging.Level;
+
+/**
+ *  Post Order Documents.
+ *  <pre>
+ *  Table:              C_Order (259)
+ *  Document Types:     SOO, POO
+ *  </pre>
+ *  @author Jorg Janke
+ *  @version  $Id: Doc_Order.java,v 1.3 2006/07/30 00:53:33 jjanke Exp $
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
+ */
+public class Doc_Order extends Doc
+{
+	/**
+	 *  Constructor
+	 * 	@param ass accounting schemata
+	 * 	@param rs record
+	 * 	@param trxName trx
+	 */
+	public Doc_Order (MAcctSchema[] ass, ResultSet rs, String trxName)
+	{
+		super (ass, MOrder.class, rs, null, trxName);
+	}	//	Doc_Order
+
+	/** Contained Optional Tax Lines    */
+	private DocTax[]        m_taxes = null;
+	/** Requisitions					*/
+	private DocLine[]		m_requisitions = null;
+	/** Order Currency Precision		*/
+	private int				m_precision = -1;
+
+	/**
+	 *  Load Specific Document Details
+	 *  @return error message or null
+	 */
+	public String loadDocumentDetails ()
+	{
+		MOrder order = (MOrder)getPO();
+		setDateDoc(order.getDateOrdered());
+		setIsTaxIncluded(order.isTaxIncluded());
+		//	Amounts
+		setAmount(AMTTYPE_Gross, order.getGrandTotal());
+		setAmount(AMTTYPE_Net, order.getTotalLines());
+		setAmount(AMTTYPE_Charge, order.getChargeAmt());
+				
+		//	Contained Objects
+		m_taxes = loadTaxes();
+		p_lines = loadLines(order);
+	//	log.fine( "Lines=" + p_lines.length + ", Taxes=" + m_taxes.length);
+		return null;
+	}   //  loadDocumentDetails
+
+
+	/**
+	 *	Load Invoice Line
+	 *	@param order order
+	 *  @return DocLine Array
+	 */
+	public DocLine[] loadLines(MOrder order)
+	{
+		ArrayList<DocLine> list = new ArrayList<DocLine>();
+		MOrderLine[] lines = order.getLines();
+		for (int i = 0; i < lines.length; i++)
+		{
+			MOrderLine line = lines[i];
+			DocLine docLine = new DocLine (line, this);
+			BigDecimal Qty = line.getQtyOrdered();
+			docLine.setQty(Qty, order.isSOTrx());
+			//
+			BigDecimal priceCost = null;
+			if (getDocumentType().equals(DOCTYPE_POrder))	//	PO
+				priceCost = line.getPriceCost();
+			BigDecimal LineNetAmt = null;
+			if (priceCost != null && priceCost.signum() != 0)
+				LineNetAmt = Qty.multiply(priceCost);
+			else
+				LineNetAmt = line.getLineNetAmt();
+			docLine.setAmount (LineNetAmt);	//	DR
+			BigDecimal PriceList = line.getPriceList();
+			int C_Tax_ID = docLine.getC_Tax_ID();
+			//	Correct included Tax
+			if (isTaxIncluded() && C_Tax_ID != 0)
+			{
+				MTax tax = MTax.get(getCtx(), C_Tax_ID);
+				if (!tax.isZeroTax())
+				{
+					BigDecimal LineNetAmtTax = tax.calculateTax(LineNetAmt, true, getStdPrecision());
+					log.fine("LineNetAmt=" + LineNetAmt + " - Tax=" + LineNetAmtTax);
+					LineNetAmt = LineNetAmt.subtract(LineNetAmtTax);
+					for (int t = 0; t < m_taxes.length; t++)
+					{
+						if (m_taxes[t].getC_Tax_ID() == C_Tax_ID)
+						{
+							m_taxes[t].addIncludedTax(LineNetAmtTax);
+							break;
+						}
+					}
+					BigDecimal PriceListTax = tax.calculateTax(PriceList, true, getStdPrecision());
+					PriceList = PriceList.subtract(PriceListTax);
+				}
+			}	//	correct included Tax
+			
+			docLine.setAmount (LineNetAmt, PriceList, Qty);
+			list.add(docLine);
+		}
+
+		//	Return Array
+		DocLine[] dl = new DocLine[list.size()];
+		list.toArray(dl);
+		return dl;
+	}	//	loadLines
+	
+	
+	/**
+	 * 	Load Requisitions
+	 *	@return requisition lines of Order
+	 */
+	public DocLine[] loadRequisitions ()
+	{
+		MOrder order = (MOrder)getPO();
+		MOrderLine[] oLines = order.getLines();
+		HashMap<Integer,BigDecimal> qtys = new HashMap<Integer,BigDecimal>();
+		for (int i = 0; i < oLines.length; i++)
+		{
+			MOrderLine line = oLines[i];
+			qtys.put(Integer.valueOf(line.getC_OrderLine_ID()), line.getQtyOrdered());
+		}
+		//
+		ArrayList<DocLine> list = new ArrayList<DocLine>();
+		String sql = "SELECT * FROM M_RequisitionLine rl "
+			+ "WHERE EXISTS (SELECT * FROM C_Order o "
+				+ " INNER JOIN C_OrderLine ol ON (o.C_Order_ID=ol.C_Order_ID) "
+				+ "WHERE ol.C_OrderLine_ID=rl.C_OrderLine_ID"
+				+ " AND o.C_Order_ID=?) "
+			+ "ORDER BY rl.C_OrderLine_ID";
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		try
+		{
+			pstmt = DB.prepareStatement (sql, null);
+			pstmt.setInt (1, order.getC_Order_ID());
+			rs = pstmt.executeQuery ();
+			while (rs.next ())
+			{
+				MRequisitionLine line = new MRequisitionLine (getCtx(), rs, null);
+				DocLine docLine = new DocLine (line, this);
+				//	Quantity - not more then OrderLine
+				//	Issue: Split of Requisition to multiple POs & different price
+				Integer key = Integer.valueOf(line.getC_OrderLine_ID());
+				BigDecimal maxQty = qtys.get(key);
+				BigDecimal Qty = line.getQty().max(maxQty);
+				if (Qty.signum() == 0)
+					continue;
+				docLine.setQty (Qty, false);
+				qtys.put(key, maxQty.subtract(Qty));
+				//
+				BigDecimal PriceActual = line.getPriceActual();
+				BigDecimal LineNetAmt = line.getLineNetAmt();
+				if (line.getQty().compareTo(Qty) != 0)
+					LineNetAmt = PriceActual.multiply(Qty);
+				docLine.setAmount (LineNetAmt);	 // DR
+				list.add (docLine);
+			}
+		}
+		catch (Exception e)
+		{
+			log.log (Level.SEVERE, sql, e);
+		}
+		finally
+		{
+			DB.close(rs, pstmt);
+			rs = null; pstmt = null;
+		}
+		
+		// Return Array
+		DocLine[] dls = new DocLine[list.size ()];
+		list.toArray (dls);
+		return dls;
+	}	// loadRequisitions
+
+	
+	/**
+	 * 	Get Currency Precision
+	 *	@return precision
+	 */
+	public int getStdPrecision()
+	{
+		if (m_precision == -1)
+			m_precision = MCurrency.getStdPrecision(getCtx(), getC_Currency_ID());
+		return m_precision;
+	}	//	getPrecision
+
+	/**
+	 *	Load Invoice Taxes
+	 *  @return DocTax Array
+	 */
+	public DocTax[] loadTaxes()
+	{
+		ArrayList<DocTax> list = new ArrayList<DocTax>();
+		String sql = "SELECT it.C_Tax_ID, t.Name, t.Rate, it.TaxBaseAmt, it.TaxAmt, t.IsSalesTax "
+			+ "FROM C_Tax t, C_OrderTax it "
+			+ "WHERE t.C_Tax_ID=it.C_Tax_ID AND it.C_Order_ID=?";
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		try
+		{
+			pstmt = DB.prepareStatement(sql, getTrxName());
+			pstmt.setInt(1, get_ID());
+			rs = pstmt.executeQuery();
+			//
+			while (rs.next())
+			{
+				int C_Tax_ID = rs.getInt(1);
+				String name = rs.getString(2);
+				BigDecimal rate = rs.getBigDecimal(3);
+				BigDecimal taxBaseAmt = rs.getBigDecimal(4);
+				BigDecimal amount = rs.getBigDecimal(5);
+				boolean salesTax = "Y".equals(rs.getString(6));
+				//
+				DocTax taxLine = new DocTax(C_Tax_ID, name, rate, 
+					taxBaseAmt, amount, salesTax);
+				list.add(taxLine);
+			}
+		}
+		catch (SQLException e)
+		{
+			log.log(Level.SEVERE, sql, e);
+		}
+		finally {
+			DB.close(rs, pstmt);
+			rs = null; pstmt = null;
+		}
+
+		//	Return Array
+		DocTax[] tl = new DocTax[list.size()];
+		list.toArray(tl);
+		return tl;
+	}	//	loadTaxes
+
+	
+	/**************************************************************************
+	 *  Get Source Currency Balance - subtracts line and tax amounts from total - no rounding
+	 *  @return positive amount, if total invoice is bigger than lines
+	 */
+	public BigDecimal getBalance()
+	{
+		BigDecimal retValue = Env.ZERO;
+		StringBuffer sb = new StringBuffer (" [");
+		//  Total
+		retValue = retValue.add(getAmount(Doc.AMTTYPE_Gross));
+		sb.append(getAmount(Doc.AMTTYPE_Gross));
+		//  - Header Charge
+		retValue = retValue.subtract(getAmount(Doc.AMTTYPE_Charge));
+		sb.append("-").append(getAmount(Doc.AMTTYPE_Charge));
+		//  - Tax
+		if (m_taxes != null)
+		{
+			for (int i = 0; i < m_taxes.length; i++)
+			{
+				retValue = retValue.subtract(m_taxes[i].getAmount());
+				sb.append("-").append(m_taxes[i].getAmount());
+			}
+		}
+		//  - Lines
+		if (p_lines != null)
+		{
+			for (int i = 0; i < p_lines.length; i++)
+			{
+				retValue = retValue.subtract(p_lines[i].getAmtSource());
+				sb.append("-").append(p_lines[i].getAmtSource());
+			}
+			sb.append("]");
+		}
+		//
+		if (retValue.signum() != 0		//	Sum of Cost(vs. Price) in lines may not add up 
+			&& getDocumentType().equals(DOCTYPE_POrder))	//	PO
+		{
+			log.fine(toString() + " Balance=" + retValue + sb.toString() + " (ignored)");
+			retValue = Env.ZERO;
+		}
+		else
+			log.fine(toString() + " Balance=" + retValue + sb.toString());
+		return retValue;
+	}   //  getBalance
+
+	
+	/*************************************************************************
+	 *  Create Facts (the accounting logic) for
+	 *  SOO, POO.
+	 *  <pre>
+	 *  Reservation (release)
+	 * 		Expense			DR
+	 * 		Offset					CR
+	 *  Commitment
+	 *  (to be released by Invoice Matching)
+	 * 		Expense					CR
+	 * 		Offset			DR
+	 *  </pre>
+	 *  @param as accounting schema
+	 *  @return Fact
+	 */
+	public ArrayList<Fact> createFacts (MAcctSchema as)
+	{
+		ArrayList<Fact> facts = new ArrayList<Fact>();
+		//  Purchase Order
+		if (getDocumentType().equals(DOCTYPE_POrder))
+		{
+			updateProductInfo(as.getC_AcctSchema_ID());
+			//  Commitment
+			if (as.isCreatePOCommitment()) {
+				Fact fact = new Fact(this, as, Fact.POST_Commitment);
+				BigDecimal total = Env.ZERO;
+				for (int i = 0; i < p_lines.length; i++)
+				{
+					DocLine line = p_lines[i];
+					BigDecimal cost = line.getAmtSource();
+					total = total.add(cost);
+
+					//	Account
+					MAccount expense = line.getAccount(ProductCost.ACCTTYPE_P_Expense, as);
+					fact.createLine (line, expense, getC_Currency_ID(), cost, null);
+				}
+				//	Offset
+				MAccount offset = getAccount(ACCTTYPE_CommitmentOffset, as);
+				if (offset == null)
+				{
+					p_Error = "@NotFound@ @CommitmentOffset_Acct@";
+					log.log(Level.SEVERE, p_Error);
+					return null;
+				}
+				fact.createLine (null, offset, getC_Currency_ID(), null, total);
+				//
+				facts.add(fact);
+			}
+			
+			//  Reverse Reservation
+			if (as.isCreateReservation())
+			{
+				Fact fact = new Fact(this, as, Fact.POST_Reservation);
+				BigDecimal total = Env.ZERO;
+				if (m_requisitions == null)
+					m_requisitions = loadRequisitions();
+				for (int i = 0; i < m_requisitions.length; i++)
+				{
+					DocLine line = m_requisitions[i];
+					BigDecimal cost = line.getAmtSource();
+					total = total.add(cost);
+
+					//	Account
+					MAccount expense = line.getAccount(ProductCost.ACCTTYPE_P_Expense, as);
+					fact.createLine (line, expense, getC_Currency_ID(), null, cost);
+				}
+				//	Offset
+				if (m_requisitions.length > 0)
+				{
+					MAccount offset = getAccount(ACCTTYPE_CommitmentOffset, as);
+					if (offset == null)
+					{
+						p_Error = "@NotFound@ @CommitmentOffset_Acct@";
+						log.log(Level.SEVERE, p_Error);
+						return null;
+					}
+					fact.createLine (null, offset,
+						getC_Currency_ID(), total, null);
+				}
+				//
+				facts.add(fact);
+			}	//	reservations
+		}
+		//	SO
+		else if (getDocumentType().equals(DOCTYPE_SOrder))
+		{
+			//  Commitment
+			if (as.isCreateSOCommitment())
+			{
+				Fact fact = new Fact(this, as, Fact.POST_Commitment);
+				BigDecimal total = Env.ZERO;
+				for (int i = 0; i < p_lines.length; i++)
+				{
+					DocLine line = p_lines[i];
+					BigDecimal cost = line.getAmtSource();
+					total = total.add(cost);
+
+					//	Account
+					MAccount revenue = line.getAccount(ProductCost.ACCTTYPE_P_Revenue, as);
+					fact.createLine (line, revenue, getC_Currency_ID(), null, cost);
+				}
+				//	Offset
+				MAccount offset = getAccount(ACCTTYPE_CommitmentOffsetSales, as);
+				if (offset == null)
+				{
+					p_Error = "@NotFound@ @CommitmentOffsetSales_Acct@";
+					log.log(Level.SEVERE, p_Error);
+					return null;
+				}
+				fact.createLine (null, offset,
+					getC_Currency_ID(), total, null);
+				//
+				facts.add(fact);
+			}
+			
+		}
+		return facts;
+	}   //  createFact
+
+	
+
+	
+	
+	/**
+	 * 	Get Commitments
+	 * 	@param document document
+	 * 	@param maxQuantity Qty invoiced/matched
+	 * 	@param invoiceLineId invoice line
+	 *	@return commitments (order lines)
+	 */
+	public static DocLine[] getCommitments(Doc document, BigDecimal maxQuantity, int invoiceLineId) {
+		String whereClause = "EXISTS(SELECT 1 FROM C_InvoiceLine il "
+				+ "WHERE il.C_OrderLine_ID = C_OrderLine.C_OrderLine_ID"
+				+ " AND il.C_InvoiceLine_ID=?)"
+			+ " OR EXISTS(SELECT 1 FROM M_MatchPO po "
+				+ "WHERE po.C_OrderLine_ID = C_OrderLine.C_OrderLine_ID"
+				+ " AND po.C_InvoiceLine_ID=?)";
+		List<MOrderLine> orderLineList = new Query(document.getCtx(), I_C_OrderLine.Table_Name, whereClause, null)
+				.setParameters(invoiceLineId, invoiceLineId)
+				.list();
+		return getCommitments(document, orderLineList, maxQuantity);
+	}
+	
+	/**
+	 * 	Get Commitment Release.
+	 * 	Called from MatchInv for accrual and Allocation for Cash Based
+	 *	@param as accounting schema
+	 *	@param doc doc
+	 *	@param Qty qty invoiced/matched
+	 *	@param C_InvoiceLine_ID line
+	 *	@param multiplier 1 for accrual
+	 *	@return Fact
+	 */
+	public static Fact getCommitmentRelease(MAcctSchema as, Doc doc, 
+		BigDecimal Qty, int C_InvoiceLine_ID, BigDecimal multiplier)
+	{
+		Fact fact = new Fact(doc, as, Fact.POST_Commitment);
+		DocLine[] commitments = Doc_Order.getCommitments(doc, Qty, 
+				C_InvoiceLine_ID);
+		
+		BigDecimal total = Env.ZERO;
+		int C_Currency_ID = -1;
+		for (int i = 0; i < commitments.length; i++)
+		{
+			DocLine line = commitments[i];
+			if (C_Currency_ID == -1)
+				C_Currency_ID = line.getC_Currency_ID();
+			else if (C_Currency_ID != line.getC_Currency_ID())
+			{
+				doc.p_Error = "Different Currencies of Order Lines";
+				s_log.log(Level.SEVERE, doc.p_Error);
+				return null;
+			}
+			BigDecimal cost = line.getAmtSource().multiply(multiplier);
+			total = total.add(cost);
+
+			//	Account
+			MAccount expense = line.getAccount(ProductCost.ACCTTYPE_P_Expense, as);
+			fact.createLine (line, expense, C_Currency_ID, null, cost);
+		}
+		//	Offset
+		MAccount offset = doc.getAccount(ACCTTYPE_CommitmentOffset, as);
+		if (offset == null)
+		{
+			doc.p_Error = "@NotFound@ @CommitmentOffset_Acct@";
+			s_log.log(Level.SEVERE, doc.p_Error);
+			return null;
+		}
+		fact.createLine (null, offset,
+			C_Currency_ID, total, null);
+		return fact;
+	}	//	getCommitmentRelease
+	
+	/**
+	 * Get Commitment from list
+	 * @param document
+	 * @param orderLineList
+	 * @param maxQuantity
+	 * @return
+	 */
+	public static DocLine[] getCommitments(Doc document, List<MOrderLine> orderLineList, BigDecimal maxQuantity) {
+		int precision = -1;
+		ArrayList<DocLine> list = new ArrayList<DocLine>();
+		//	
+		for(MOrderLine orderLine : orderLineList) {
+			if (maxQuantity.signum() == 0)
+				continue;
+			DocLine documentLine = new DocLine (orderLine, document);
+			//	Currency
+			if (precision == -1) {
+				document.setC_Currency_ID(documentLine.getC_Currency_ID());
+				precision = MCurrency.getStdPrecision(document.getCtx(), documentLine.getC_Currency_ID());
+			}
+			//	Quantity
+			BigDecimal quantity = orderLine.getQtyOrdered();
+			if(maxQuantity.compareTo(quantity) != 0) {
+				quantity = maxQuantity;
+			}
+			documentLine.setQty(quantity, false);
+			//
+			BigDecimal priceActual = orderLine.getPriceActual();
+			BigDecimal priceCost = orderLine.getPriceCost();
+			BigDecimal lineNetAmt = null;
+			if (priceCost != null && priceCost.signum() != 0)
+				lineNetAmt = quantity.multiply(priceCost);
+			else if (orderLine.getQtyOrdered().equals(maxQuantity))
+				lineNetAmt = orderLine.getLineNetAmt();
+			else
+				lineNetAmt = quantity.multiply(priceActual);
+			maxQuantity = maxQuantity.subtract(quantity);
+			
+			documentLine.setAmount (lineNetAmt);	//	DR
+			BigDecimal priceList = orderLine.getPriceList();
+			int taxId = documentLine.getC_Tax_ID();
+			//	Correct included Tax
+			if (taxId != 0 && orderLine.getParent().isTaxIncluded()) {
+				MTax tax = MTax.get(document.getCtx(), taxId);
+				if (!tax.isZeroTax()) {
+					BigDecimal lineNetAmtTax = tax.calculateTax(lineNetAmt, true, precision);
+					s_log.fine("LineNetAmt=" + lineNetAmt + " - Tax=" + lineNetAmtTax);
+					lineNetAmt = lineNetAmt.subtract(lineNetAmtTax);
+					BigDecimal priceListTax = tax.calculateTax(priceList, true, precision);
+					priceList = priceList.subtract(priceListTax);
+				}
+			}	//	correct included Tax
+			
+			documentLine.setAmount (lineNetAmt, priceList, quantity);
+			list.add(documentLine);
+		}
+		//	Return Array
+		DocLine[] documentLineAsArray = new DocLine[list.size()];
+		list.toArray(documentLineAsArray);
+		return documentLineAsArray;
+	}
+	
+	/**
+	 * 	Get Commitments Sales
+	 * 	@param document document
+	 * 	@param maxQuantity Qty invoiced/matched
+	 * 	@param C_OrderLine_ID invoice line
+	 *	@return commitments (order lines)
+	 */
+	public static DocLine[] getCommitmentsSales(Doc document, BigDecimal maxQuantity, int inOutLineId) {
+		//
+		String whereClause = "EXISTS (SELECT 1 FROM M_InOutLine il "
+					+ "	WHERE il.C_OrderLine_ID = C_OrderLine.C_OrderLine_ID"
+					+ " AND il.M_InOutLine_ID = ?)";
+		List<MOrderLine> orderLineList = new Query(document.getCtx(), I_C_OrderLine.Table_Name, whereClause, null)
+			.setParameters(inOutLineId)
+			.list();
+		return getCommitments(document, orderLineList, maxQuantity);
+	}	//	getCommitmentsSales
+
+	/**
+	 * 	Get Commitment Sales Release.
+	 * 	Called from InOut
+	 *	@param as accounting schema
+	 *	@param doc doc
+	 *	@param Qty qty invoiced/matched
+	 *	@param C_OrderLine_ID line
+	 *	@param multiplier 1 for accrual
+	 *	@return Fact
+	 */
+	public static Fact getCommitmentSalesRelease(MAcctSchema as, Doc doc, 
+		BigDecimal Qty, int M_InOutLine_ID, BigDecimal multiplier)
+	{
+		Fact fact = new Fact(doc, as, Fact.POST_Commitment);
+		DocLine[] commitments = Doc_Order.getCommitmentsSales(doc, Qty, 
+				M_InOutLine_ID);
+		
+		BigDecimal total = Env.ZERO;
+		int C_Currency_ID = -1;
+		for (int i = 0; i < commitments.length; i++)
+		{
+			DocLine line = commitments[i];
+			if (C_Currency_ID == -1)
+				C_Currency_ID = line.getC_Currency_ID();
+			else if (C_Currency_ID != line.getC_Currency_ID())
+			{
+				doc.p_Error = "Different Currencies of Order Lines";
+				s_log.log(Level.SEVERE, doc.p_Error);
+				return null;
+			}
+			BigDecimal cost = line.getAmtSource().multiply(multiplier);
+			total = total.add(cost);
+
+			//	Account
+			MAccount revenue = line.getAccount(ProductCost.ACCTTYPE_P_Revenue, as);
+			fact.createLine (line, revenue, C_Currency_ID, cost, null);
+		}
+		//	Offset
+		MAccount offset = doc.getAccount(ACCTTYPE_CommitmentOffsetSales, as);
+		if (offset == null)
+		{
+			doc.p_Error = "@NotFound@ @CommitmentOffsetSales_Acct@";
+			s_log.log(Level.SEVERE, doc.p_Error);
+			return null;
+		}
+		fact.createLine (null, offset,
+			C_Currency_ID, null, total);
+		return fact;
+	}	//	getCommitmentSalesRelease
+	
+	/**************************************************************************
+	 *  Update Product Info (old)
+	 *  - Costing (PriceLastPO)
+	 *  - PO (PriceLastPO)
+	 *  @param C_AcctSchema_ID accounting schema
+	 *  @deprecated old costing
+	 */
+	public void updateProductInfo (int C_AcctSchema_ID)
+	{
+		log.fine("C_Order_ID=" + get_ID());
+
+		/** @todo Last.. would need to compare document/last updated date
+		 *  would need to maintain LastPriceUpdateDate on _PO and _Costing */
+
+		//  update Product Costing
+		//  requires existence of currency conversion !!
+		//  if there are multiple lines of the same product last price uses first
+		StringBuffer sql = new StringBuffer (
+			"UPDATE M_Product_Costing pc "
+			+ "SET PriceLastPO = "
+			+ "(SELECT currencyConvert(ol.PriceActual,ol.C_Currency_ID,a.C_Currency_ID,o.DateOrdered,o.C_ConversionType_ID,o.AD_Client_ID,o.AD_Org_ID) "
+			+ "FROM C_Order o, C_OrderLine ol, C_AcctSchema a "
+			+ "WHERE o.C_Order_ID=ol.C_Order_ID"
+			+ " AND pc.M_Product_ID=ol.M_Product_ID AND pc.C_AcctSchema_ID=a.C_AcctSchema_ID ");
+			if (DB.isOracle()) //jz
+			{
+				sql.append(" AND ROWNUM=1 ");
+			}
+			else 
+				sql.append(" AND ol.C_OrderLine_ID = (SELECT MIN(ol1.C_OrderLine_ID) "
+						+ "FROM C_Order o1, C_OrderLine ol1 "
+						+ "WHERE o1.C_Order_ID=ol1.C_Order_ID"
+						+ " AND pc.M_Product_ID=ol1.M_Product_ID ")
+						.append("  AND o1.C_Order_ID=").append(get_ID()).append(") ");
+			sql.append(" AND pc.C_AcctSchema_ID=").append(C_AcctSchema_ID).append(" AND o.C_Order_ID=")
+			.append(get_ID()).append(") ")
+			.append("WHERE EXISTS (SELECT * "
+			+ "FROM C_Order o, C_OrderLine ol, C_AcctSchema a "
+			+ "WHERE o.C_Order_ID=ol.C_Order_ID"
+			+ " AND pc.M_Product_ID=ol.M_Product_ID AND pc.C_AcctSchema_ID=a.C_AcctSchema_ID"
+			+ " AND pc.C_AcctSchema_ID=").append(C_AcctSchema_ID).append(" AND o.C_Order_ID=")
+			.append(get_ID()).append(")");
+		int no = DB.executeUpdate(sql.toString(), getTrxName());
+		log.fine("M_Product_Costing - Updated=" + no);
+	}   //  updateProductInfo
+
+}   //  Doc_Order

--- a/src/patches/org/compiere/model/MCost.java
+++ b/src/patches/org/compiere/model/MCost.java
@@ -1,0 +1,2051 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 1999-2006 ComPiere, Inc. All Rights Reserved.                *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * ComPiere, Inc., 2620 Augustine Dr. #245, Santa Clara, CA 95054, USA        *
+ * or via info@compiere.org or http://www.compiere.org/license.html           *
+ * Contributor(s): Teo Sarca                                                  *
+ *****************************************************************************/
+package org.compiere.model;
+
+import org.adempiere.core.domains.models.I_M_Cost;
+import org.adempiere.core.domains.models.X_M_Cost;
+import org.adempiere.engine.CostComponent;
+import org.adempiere.engine.IDocumentLine;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.exceptions.DBException;
+import org.compiere.Adempiere;
+import org.compiere.util.CLogger;
+import org.compiere.util.DB;
+import org.compiere.util.Env;
+import org.compiere.util.Msg;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.logging.Level;
+
+/**
+ * 	Product Cost Model
+ *
+ *  @author Jorg Janke
+ *  @version $Id: MCost.java,v 1.6 2006/07/30 00:51:02 jjanke Exp $
+ *
+ *  @author Carlos Ruiz - globalqss
+ *		<li>integrate bug fix from Teo Sarca - [ 1619112 ] Posible problem for LastPO costing, Batch/Lot level
+ *
+ *  @author Red1
+ *  	<li>FR: [ 2214883 ] Remove SQL code and Replace for Query - red1 (only non-join query)
+ *  
+ *  @author Teo Sarca
+ *  	<li>BF [ 2847648 ] Manufacture & shipment cost errors
+ *  		https://sourceforge.net/tracker/?func=detail&aid=2847648&group_id=176962&atid=934929
+ */
+public class MCost extends X_M_Cost
+{
+    /**
+     *
+     * @param product
+     * @param as
+     * @param M_CostType_ID
+     * @param AD_Org_ID
+     * @param M_Warehouse_ID
+     * @param M_AttributeSetInstance_ID
+     * @param M_CostElement_ID
+     * @return
+     */
+        public static List<MCost> getByElement(MProduct product, MAcctSchema as,
+                                        int M_CostType_ID, int AD_Org_ID,int M_Warehouse_ID ,int M_AttributeSetInstance_ID,
+                                        int M_CostElement_ID) {
+            org.adempiere.engine.CostDimension cd = new org.adempiere.engine.CostDimension(product, as, M_CostType_ID,
+                    AD_Org_ID,  M_Warehouse_ID, M_AttributeSetInstance_ID, M_CostElement_ID);
+            return cd.toQuery(MCost.class, product.get_TrxName())
+                    .setOnlyActiveRecords(true).list();
+        }
+
+		public static MCost getDimension(MProduct product , int C_AcctSchema_ID , int  AD_Org_ID , int  M_Warehouse_ID , int M_AttributeSetInstance_ID, int M_CostType_ID , int M_CostElement_ID)
+		{
+			MAcctSchema acctSchema = new  MAcctSchema(product.getCtx(), C_AcctSchema_ID , product.get_TrxName());
+
+			ArrayList<Object> parameters = new ArrayList<Object>();
+			StringBuilder whereClause = new StringBuilder();
+			
+			whereClause.append(I_M_Cost.COLUMNNAME_C_AcctSchema_ID).append("=? AND ");
+			whereClause.append(I_M_Cost.COLUMNNAME_M_Product_ID).append("=? AND ");
+			whereClause.append(I_M_Cost.COLUMNNAME_M_CostType_ID).append("=? AND ");
+			whereClause.append(I_M_Cost.COLUMNNAME_M_CostElement_ID ).append("=? ");
+			
+			parameters.add(C_AcctSchema_ID);
+			parameters.add(product.getM_Product_ID());
+			parameters.add(M_CostType_ID);
+			parameters.add(M_CostElement_ID);
+
+			if (M_CostElement_ID == 0)
+				throw new IllegalArgumentException(
+						"No Costing Element Material Type");
+
+			if (M_CostType_ID == 0)
+				throw new AdempiereException(
+						"Error do not exist material cost element for method cost "
+								+ acctSchema.getCostingMethod());
+
+			String CostingLevel = product.getCostingLevel(acctSchema, AD_Org_ID);
+			MCostType costType =  new MCostType(product.getCtx() , M_CostType_ID , product.get_TrxName());
+			String costingMethod = costType.getCostingMethod();
+
+			if (MAcctSchema.COSTINGLEVEL_Client.equals(CostingLevel)) {
+				//Ignore organization, warehouse , asi
+				AD_Org_ID = 0;
+				M_Warehouse_ID = 0;
+				M_AttributeSetInstance_ID = 0;
+			}
+			else if (MAcctSchema.COSTINGLEVEL_Organization.equals(CostingLevel))
+			{
+				if (AD_Org_ID <= 0)
+					throw new AdempiereException("@AD_Org_ID@ @NotFound@");
+				//Ignore  warehouse , asi
+				M_Warehouse_ID = 0;
+				M_AttributeSetInstance_ID = 0;
+			}
+			else if (MAcctSchema.COSTINGLEVEL_Warehouse.equals(CostingLevel))
+			{
+				if (M_Warehouse_ID <= 0)
+					throw new AdempiereException("@M_Warehouse_ID@ @NotFound@");
+				//Ignore organization asi
+				M_AttributeSetInstance_ID = 0;
+			}
+			else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(CostingLevel))
+			{
+				//Ignore organization, warehouse
+				AD_Org_ID = 0;
+				M_Warehouse_ID = 0;
+			}
+			// Costing Method
+			if (costingMethod == null) {
+				costingMethod = product.getCostingMethod(acctSchema, AD_Org_ID);
+				if (costingMethod == null) {
+					throw new IllegalArgumentException("No Costing Method");
+				}
+			}
+
+			if (AD_Org_ID > 0 )
+			{
+				whereClause.append(" AND ").append(I_M_Cost.COLUMNNAME_AD_Org_ID).append("=? ");
+				parameters.add(AD_Org_ID);
+			}
+			if (M_Warehouse_ID > 0 )
+			{
+				whereClause.append(" AND ").append(I_M_Cost.COLUMNNAME_M_Warehouse_ID).append("=? ");
+				parameters.add(M_Warehouse_ID);
+			}
+			 
+			if (M_AttributeSetInstance_ID > 0)
+			{
+				whereClause.append(" AND ").append(I_M_Cost.COLUMNNAME_M_AttributeSetInstance_ID).append("=? ");
+				parameters.add(M_AttributeSetInstance_ID);
+			}
+
+			return new Query(product.getCtx(), I_M_Cost.Table_Name, whereClause.toString(), product.get_TrxName())
+			.setClient_ID()
+			.setOnlyActiveRecords(true)
+			.setParameters(parameters)	
+			.first();
+		}
+		
+		public static MCost validateCostForCostType(MAcctSchema as, MCostType ct,
+				MCostElement ce, int M_Product_ID, int AD_Org_ID, int M_Warehouse_ID,
+				int M_AttributeSetInstance_ID, String trxName) {
+			
+			if (ce == null)
+				throw new IllegalArgumentException(
+						"No Costing Element Material Type");
+
+			if (ct == null)
+				throw new AdempiereException(
+						"Error do not exist material cost element for method cost "
+								+ as.getCostingMethod());
+
+			MProduct product = new MProduct(ct.getCtx(), M_Product_ID,trxName);
+			
+			String CostingLevel = product.getCostingLevel(as, AD_Org_ID);
+			String costingMethod = ct.getCostingMethod();
+
+			if (MAcctSchema.COSTINGLEVEL_Client.equals(CostingLevel)) {
+				//Ignore organization, warehouse , asi
+				AD_Org_ID = 0;
+				M_Warehouse_ID = 0;
+				M_AttributeSetInstance_ID = 0;
+			} 
+			else if (MAcctSchema.COSTINGLEVEL_Organization.equals(CostingLevel))
+			{
+				if (AD_Org_ID <= 0)
+					throw new AdempiereException("@AD_Org_ID@ @NotFound@");
+				//Ignore  warehouse , asi
+				M_Warehouse_ID = 0;
+				M_AttributeSetInstance_ID = 0;
+			}	
+			else if (MAcctSchema.COSTINGLEVEL_Warehouse.equals(CostingLevel))
+			{	
+				//Ignore organization asi
+				if (M_Warehouse_ID <= 0)
+					throw new AdempiereException("@M_Warehouse_ID@ @NotFound@");
+				M_AttributeSetInstance_ID = 0;
+			}	
+			else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(CostingLevel))
+			{	
+				//Ignore organization, warehouse
+				AD_Org_ID = 0;
+				M_Warehouse_ID = 0;
+			}	
+			// Costing Method
+			if (costingMethod == null) {
+				costingMethod = product.getCostingMethod(as, AD_Org_ID);
+				if (costingMethod == null) {
+					throw new IllegalArgumentException("No Costing Method");
+				}
+			}		
+			
+			// Get or Create MCost
+			return MCost.getOrCreate(product, M_AttributeSetInstance_ID, as,
+					AD_Org_ID, M_Warehouse_ID, ct.getM_CostType_ID(), ce.getM_CostElement_ID());
+		}
+
+    	/**
+    	 * Get MCost (Cost Dimension) for this Product 
+    	 * @param as Account Schema
+    	 * @param model Document Line Model
+    	 * @return Cost Dimension List for this product
+    	 */
+    	public static List<MCost> getForProduct(MAcctSchema as, IDocumentLine model)
+    	{
+    		int AD_Org_ID = 0;
+    		int M_Warehouse_ID = 0;
+    		int M_AttributeSetInstance_ID = 0;
+    		String CostingLevel = MProduct.get(as.getCtx(), model.getM_Product_ID()).getCostingLevel(as,model.getAD_Org_ID());
+    		if (MAcctSchema.COSTINGLEVEL_Client.equals(CostingLevel))
+    		{
+    			AD_Org_ID = 0;
+    			M_AttributeSetInstance_ID = 0;
+    			M_Warehouse_ID = 0;
+    		}
+    		else if (MAcctSchema.COSTINGLEVEL_Organization.equals(CostingLevel))
+    		{	
+    			AD_Org_ID = model.getAD_Org_ID();
+    			M_Warehouse_ID = 0;
+    			M_AttributeSetInstance_ID = 0;
+    		}	
+    		else if (MAcctSchema.COSTINGLEVEL_Warehouse.equals(CostingLevel))
+    		{	
+    			AD_Org_ID = model.getM_Locator_ID();
+    			M_Warehouse_ID = MLocator.get(model.getCtx(), model.getM_Locator_ID()).getM_Warehouse_ID();
+    			M_AttributeSetInstance_ID = 0;
+    		}	
+    		else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(CostingLevel))
+    		{	
+    			AD_Org_ID = model.getAD_Org_ID();
+    			M_Warehouse_ID = 0;
+    			M_AttributeSetInstance_ID = model.getM_AttributeSetInstance_ID();
+    		}
+
+            final String whereClause = "M_Product_ID=?  AND AD_Org_ID=? AND (M_Warehouse_ID=? or m_Warehouse_ID IS NULL) AND M_AttributeSetInstance_ID=?" ;
+    		
+    		return new Query(as.getCtx(), Table_Name, whereClause, model.get_TrxName())
+    			.setParameters(model.getM_Product_ID(), AD_Org_ID, M_Warehouse_ID , M_AttributeSetInstance_ID)
+    			.setClient_ID()
+    			.setOrderBy("AD_Client_ID, AD_Org_ID, M_Warehouse_ID , M_AttributeSetInstance_ID")
+    			.list();
+       	}   
+
+    	/**
+    	 * get CostComponets
+    	 * @param product
+    	 * @param M_ASI_ID
+    	 * @param as
+    	 * @param Org_ID
+    	 * @param M_CostType_ID
+    	 * @param costingMethod
+    	 * @param qty
+    	 * @param C_OrderLine_ID
+    	 * @param zeroCostsOK
+    	 * @param trxName
+    	 * @param cost
+    	 * @return get List Cost Component
+    	 */
+    	private static List<CostComponent> getCurrentCostLayers (MProduct product, int M_ASI_ID, 
+    			MAcctSchema as, int Org_ID,int M_Warehouse_ID, int M_CostType_ID,  
+    			String costingMethod, BigDecimal qty, int C_OrderLine_ID, 
+    			boolean zeroCostsOK, String trxName, MCost cost)
+    	{
+    		List<CostComponent> list = new ArrayList<CostComponent>();
+    		BigDecimal currentCostPrice = null;
+    		BigDecimal currentCostPriceLL = null;
+    		String costElementType = null;
+    		//int M_CostElement_ID = 0;
+    		BigDecimal percent = null;
+    		//
+    		BigDecimal materialCostEach = Env.ZERO;
+    		BigDecimal otherCostEach = Env.ZERO;
+    		BigDecimal percentage = Env.ZERO;
+    		int count = 0;
+    		//
+    		String sql = "SELECT SUM(c.CurrentCostPrice), ce.CostElementType, c.CostingMethod,"
+    			+ " c.Percent, c.M_CostElement_ID , SUM(c.CurrentCostPriceLL) "					//	4..5
+    			+ "FROM M_Cost c"
+    			+ " LEFT OUTER JOIN M_CostElement ce ON (c.M_CostElement_ID=ce.M_CostElement_ID) "
+    			+ "WHERE c.AD_Client_ID=? AND c.AD_Org_ID=?"		//	#1/2
+    			+ " AND c.M_Product_ID=?"							//	#3
+    			+ " AND (c.M_AttributeSetInstance_ID=? OR c.M_AttributeSetInstance_ID=0)"	//	#4
+    			+ " AND c.M_CostType_ID=? AND c.C_AcctSchema_ID=?"	//	#5/6
+//    			+ " AND (ce.CostingMethod IS NULL OR ce.CostingMethod=?) "	//	#7
+    			+ " AND c.CostingMethod=? "	//	#7
+    			+ "GROUP BY ce.CostElementType, c.CostingMethod, c.Percent, c.M_CostElement_ID";
+    		PreparedStatement pstmt = null;
+    		ResultSet rs = null;
+    		try
+    		{
+    			pstmt = DB.prepareStatement (sql, trxName);
+    			pstmt.setInt (1, product.getAD_Client_ID());
+    			pstmt.setInt (2, Org_ID);
+    			pstmt.setInt (3, product.getM_Product_ID());
+    			pstmt.setInt (4, M_ASI_ID);
+    			pstmt.setInt (5, M_CostType_ID);
+    			pstmt.setInt (6, as.getC_AcctSchema_ID());
+    			pstmt.setString (7, costingMethod);
+    			rs = pstmt.executeQuery ();
+    			while (rs.next ())
+    			{
+    				currentCostPrice = rs.getBigDecimal(1);
+    				currentCostPriceLL = rs.getBigDecimal(6);
+    				costElementType = rs.getString(2);
+    				String cm = rs.getString(3);
+    				percent = rs.getBigDecimal(4);
+    				//	M_CostElement_ID = rs.getInt(5);
+    				s_log.finest("CurrentCostPrice=" + currentCostPrice 
+    						+ ", CostElementType=" + costElementType
+    						+ ", CostingMethod=" + cm
+    						+ ", Percent=" + percent);
+    				//
+    				if (currentCostPrice != null && currentCostPrice.signum() != 0)
+    				{
+    					if (cm != null)
+    					{	
+    						materialCostEach = materialCostEach.add(currentCostPrice).add(currentCostPriceLL);
+    					}	
+    					else
+    						otherCostEach = otherCostEach.add(currentCostPrice).add(currentCostPriceLL);
+    				}
+    				if (percent != null && percent.signum() != 0)
+    					percentage = percentage.add(percent);
+    				count++;
+    			}
+    		}
+    		catch (SQLException e)
+    		{
+    			throw new DBException(e, sql);
+    		}
+    		finally
+    		{
+    			DB.close(rs, pstmt);
+    			rs = null; pstmt = null;
+    		}
+
+    		if (count > 1)	//	Print summary
+    			s_log.finest("MaterialCost=" + materialCostEach 
+    					+ ", OtherCosts=" + otherCostEach
+    					+ ", Percentage=" + percentage);
+
+    		//	Seed Initial Costs
+    		if (materialCostEach.signum() == 0)		//	no costs
+    		{
+    			if (zeroCostsOK)
+    				return new ArrayList<CostComponent>();
+    			materialCostEach = getSeedCosts(product, M_ASI_ID,
+    					as, Org_ID, M_Warehouse_ID , costingMethod, C_OrderLine_ID);
+    		}
+    		if (materialCostEach == null)
+    			return null;
+    		list.add(new CostComponent(qty, materialCostEach));
+    		list.add(new CostComponent(qty, otherCostEach));
+
+    		//	Standard costs - just Material Costs
+    		if (MCostElement.COSTINGMETHOD_StandardCosting.equals(costingMethod))
+    		{
+    			return list;
+    		}
+    		if (MCostElement.COSTINGMETHOD_Fifo.equals(costingMethod)
+    				|| MCostElement.COSTINGMETHOD_Lifo.equals(costingMethod))
+    		{
+    			list = MCostQueue.getCostLayers(cost, qty, null, trxName);
+    		}
+    		//
+    		for (CostComponent cc : list)
+    		{
+    			cc.setScale(as.getCostingPrecision());
+    			cc.setPercent(percentage);
+    		}
+    		return list;
+    	}
+    	
+    	/**
+    	 * get Cost Component
+    	 * @param cost
+    	 * @param qty
+    	 * @param C_OrderLine_ID
+    	 * @param zeroCostsOK
+    	 * @param trxName
+    	 * @return get list Cost Component
+    	 */
+    	public static List<CostComponent> getCurrentCostLayers (MCost cost, 
+    			BigDecimal qty, int C_OrderLine_ID,
+    			boolean zeroCostsOK, String trxName)
+    	{
+    		MProduct product = MProduct.get(cost.getCtx(), cost.getM_Product_ID());
+    		MAcctSchema as = MAcctSchema.get(cost.getCtx(), cost.getC_AcctSchema_ID());
+    		int AD_Org_ID = cost.getAD_Org_ID();
+    		int M_Warehouse_ID = cost.getM_Warehouse_ID();
+    		int M_AttributeSetInstance_ID = cost.getM_AttributeSetInstance_ID();
+    		String costingMethod = cost.getCostingMethod(); 
+    		
+    		String CostingLevel = product.getCostingLevel(as,product.getAD_Org_ID());
+    		if (MAcctSchema.COSTINGLEVEL_Client.equals(CostingLevel))
+    		{
+    			AD_Org_ID = 0;
+    			M_AttributeSetInstance_ID = 0;
+    		}
+    		else if (MAcctSchema.COSTINGLEVEL_Organization.equals(CostingLevel))
+    			M_AttributeSetInstance_ID = 0;
+    		else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(CostingLevel))
+    			AD_Org_ID = 0;
+    		//	Costing Method
+    		if (costingMethod == null)
+    		{
+    			costingMethod = product.getCostingMethod(as, AD_Org_ID);
+    			if (costingMethod == null)
+    			{
+    				throw new IllegalArgumentException("No Costing Method");
+    			}
+    		}
+
+    		//	Create/Update Costs
+    	//	MCostDetail.processProduct (product, trxName);
+
+    		return getCurrentCostLayers (
+    				product, M_AttributeSetInstance_ID, 
+    				as, AD_Org_ID, M_Warehouse_ID, as.getM_CostType_ID(), costingMethod, qty, 
+    				C_OrderLine_ID, zeroCostsOK, trxName, cost);
+    	}
+    	
+	/**
+	 * 	Retrieve/Calculate Current Cost Price
+	 *	@param product product
+	 *	@param M_AttributeSetInstance_ID real asi
+	 *	@param as accounting schema
+	 *	@param AD_Org_ID real org
+	 *	@param costingMethod AcctSchema.COSTINGMETHOD_*
+	 *	@param qty qty
+	 *	@param C_OrderLine_ID optional order line
+	 *	@param zeroCostsOK zero/no costs are OK
+	 *	@param trxName trx
+	 *	@return current cost price or null
+	 *	@deprecated
+	 */
+	/*public static BigDecimal getCurrentCost (MProduct product,
+		int M_AttributeSetInstance_ID,
+		MAcctSchema as, int AD_Org_ID, int M_Warehouse_ID, String costingMethod,
+		BigDecimal qty, int C_OrderLine_ID,
+		boolean zeroCostsOK, String trxName)
+	{
+		String CostingLevel = product.getCostingLevel(as);
+		if (MAcctSchema.COSTINGLEVEL_Client.equals(CostingLevel))
+		{
+			AD_Org_ID = 0;
+			M_AttributeSetInstance_ID = 0;
+		}
+		else if (MAcctSchema.COSTINGLEVEL_Organization.equals(CostingLevel))
+			M_AttributeSetInstance_ID = 0;
+		else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(CostingLevel))
+			AD_Org_ID = 0;
+		//	Costing Method
+		if (costingMethod == null)
+		{
+			costingMethod = product.getCostingMethod(as);
+			if (costingMethod == null)
+			{
+				throw new IllegalArgumentException("No Costing Method");
+			}
+		}
+
+		//	Create/Update Costs
+		MCostDetail.processProduct (product, trxName);
+
+		return getCurrentCost (
+			product, M_AttributeSetInstance_ID,
+			as, AD_Org_ID, M_Warehouse_ID, as.getM_CostType_ID(), costingMethod, qty,
+			C_OrderLine_ID, zeroCostsOK, trxName);
+	}	//	getCurrentCost
+	*/
+
+	/**
+	 * 	Get Current Cost Price for Costing Level
+	 *	@param product product
+	 *	@param M_ASI_ID costing level asi
+	 *	@param Org_ID costing level org
+	 *	@param M_CostType_ID cost type
+	 *	@param as AcctSchema
+	 *	@param costingMethod method
+	 *	@param qty quantity
+	 *	@param C_OrderLine_ID optional order line
+	 *	@param zeroCostsOK zero/no costs are OK
+	 *	@param trxName trx
+	 *	@return cost price or null
+	 *	@deprecated
+	 */
+	private static BigDecimal getCurrentCost (MProduct product, int M_ASI_ID,
+		MAcctSchema as, int Org_ID, int M_Warehouse_ID,  int M_CostType_ID,
+		String costingMethod, BigDecimal qty, int C_OrderLine_ID,
+		boolean zeroCostsOK, String trxName)
+	{
+		String costElementType = null;
+		BigDecimal percent = null;
+		//
+		BigDecimal materialCostEach = Env.ZERO;
+		BigDecimal otherCostEach = Env.ZERO;
+		BigDecimal percentage = Env.ZERO;
+		int count = 0;
+		//
+		String sql = "SELECT"
+			+ " COALESCE(SUM(c.CurrentCostPrice),0),"		// 1
+			+ " ce.CostElementType, ce.CostingMethod,"		// 2,3
+			+ " c.Percent, c.M_CostElement_ID ,"			// 4,5
+			+ " COALESCE(SUM(c.CurrentCostPriceLL),0) "		// 6
+			+ " FROM M_Cost c"
+			+ " LEFT OUTER JOIN M_CostElement ce ON (c.M_CostElement_ID=ce.M_CostElement_ID) "
+			+ "WHERE c.AD_Client_ID=? AND c.AD_Org_ID=?"		//	#1/2
+			+ " AND c.M_Product_ID=?"							//	#3
+			+ " AND (c.M_AttributeSetInstance_ID=? OR c.M_AttributeSetInstance_ID=0)"	//	#4
+			+ " AND c.M_CostType_ID=? AND c.C_AcctSchema_ID=?"	//	#5/6
+			+ " AND (ce.CostingMethod IS NULL OR ce.CostingMethod=?) "	//	#7
+			+ "GROUP BY ce.CostElementType, ce.CostingMethod, c.Percent, c.M_CostElement_ID";
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		try
+		{
+			pstmt = DB.prepareStatement (sql, trxName);
+			pstmt.setInt (1, product.getAD_Client_ID());
+			pstmt.setInt (2, Org_ID);
+			pstmt.setInt (3, product.getM_Product_ID());
+			pstmt.setInt (4, M_ASI_ID);
+			pstmt.setInt (5, M_CostType_ID);
+			pstmt.setInt (6, as.getC_AcctSchema_ID());
+			pstmt.setString (7, costingMethod);
+			rs = pstmt.executeQuery ();
+			while (rs.next ())
+			{
+				BigDecimal currentCostPrice = rs.getBigDecimal(1);
+				BigDecimal currentCostPriceLL = rs.getBigDecimal(6);
+				costElementType = rs.getString(2);
+				String cm = rs.getString(3);
+				percent = rs.getBigDecimal(4);
+				//M_CostElement_ID = rs.getInt(5);
+				s_log.finest("CurrentCostPrice=" + currentCostPrice
+					+ ", CurrentCostPriceLL=" + currentCostPriceLL
+					+ ", CostElementType=" + costElementType
+					+ ", CostingMethod=" + cm
+					+ ", Percent=" + percent);
+				//
+				if (currentCostPrice.signum() != 0 || currentCostPriceLL.signum() != 0)
+				{
+					if (cm != null)
+					{
+						materialCostEach = materialCostEach.add(currentCostPrice).add(currentCostPriceLL);
+					}
+					else
+					{
+						otherCostEach = otherCostEach.add(currentCostPrice).add(currentCostPriceLL);
+					}
+				}
+				if (percent != null && percent.signum() != 0)
+					percentage = percentage.add(percent);
+				count++;
+			}
+		}
+		catch (SQLException e)
+		{
+			throw new DBException(e, sql);
+		}
+		finally
+		{
+			DB.close(rs, pstmt);
+			rs = null; pstmt = null;
+		}
+
+		if (count > 1)	//	Print summary
+			s_log.finest("MaterialCost=" + materialCostEach
+				+ ", OtherCosts=" + otherCostEach
+				+ ", Percentage=" + percentage);
+
+		//	Seed Initial Costs
+		if (materialCostEach.signum() == 0)		//	no costs
+		{
+			if (zeroCostsOK)
+				return Env.ZERO;
+			materialCostEach = getSeedCosts(product, M_ASI_ID,
+				as, Org_ID, M_Warehouse_ID , costingMethod, C_OrderLine_ID);
+		}
+		if (materialCostEach == null)
+			return null;
+
+		//	Material Costs
+		BigDecimal materialCost = materialCostEach.multiply(qty);
+		//	Standard costs - just Material Costs
+		if (MCostElement.COSTINGMETHOD_StandardCosting.equals(costingMethod))
+		{
+			s_log.finer("MaterialCosts = " + materialCost);
+			return materialCost;
+		}
+		if (MCostElement.COSTINGMETHOD_Fifo.equals(costingMethod)
+			|| MCostElement.COSTINGMETHOD_Lifo.equals(costingMethod))
+		{
+			MCostElement ce = MCostElement.getMaterialCostElement(product);
+			materialCost = MCostQueue.getCosts(product, M_ASI_ID,
+				as, Org_ID,M_Warehouse_ID , ce, qty, trxName);
+		}
+
+		//	Other Costs
+		BigDecimal otherCost = otherCostEach.multiply(qty);
+
+		//	Costs
+		BigDecimal costs = otherCost.add(materialCost);
+		if (costs.signum() == 0)
+			return null;
+
+		s_log.finer("Sum Costs = " + costs);
+		int precision = as.getCostingPrecision();
+		if (percentage.signum() == 0)	//	no percentages
+		{
+			if (costs.scale() > precision)
+				costs = costs.setScale(precision, BigDecimal.ROUND_HALF_UP);
+			return costs;
+		}
+		//
+		BigDecimal percentCost = costs.multiply(percentage);
+		percentCost = percentCost.divide(Env.ONEHUNDRED, precision, BigDecimal.ROUND_HALF_UP);
+		costs = costs.add(percentCost);
+		if (costs.scale() > precision)
+			costs = costs.setScale(precision, BigDecimal.ROUND_HALF_UP);
+		s_log.finer("Sum Costs = " + costs + " (Add=" + percentCost + ")");
+		return costs;
+	}	//	getCurrentCost
+
+	/**
+	 * 	Get Seed Costs
+	 *	@param product product
+	 *	@param M_ASI_ID costing level asi
+	 *	@param as accounting schema
+	 *	@param Org_ID costing level org
+	 *	@param costingMethod costing method
+	 *	@param C_OrderLine_ID optional order line
+	 *	@return price or null
+	 */
+	public static BigDecimal getSeedCosts (MProduct product, int M_ASI_ID,
+		MAcctSchema as, int Org_ID, int M_Warehouse_ID, String costingMethod, int C_OrderLine_ID)
+	{
+		BigDecimal retValue = null;
+		//	Direct Data
+		if (MCostElement.COSTINGMETHOD_AverageInvoice.equals(costingMethod))
+			retValue = calculateAverageInv(product, M_ASI_ID, as, Org_ID);
+		else if (MCostElement.COSTINGMETHOD_AveragePO.equals(costingMethod))
+			retValue = calculateAveragePO(product, M_ASI_ID, as, Org_ID);
+		else if (MCostElement.COSTINGMETHOD_Fifo.equals(costingMethod))
+			retValue = calculateFiFo(product, M_ASI_ID, as, Org_ID);
+		else if (MCostElement.COSTINGMETHOD_Lifo.equals(costingMethod))
+			retValue = calculateLiFo(product, M_ASI_ID, as, Org_ID);
+		else if (MCostElement.COSTINGMETHOD_LastInvoice.equals(costingMethod))
+			retValue = getLastInvoicePrice(product, M_ASI_ID, Org_ID, as.getC_Currency_ID());
+		else if (MCostElement.COSTINGMETHOD_LastPOPrice.equals(costingMethod))
+		{
+			if (C_OrderLine_ID != 0)
+				retValue = getPOPrice(product, C_OrderLine_ID, as.getC_Currency_ID());
+			if (retValue == null || retValue.signum() == 0)
+				retValue = getLastPOPrice(product, M_ASI_ID, Org_ID, as.getC_Currency_ID());
+		}
+		else if (MCostElement.COSTINGMETHOD_StandardCosting.equals(costingMethod))
+		{
+			//	migrate old costs
+			MProductCosting pc = MProductCosting.get(product.getCtx(), product.getM_Product_ID(),
+				as.getC_AcctSchema_ID(), null);
+			if (pc != null)
+				retValue = pc.getCurrentCostPrice();
+		}
+		else if (MCostElement.COSTINGMETHOD_UserDefined.equals(costingMethod))
+			;
+		else
+			throw new IllegalArgumentException("Unknown Costing Method = " + costingMethod);
+		if (retValue != null && retValue.signum() != 0)
+		{
+			s_log.fine(product.getName() + ", CostingMethod=" + costingMethod + " - " + retValue);
+			return retValue;
+		}
+
+		//	Look for exact Order Line
+		if (C_OrderLine_ID != 0)
+		{
+			retValue = getPOPrice(product, C_OrderLine_ID, as.getC_Currency_ID());
+			if (retValue != null && retValue.signum() != 0)
+			{
+				s_log.fine(product.getName() + ", PO - " + retValue);
+				return retValue;
+			}
+		}
+
+		//	Look for Standard Costs first
+		if (!MCostElement.COSTINGMETHOD_StandardCosting.equals(costingMethod))
+		{
+			/*
+			MCostElement ce = MCostElement.getMaterialCostElement(as, MCostElement.COSTINGMETHOD_StandardCosting);
+			MCost cost = get(product, M_ASI_ID, as, Org_ID, ce.getM_CostElement_ID());
+			if (cost != null && cost.getCurrentCostPrice().signum() != 0)
+			{
+				s_log.fine(product.getName() + ", Standard - " + cost);
+				return cost.getCurrentCostPrice();
+			}*/
+			
+			MCostElement ce = MCostElement.getByMaterialCostElementType(as);
+			List<MCostType> costtypes = MCostType.get(product.getCtx(), product.get_TrxName()); 
+			for (MCostType mc : costtypes)
+			{
+				MCost cost = getOrCreate(product, M_ASI_ID, as , Org_ID , M_Warehouse_ID , mc.getM_CostType_ID(), ce.getM_CostElement_ID());
+				if (cost != null && cost.getCurrentCostPrice().signum() != 0)
+				{
+					s_log.fine(product.getName() + ", Standard - " + retValue);
+					return cost.getCurrentCostPrice();
+				}
+			}
+		}
+
+		//	We do not have a price
+		//	PO first
+		if (MCostElement.COSTINGMETHOD_AveragePO.equals(costingMethod)
+			|| MCostElement.COSTINGMETHOD_LastPOPrice.equals(costingMethod)
+			|| MCostElement.COSTINGMETHOD_StandardCosting.equals(costingMethod))
+		{
+			//	try Last PO
+			retValue = getLastPOPrice(product, M_ASI_ID, Org_ID, as.getC_Currency_ID());
+			if (Org_ID != 0 && (retValue == null || retValue.signum() == 0))
+				retValue = getLastPOPrice(product, M_ASI_ID, 0, as.getC_Currency_ID());
+			if (retValue != null && retValue.signum() != 0)
+			{
+				s_log.fine(product.getName() + ", LastPO = " + retValue);
+				return retValue;
+			}
+		}
+		else	//	Inv first
+		{
+			//	try last Inv
+			retValue = getLastInvoicePrice(product, M_ASI_ID, Org_ID, as.getC_Currency_ID());
+			if (Org_ID != 0 && (retValue == null || retValue.signum() == 0))
+				retValue = getLastInvoicePrice(product, M_ASI_ID, 0, as.getC_Currency_ID());
+			if (retValue != null && retValue.signum() != 0)
+			{
+				s_log.fine(product.getName() + ", LastInv = " + retValue);
+				return retValue;
+			}
+		}
+
+		//	Still Nothing
+		//	Inv second
+		if (MCostElement.COSTINGMETHOD_AveragePO.equals(costingMethod)
+			|| MCostElement.COSTINGMETHOD_LastPOPrice.equals(costingMethod)
+			|| MCostElement.COSTINGMETHOD_StandardCosting.equals(costingMethod))
+		{
+			//	try last Inv
+			retValue = getLastInvoicePrice(product, M_ASI_ID, Org_ID, as.getC_Currency_ID());
+			if (Org_ID != 0 && (retValue == null || retValue.signum() == 0))
+				retValue = getLastInvoicePrice(product, M_ASI_ID, 0, as.getC_Currency_ID());
+			if (retValue != null && retValue.signum() != 0)
+			{
+				s_log.fine(product.getName() + ", LastInv = " + retValue);
+				return retValue;
+			}
+		}
+		else	//	PO second
+		{
+			//	try Last PO
+			retValue = getLastPOPrice(product, M_ASI_ID, Org_ID, as.getC_Currency_ID());
+			if (Org_ID != 0 && (retValue == null || retValue.signum() == 0))
+				retValue = getLastPOPrice(product, M_ASI_ID, 0, as.getC_Currency_ID());
+			if (retValue != null && retValue.signum() != 0)
+			{
+				s_log.fine(product.getName() + ", LastPO = " + retValue);
+				return retValue;
+			}
+		}
+
+		//	Still nothing try ProductPO
+		MProductPO[] pos = MProductPO.getOfProductAndOrg(product.getCtx(), product.getM_Product_ID(), Org_ID,null);
+		for (int i = 0; i < pos.length; i++)
+		{
+			BigDecimal price = pos[i].getPricePO();
+			if (price == null || price.signum() == 0)
+				price = pos[i].getPriceList();
+			if (price != null && price.signum() != 0)
+			{
+				price = MConversionRate.convert(product.getCtx(), price,
+					pos[i].getC_Currency_ID(), as.getC_Currency_ID(),
+					as.getAD_Client_ID(), Org_ID);
+				if (price != null && price.signum() != 0)
+				{
+					if (pos[i].getC_UOM_ID() != product.getC_UOM_ID())
+					{
+						price = MUOMConversion.convertProductTo (Env.getCtx(), product.getM_Product_ID(),
+								pos[i].getC_UOM_ID(), price);
+					}
+				}
+				if (price != null && price.signum() != 0)
+				{
+					retValue = price;
+					s_log.fine(product.getName() + ", Product_PO = " + retValue);
+					return retValue;
+				}
+			}
+		}
+
+		//	Still nothing try Purchase Price List
+		//	....
+
+		s_log.fine(product.getName() + " = " + retValue);
+		return retValue;
+	}	//	getSeedCosts
+
+
+	/**
+	 * 	Get Last Invoice Price in currency
+	 *	@param product product
+	 *	@param M_ASI_ID attribute set instance
+	 *	@param AD_Org_ID org
+	 *	@param C_Currency_ID accounting currency
+	 *	@return last invoice price in currency
+	 */
+	public static BigDecimal getLastInvoicePrice (MProduct product,
+		int M_ASI_ID, int AD_Org_ID, int C_Currency_ID)
+	{
+		BigDecimal retValue = null;
+		String sql = "SELECT currencyConvert(il.PriceActual, i.C_Currency_ID, ?, i.DateAcct, i.C_ConversionType_ID, il.AD_Client_ID, il.AD_Org_ID) "
+			// ,il.PriceActual, il.QtyInvoiced, i.DateInvoiced, il.Line
+			+ "FROM C_InvoiceLine il "
+			+ " INNER JOIN C_Invoice i ON (il.C_Invoice_ID=i.C_Invoice_ID) "
+			+ "WHERE il.M_Product_ID=?"
+			+ " AND i.IsSOTrx='N'";
+		if (AD_Org_ID != 0)
+			sql += " AND il.AD_Org_ID=?";
+		else if (M_ASI_ID != 0)
+			sql += " AND il.M_AttributeSetInstance_ID=?";
+		sql += " ORDER BY i.DateInvoiced DESC, il.Line DESC";
+		//
+		PreparedStatement pstmt = null;
+		try
+		{
+			pstmt = DB.prepareStatement (sql, product.get_TrxName());
+			pstmt.setInt (1, C_Currency_ID);
+			pstmt.setInt (2, product.getM_Product_ID());
+			if (AD_Org_ID != 0)
+				pstmt.setInt (3, AD_Org_ID);
+			else if (M_ASI_ID != 0)
+				pstmt.setInt(3, M_ASI_ID);
+			ResultSet rs = pstmt.executeQuery ();
+			if (rs.next ())
+				retValue = rs.getBigDecimal(1);
+			rs.close ();
+			pstmt.close ();
+			pstmt = null;
+		}
+		catch (Exception e)
+		{
+			s_log.log (Level.SEVERE, sql, e);
+		}
+		try
+		{
+			if (pstmt != null)
+				pstmt.close ();
+			pstmt = null;
+		}
+		catch (Exception e)
+		{
+			pstmt = null;
+		}
+
+		if (retValue != null)
+		{
+			s_log.finer(product.getName() + " = " + retValue);
+			return retValue;
+		}
+		return null;
+	}	//	getLastInvoicePrice
+
+	/**
+	 * 	Get Last PO Price in currency
+	 *	@param product product
+	 *	@param M_ASI_ID attribute set instance
+	 *	@param AD_Org_ID org
+	 *	@param C_Currency_ID accounting currency
+	 *	@return last PO price in currency or null
+	 */
+	public static BigDecimal getLastPOPrice (MProduct product,
+		int M_ASI_ID, int AD_Org_ID, int C_Currency_ID)
+	{
+		BigDecimal retValue = null;
+		String sql = "SELECT currencyConvert(ol.PriceCost, o.C_Currency_ID, ?, o.DateAcct, o.C_ConversionType_ID, ol.AD_Client_ID, ol.AD_Org_ID),"
+			+ " currencyConvert(ol.PriceActual, o.C_Currency_ID, ?, o.DateAcct, o.C_ConversionType_ID, ol.AD_Client_ID, ol.AD_Org_ID) "
+			//	,ol.PriceCost,ol.PriceActual, ol.QtyOrdered, o.DateOrdered, ol.Line
+			+ "FROM C_OrderLine ol"
+			+ " INNER JOIN C_Order o ON (ol.C_Order_ID=o.C_Order_ID) "
+			+ "WHERE ol.M_Product_ID=?"
+			+ " AND o.IsSOTrx='N'";
+		if (AD_Org_ID != 0)
+			sql += " AND ol.AD_Org_ID=?";
+		else if (M_ASI_ID != 0)
+			sql += " AND ol.M_AttributeSetInstance_ID=?";
+		sql += " ORDER BY o.DateOrdered DESC, ol.Line DESC";
+		//
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		try
+		{
+			pstmt = DB.prepareStatement (sql, product.get_TrxName());
+			pstmt.setInt (1, C_Currency_ID);
+			pstmt.setInt (2, C_Currency_ID);
+			pstmt.setInt (3, product.getM_Product_ID());
+			if (AD_Org_ID != 0)
+				pstmt.setInt (4, AD_Org_ID);
+			else if (M_ASI_ID != 0)
+				pstmt.setInt(4, M_ASI_ID);
+			rs = pstmt.executeQuery ();
+			if (rs.next ())
+			{
+				retValue = rs.getBigDecimal(1);
+				if (retValue == null || retValue.signum() == 0)
+					retValue = rs.getBigDecimal(2);
+			}
+		}
+		catch (SQLException e)
+		{
+			throw new DBException(e, sql);
+		}
+		finally
+		{
+			DB.close(rs, pstmt);
+			rs = null; pstmt = null;
+		}
+
+		if (retValue != null)
+		{
+			s_log.finer(product.getName() + " = " + retValue);
+			return retValue;
+		}
+		return null;
+	}	//	getLastPOPrice
+
+	/**
+	 * 	Get PO Price in currency
+	 * 	@param product product
+	 *	@param C_OrderLine_ID order line
+	 *	@param C_Currency_ID accounting currency
+	 *	@return last PO price in currency or null
+	 */
+	public static BigDecimal getPOPrice (MProduct product, int C_OrderLine_ID, int C_Currency_ID)
+	{
+		BigDecimal retValue = null;
+		String sql = "SELECT currencyConvert(ol.PriceCost, o.C_Currency_ID, ?, o.DateAcct, o.C_ConversionType_ID, ol.AD_Client_ID, ol.AD_Org_ID),"
+			+ " currencyConvert(ol.PriceActual, o.C_Currency_ID, ?, o.DateAcct, o.C_ConversionType_ID, ol.AD_Client_ID, ol.AD_Org_ID) "
+			//	,ol.PriceCost,ol.PriceActual, ol.QtyOrdered, o.DateOrdered, ol.Line
+			+ "FROM C_OrderLine ol"
+			+ " INNER JOIN C_Order o ON (ol.C_Order_ID=o.C_Order_ID) "
+			+ "WHERE ol.C_OrderLine_ID=?"
+			+ " AND o.IsSOTrx='N'";
+		//
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		try
+		{
+			pstmt = DB.prepareStatement (sql, product.get_TrxName());
+			pstmt.setInt (1, C_Currency_ID);
+			pstmt.setInt (2, C_Currency_ID);
+			pstmt.setInt (3, C_OrderLine_ID);
+			rs = pstmt.executeQuery ();
+			if (rs.next ())
+			{
+				retValue = rs.getBigDecimal(1);
+				if (retValue == null || retValue.signum() == 0)
+					retValue = rs.getBigDecimal(2);
+			}
+		}
+		catch (Exception e)
+		{
+			s_log.log (Level.SEVERE, sql, e);
+		}
+		finally
+		{
+			DB.close(rs, pstmt);
+			rs = null; pstmt = null;
+		}
+
+		if (retValue != null)
+		{
+			s_log.finer(product.getName() + " = " + retValue);
+			return retValue;
+		}
+		return null;
+	}	//	getPOPrice
+
+	/**************************************************************************
+	 * 	Create costing for client.
+	 * 	Handles Transaction if not in a transaction
+	 *	@param client client
+	 */
+	@Deprecated
+	/*public static void create (MClient client)
+	{
+		MAcctSchema[] ass = MAcctSchema.getClientAcctSchema(client.getCtx(), client.getAD_Client_ID());
+		String trxName = client.get_TrxName();
+		String trxNameUsed = trxName;
+		Trx trx = null;
+		if (trxName == null)
+		{
+			trxNameUsed = Trx.createTrxName("Cost");
+			trx = Trx.get(trxNameUsed, true);
+		}
+		boolean success = true;
+		//	For all Products
+		String sql = "SELECT * FROM M_Product p "
+			+ "WHERE AD_Client_ID=?"
+			+ " AND EXISTS (SELECT * FROM M_CostDetail cd "
+				+ "WHERE p.M_Product_ID=cd.M_Product_ID AND Processed='N')";
+		PreparedStatement pstmt = null;
+		try
+		{
+			pstmt = DB.prepareStatement (sql, trxNameUsed);
+			pstmt.setInt (1, client.getAD_Client_ID());
+			ResultSet rs = pstmt.executeQuery ();
+			while (rs.next ())
+			{
+				MProduct product = new MProduct (client.getCtx(), rs, trxNameUsed);
+				for (int i = 0; i < ass.length; i++)
+				{
+					BigDecimal cost = getCurrentCost(product, 0, ass[i], 0, 0 ,
+						null, Env.ONE, 0, false, trxNameUsed);		//	create non-zero costs
+					s_log.info(product.getName() + " = " + cost);
+				}
+			}
+			rs.close ();
+			pstmt.close ();
+			pstmt = null;
+		}
+		catch (Exception e)
+		{
+			s_log.log (Level.SEVERE, sql, e);
+			success = false;
+		}
+		try
+		{
+			if (pstmt != null)
+				pstmt.close ();
+			pstmt = null;
+		}
+		catch (Exception e)
+		{
+			pstmt = null;
+		}
+		//	Transaction
+		if (trx != null)
+		{
+			if (success)
+				trx.commit();
+			else
+				trx.rollback();
+			trx.close();
+		}
+	}	//	create
+	*/
+
+
+	/**
+	 * 	Create standard Costing records for Product
+	 *	@param product product
+	 */
+	protected static void create (MProduct product)
+	{
+			s_log.config(product.getName());
+
+			//	Cost Elements
+			List <MCostElement> ces = MCostElement.getDefaultElements(product);
+
+			MAcctSchema[] mass = MAcctSchema.getClientAcctSchema(product.getCtx(),
+				product.getAD_Client_ID(), product.get_TrxName());
+			MOrg[] orgs = null;
+
+			int M_ASI_ID = 0;		//	No Attribute
+			for (MAcctSchema as : mass)
+			{
+				String cl = product.getCostingLevel(as);
+				//	Create Std Costing
+				if (MAcctSchema.COSTINGLEVEL_Client.equals(cl))
+				{
+					for (MCostType ct : MCostType.get(product.getCtx(), product.get_TrxName()))
+					{	
+						for(MCostElement ce : ces)
+						{
+							MCost cost = MCost.getOrCreate(product, M_ASI_ID,
+								as, 0 , 0 , ct.getM_CostType_ID() ,ce.getM_CostElement_ID());
+							if (cost.is_new())
+							{
+								if (cost.save())
+									s_log.config("Std.Cost for " + product.getName()
+										+ " - " + as.getName());
+								else
+									s_log.warning("Not created: Std.Cost for " + product.getName()
+										+ " - " + as.getName());
+							}
+						}
+					}	
+				}
+				else if (MAcctSchema.COSTINGLEVEL_Organization.equals(cl))
+				{
+					if (orgs == null)
+						orgs = MOrg.getOfClient(product);
+					for (MOrg o : orgs)
+					{
+						for (MCostType ct : MCostType.get(product.getCtx(), product.get_TrxName()))
+						{
+							for(MCostElement ce : ces)
+							{
+								MCost cost = MCost.getOrCreate(product, M_ASI_ID,
+									as, o.getAD_Org_ID(), 0 , ct.getM_CostType_ID() , ce.getM_CostElement_ID());
+								if (cost.is_new())
+								{
+									if (cost.save())
+										s_log.config("Std.Cost for " + product.getName()
+											+ " - " + o.getName()
+											+ " - " + as.getName());
+									else
+										s_log.warning("Not created: Std.Cost for " + product.getName()
+											+ " - " + o.getName()
+											+ " - " + as.getName());
+								}
+							}
+						}	
+					}	//	for all orgs
+				}
+				else
+				{
+					s_log.warning("Not created: Std.Cost for " + product.getName()
+						+ " - Costing Level on Batch/Lot");
+				}
+			}	//	accounting schema loop
+	}	//	create
+
+	/**
+	 * 	Delete standard Costing records for Product
+	 *	@param product product
+	 **/
+	protected static void delete (MProduct product)
+	{
+		s_log.config(product.getName());
+		//	Cost Elements
+		List <MCostElement> ces = MCostElement.getCostElement(product.getCtx(), product.get_TrxName());
+
+			MAcctSchema[] mass = MAcctSchema.getClientAcctSchema(product.getCtx(),
+				product.getAD_Client_ID(), product.get_TrxName());
+			MOrg[] orgs = null;
+
+			int M_ASI_ID = 0;		//	No Attribute
+			for (MAcctSchema as : mass)
+			{
+				String cl = product.getCostingLevel(as);
+				//	Create Std Costing
+				if (MAcctSchema.COSTINGLEVEL_Client.equals(cl))
+				{
+					for (MCostType ct : MCostType.get(product.getCtx(), product.get_TrxName()))
+					{
+						for(MCostElement ce : ces)
+						{
+							MCost cost = MCost.getOrCreate(product, M_ASI_ID,
+								as, 0, 0 , ct.getM_CostType_ID() , ce.getM_CostElement_ID());
+							if(cost != null)
+							cost.deleteEx(true);
+						}
+					}	
+				}
+				else if (MAcctSchema.COSTINGLEVEL_Organization.equals(cl))
+				{
+					if (orgs == null)
+						orgs = MOrg.getOfClient(product);
+					for (MOrg o : orgs)
+					{
+						for (MCostType ct : MCostType.get(product.getCtx(), product.get_TrxName()))
+						{
+							for(MCostElement ce : ces)
+							{
+								MCost cost = MCost.getOrCreate (product, M_ASI_ID,
+									as, o.getAD_Org_ID(), 0 , ct.getM_CostType_ID() , ce.getM_CostElement_ID());
+								if(cost != null)
+									cost.deleteEx(true);
+							}
+						}	
+					}	//	for all orgs
+				}
+				else
+				{
+					s_log.warning("Not created: Std.Cost for " + product.getName()
+						+ " - Costing Level on Batch/Lot");
+				}
+			}	//	accounting schema loop
+	}	//	create
+
+	/**************************************************************************
+	 * 	Calculate Average Invoice from Trx
+	 *	@param product product
+	 *	@param M_AttributeSetInstance_ID optional asi
+	 *	@param as acct schema
+	 *	@param AD_Org_ID optonal org
+	 *	@return average costs or null
+	 */
+	public static BigDecimal calculateAverageInv (MProduct product, int M_AttributeSetInstance_ID,
+		MAcctSchema as, int AD_Org_ID)
+	{
+		String sql = "SELECT t.MovementQty, mi.Qty, il.QtyInvoiced, il.PriceActual,"
+			+ " i.C_Currency_ID, i.DateAcct, i.C_ConversionType_ID, i.AD_Client_ID, i.AD_Org_ID, t.M_Transaction_ID "
+			+ "FROM M_Transaction t"
+			+ " INNER JOIN M_MatchInv mi ON (t.M_InOutLine_ID=mi.M_InOutLine_ID)"
+			+ " INNER JOIN C_InvoiceLine il ON (mi.C_InvoiceLine_ID=il.C_InvoiceLine_ID)"
+			+ " INNER JOIN C_Invoice i ON (il.C_Invoice_ID=i.C_Invoice_ID) "
+			+ "WHERE t.M_Product_ID=?";
+		if (AD_Org_ID != 0)
+			sql += " AND t.AD_Org_ID=?";
+		else if (M_AttributeSetInstance_ID != 0)
+			sql += " AND t.M_AttributeSetInstance_ID=?";
+		sql += " ORDER BY t.M_Transaction_ID";
+
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		BigDecimal newStockQty = Env.ZERO;
+		//
+		BigDecimal newAverageAmt = Env.ZERO;
+		int oldTransaction_ID = 0;
+		try
+		{
+			pstmt = DB.prepareStatement (sql, null);
+			pstmt.setInt (1, product.getM_Product_ID());
+			if (AD_Org_ID != 0)
+				pstmt.setInt (2, AD_Org_ID);
+			else if (M_AttributeSetInstance_ID != 0)
+				pstmt.setInt (2, M_AttributeSetInstance_ID);
+			rs = pstmt.executeQuery ();
+			while (rs.next ())
+			{
+				BigDecimal oldStockQty = newStockQty;
+				BigDecimal movementQty = rs.getBigDecimal(1);
+				int M_Transaction_ID = rs.getInt(10);
+				if (M_Transaction_ID != oldTransaction_ID)
+					newStockQty = oldStockQty.add(movementQty);
+				M_Transaction_ID = oldTransaction_ID;
+				//
+				BigDecimal matchQty = rs.getBigDecimal(2);
+				if (matchQty == null)
+				{
+					s_log.finer("Movement=" + movementQty + ", StockQty=" + newStockQty);
+					continue;
+				}
+				//	Assumption: everything is matched
+				BigDecimal price = rs.getBigDecimal(4);
+				int C_Currency_ID = rs.getInt(5);
+				Timestamp DateAcct = rs.getTimestamp(6);
+				int C_ConversionType_ID = rs.getInt(7);
+				int Client_ID = rs.getInt(8);
+				int Org_ID = rs.getInt(9);
+				BigDecimal cost = MConversionRate.convert(product.getCtx(), price,
+					C_Currency_ID, as.getC_Currency_ID(),
+					DateAcct, C_ConversionType_ID, Client_ID, Org_ID);
+				//
+				BigDecimal oldAverageAmt = newAverageAmt;
+				BigDecimal averageCurrent = oldStockQty.multiply(oldAverageAmt);
+				BigDecimal averageIncrease = matchQty.multiply(cost);
+				BigDecimal newAmt = averageCurrent.add(averageIncrease);
+				newAmt = newAmt.setScale(as.getCostingPrecision(), RoundingMode.HALF_UP);
+				newAverageAmt = newAmt.divide(newStockQty, as.getCostingPrecision(), RoundingMode.HALF_UP);
+				s_log.finer("Movement=" + movementQty + ", StockQty=" + newStockQty
+					+ ", Match=" + matchQty + ", Cost=" + cost + ", NewAvg=" + newAverageAmt);
+			}
+		}
+		catch (SQLException e)
+		{
+			throw new DBException(e, sql);
+		}
+		finally
+		{
+			DB.close(rs, pstmt);
+			rs = null; pstmt = null;
+		}
+		//
+		if (newAverageAmt != null && newAverageAmt.signum() != 0)
+		{
+			s_log.finer(product.getName() + " = " + newAverageAmt);
+			return newAverageAmt;
+		}
+		return null;
+	}	//	calculateAverageInv
+
+	/**
+	 * 	Calculate Average PO
+	 *	@param product product
+	 *	@param M_AttributeSetInstance_ID asi
+	 *	@param as acct schema
+	 *	@param AD_Org_ID org
+	 *	@return costs or null
+	 */
+	public static BigDecimal calculateAveragePO (MProduct product, int M_AttributeSetInstance_ID,
+		MAcctSchema as, int AD_Org_ID)
+	{
+		String sql = "SELECT t.MovementQty, mp.Qty, ol.QtyOrdered, ol.PriceCost, ol.PriceActual,"	//	1..5
+			+ " o.C_Currency_ID, o.DateAcct, o.C_ConversionType_ID,"	//	6..8
+			+ " o.AD_Client_ID, o.AD_Org_ID, t.M_Transaction_ID "		//	9..11
+			+ "FROM M_Transaction t"
+			+ " INNER JOIN M_MatchPO mp ON (t.M_InOutLine_ID=mp.M_InOutLine_ID)"
+			+ " INNER JOIN C_OrderLine ol ON (mp.C_OrderLine_ID=ol.C_OrderLine_ID)"
+			+ " INNER JOIN C_Order o ON (ol.C_Order_ID=o.C_Order_ID) "
+			+ "WHERE t.M_Product_ID=?";
+		if (AD_Org_ID != 0)
+			sql += " AND t.AD_Org_ID=?";
+		else if (M_AttributeSetInstance_ID != 0)
+			sql += " AND t.M_AttributeSetInstance_ID=?";
+		sql += " ORDER BY t.M_Transaction_ID";
+
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		BigDecimal newStockQty = Env.ZERO;
+		//
+		BigDecimal newAverageAmt = Env.ZERO;
+		int oldTransaction_ID = 0;
+		try
+		{
+			pstmt = DB.prepareStatement (sql, null);
+			pstmt.setInt (1, product.getM_Product_ID());
+			if (AD_Org_ID != 0)
+				pstmt.setInt (2, AD_Org_ID);
+			else if (M_AttributeSetInstance_ID != 0)
+				pstmt.setInt (2, M_AttributeSetInstance_ID);
+			rs = pstmt.executeQuery ();
+			while (rs.next ())
+			{
+				BigDecimal oldStockQty = newStockQty;
+				BigDecimal movementQty = rs.getBigDecimal(1);
+				int M_Transaction_ID = rs.getInt(11);
+				if (M_Transaction_ID != oldTransaction_ID)
+					newStockQty = oldStockQty.add(movementQty);
+				M_Transaction_ID = oldTransaction_ID;
+				//
+				BigDecimal matchQty = rs.getBigDecimal(2);
+				if (matchQty == null)
+				{
+					s_log.finer("Movement=" + movementQty + ", StockQty=" + newStockQty);
+					continue;
+				}
+				//	Assumption: everything is matched
+				BigDecimal price = rs.getBigDecimal(4);
+				if (price == null || price.signum() == 0)	//	PO Cost
+					price = rs.getBigDecimal(5);			//	Actual
+				int C_Currency_ID = rs.getInt(6);
+				Timestamp DateAcct = rs.getTimestamp(7);
+				int C_ConversionType_ID = rs.getInt(8);
+				int Client_ID = rs.getInt(9);
+				int Org_ID = rs.getInt(10);
+				BigDecimal cost = MConversionRate.convert(product.getCtx(), price,
+					C_Currency_ID, as.getC_Currency_ID(),
+					DateAcct, C_ConversionType_ID, Client_ID, Org_ID);
+				//
+				BigDecimal oldAverageAmt = newAverageAmt;
+				BigDecimal averageCurrent = oldStockQty.multiply(oldAverageAmt);
+				BigDecimal averageIncrease = matchQty.multiply(cost);
+				BigDecimal newAmt = averageCurrent.add(averageIncrease);
+				newAmt = newAmt.setScale(as.getCostingPrecision(), RoundingMode.HALF_UP);
+				newAverageAmt = newAmt.divide(newStockQty, as.getCostingPrecision(), RoundingMode.HALF_UP);
+				s_log.finer("Movement=" + movementQty + ", StockQty=" + newStockQty
+					+ ", Match=" + matchQty + ", Cost=" + cost + ", NewAvg=" + newAverageAmt);
+			}
+		}
+		catch (SQLException e)
+		{
+			throw new DBException(e, sql);
+		}
+		finally
+		{
+			DB.close(rs, pstmt);
+			rs = null; pstmt = null;
+		}
+		//
+		if (newAverageAmt != null && newAverageAmt.signum() != 0)
+		{
+			s_log.finer(product.getName() + " = " + newAverageAmt);
+			return newAverageAmt;
+		}
+		return null;
+	}	//	calculateAveragePO
+
+	/**
+	 * 	Calculate FiFo Cost
+	 *	@param product product
+	 *	@param M_AttributeSetInstance_ID asi
+	 *	@param as acct schema
+	 *	@param AD_Org_ID org
+	 *	@return costs or null
+	 */
+	public static BigDecimal calculateFiFo (MProduct product, int M_AttributeSetInstance_ID,
+		MAcctSchema as, int AD_Org_ID)
+	{
+		String sql = "SELECT t.MovementQty, mi.Qty, il.QtyInvoiced, il.PriceActual,"
+			+ " i.C_Currency_ID, i.DateAcct, i.C_ConversionType_ID, i.AD_Client_ID, i.AD_Org_ID, t.M_Transaction_ID "
+			+ "FROM M_Transaction t"
+			+ " INNER JOIN M_MatchInv mi ON (t.M_InOutLine_ID=mi.M_InOutLine_ID)"
+			+ " INNER JOIN C_InvoiceLine il ON (mi.C_InvoiceLine_ID=il.C_InvoiceLine_ID)"
+			+ " INNER JOIN C_Invoice i ON (il.C_Invoice_ID=i.C_Invoice_ID) "
+			+ "WHERE t.M_Product_ID=?";
+		if (AD_Org_ID != 0)
+			sql += " AND t.AD_Org_ID=?";
+		else if (M_AttributeSetInstance_ID != 0)
+			sql += " AND t.M_AttributeSetInstance_ID=?";
+		sql += " ORDER BY t.M_Transaction_ID";
+
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		//
+		int oldTransaction_ID = 0;
+		ArrayList<QtyCost> fifo = new ArrayList<QtyCost>();
+		try
+		{
+			pstmt = DB.prepareStatement (sql, null);
+			pstmt.setInt (1, product.getM_Product_ID());
+			if (AD_Org_ID != 0)
+				pstmt.setInt (2, AD_Org_ID);
+			else if (M_AttributeSetInstance_ID != 0)
+				pstmt.setInt (2, M_AttributeSetInstance_ID);
+			rs = pstmt.executeQuery ();
+			while (rs.next ())
+			{
+				BigDecimal movementQty = rs.getBigDecimal(1);
+				int M_Transaction_ID = rs.getInt(10);
+				if (M_Transaction_ID == oldTransaction_ID)
+					continue;	//	assuming same price for receipt
+				M_Transaction_ID = oldTransaction_ID;
+				//
+				BigDecimal matchQty = rs.getBigDecimal(2);
+				if (matchQty == null)	//	out (negative)
+				{
+					if (fifo.size() > 0)
+					{
+						QtyCost pp = (QtyCost)fifo.get(0);
+						pp.Qty = pp.Qty.add(movementQty);
+						BigDecimal remainder = pp.Qty;
+						if (remainder.signum() == 0)
+							fifo.remove(0);
+						else
+						{
+							while (remainder.signum() != 0)
+							{
+								if (fifo.size() == 1)	//	Last
+								{
+									pp.Cost = Env.ZERO;
+									remainder = Env.ZERO;
+								}
+								else
+								{
+									fifo.remove(0);
+									pp = (QtyCost)fifo.get(0);
+									pp.Qty = pp.Qty.add(movementQty);
+									remainder = pp.Qty;
+								}
+							}
+						}
+					}
+					else
+					{
+						QtyCost pp = new QtyCost (movementQty, Env.ZERO);
+						fifo.add(pp);
+					}
+					s_log.finer("Movement=" + movementQty + ", Size=" + fifo.size());
+					continue;
+				}
+				//	Assumption: everything is matched
+				BigDecimal price = rs.getBigDecimal(4);
+				int C_Currency_ID = rs.getInt(5);
+				Timestamp DateAcct = rs.getTimestamp(6);
+				int C_ConversionType_ID = rs.getInt(7);
+				int Client_ID = rs.getInt(8);
+				int Org_ID = rs.getInt(9);
+				BigDecimal cost = MConversionRate.convert(product.getCtx(), price,
+					C_Currency_ID, as.getC_Currency_ID(),
+					DateAcct, C_ConversionType_ID, Client_ID, Org_ID);
+
+				//	Add Stock
+				boolean used = false;
+				if (fifo.size() == 1)
+				{
+					QtyCost pp = (QtyCost)fifo.get(0);
+					if (pp.Qty.signum() < 0)
+					{
+						pp.Qty = pp.Qty.add(movementQty);
+						if (pp.Qty.signum() == 0)
+							fifo.remove(0);
+						else
+							pp.Cost = cost;
+						used = true;
+					}
+
+				}
+				if (!used)
+				{
+					QtyCost pp = new QtyCost (movementQty, cost);
+					fifo.add(pp);
+				}
+				s_log.finer("Movement=" + movementQty + ", Size=" + fifo.size());
+			}
+		}
+		catch (SQLException e)
+		{
+			throw new DBException(e, sql);
+		}
+		finally
+		{
+			DB.close(rs, pstmt);
+			rs = null; pstmt = null;
+		}
+
+		if (fifo.size() == 0)
+		{
+			return null;
+		}
+		QtyCost pp = (QtyCost)fifo.get(0);
+		s_log.finer(product.getName() + " = " + pp.Cost);
+		return pp.Cost;
+	}	//	calculateFiFo
+
+	/**
+	 * 	Calculate LiFo costs
+	 *	@param product product
+	 *	@param M_AttributeSetInstance_ID asi
+	 *	@param as acct schema
+	 *	@param AD_Org_ID org
+	 *	@return costs or null
+	 */
+	public static BigDecimal calculateLiFo (MProduct product, int M_AttributeSetInstance_ID,
+		MAcctSchema as, int AD_Org_ID)
+	{
+		String sql = "SELECT t.MovementQty, mi.Qty, il.QtyInvoiced, il.PriceActual,"
+			+ " i.C_Currency_ID, i.DateAcct, i.C_ConversionType_ID, i.AD_Client_ID, i.AD_Org_ID, t.M_Transaction_ID "
+			+ "FROM M_Transaction t"
+			+ " INNER JOIN M_MatchInv mi ON (t.M_InOutLine_ID=mi.M_InOutLine_ID)"
+			+ " INNER JOIN C_InvoiceLine il ON (mi.C_InvoiceLine_ID=il.C_InvoiceLine_ID)"
+			+ " INNER JOIN C_Invoice i ON (il.C_Invoice_ID=i.C_Invoice_ID) "
+			+ "WHERE t.M_Product_ID=?";
+		if (AD_Org_ID != 0)
+			sql += " AND t.AD_Org_ID=?";
+		else if (M_AttributeSetInstance_ID != 0)
+			sql += " AND t.M_AttributeSetInstance_ID=?";
+		//	Starting point?
+		sql += " ORDER BY t.M_Transaction_ID DESC";
+
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		//
+		int oldTransaction_ID = 0;
+		ArrayList<QtyCost> lifo = new ArrayList<QtyCost>();
+		try
+		{
+			pstmt = DB.prepareStatement (sql, null);
+			pstmt.setInt (1, product.getM_Product_ID());
+			if (AD_Org_ID != 0)
+				pstmt.setInt (2, AD_Org_ID);
+			else if (M_AttributeSetInstance_ID != 0)
+				pstmt.setInt (2, M_AttributeSetInstance_ID);
+			rs = pstmt.executeQuery ();
+			while (rs.next ())
+			{
+				BigDecimal movementQty = rs.getBigDecimal(1);
+				int M_Transaction_ID = rs.getInt(10);
+				if (M_Transaction_ID == oldTransaction_ID)
+					continue;	//	assuming same price for receipt
+				M_Transaction_ID = oldTransaction_ID;
+				//
+				BigDecimal matchQty = rs.getBigDecimal(2);
+				if (matchQty == null)	//	out (negative)
+				{
+					if (lifo.size() > 0)
+					{
+						QtyCost pp = (QtyCost)lifo.get(lifo.size()-1);
+						pp.Qty = pp.Qty.add(movementQty);
+						BigDecimal remainder = pp.Qty;
+						if (remainder.signum() == 0)
+							lifo.remove(lifo.size()-1);
+						else
+						{
+							while (remainder.signum() != 0)
+							{
+								if (lifo.size() == 1)	//	Last
+								{
+									pp.Cost = Env.ZERO;
+									remainder = Env.ZERO;
+								}
+								else
+								{
+									lifo.remove(lifo.size()-1);
+									pp = (QtyCost)lifo.get(lifo.size()-1);
+									pp.Qty = pp.Qty.add(movementQty);
+									remainder = pp.Qty;
+								}
+							}
+						}
+					}
+					else
+					{
+						QtyCost pp = new QtyCost (movementQty, Env.ZERO);
+						lifo.add(pp);
+					}
+					s_log.finer("Movement=" + movementQty + ", Size=" + lifo.size());
+					continue;
+				}
+				//	Assumption: everything is matched
+				BigDecimal price = rs.getBigDecimal(4);
+				int C_Currency_ID = rs.getInt(5);
+				Timestamp DateAcct = rs.getTimestamp(6);
+				int C_ConversionType_ID = rs.getInt(7);
+				int Client_ID = rs.getInt(8);
+				int Org_ID = rs.getInt(9);
+				BigDecimal cost = MConversionRate.convert(product.getCtx(), price,
+					C_Currency_ID, as.getC_Currency_ID(),
+					DateAcct, C_ConversionType_ID, Client_ID, Org_ID);
+				//
+				QtyCost pp = new QtyCost (movementQty, cost);
+				lifo.add(pp);
+				s_log.finer("Movement=" + movementQty + ", Size=" + lifo.size());
+			}
+		}
+		catch (SQLException e)
+		{
+			throw new DBException(e, sql);
+		}
+		finally
+		{
+			DB.close(rs, pstmt);
+			rs = null; pstmt = null;
+		}
+
+		if (lifo.size() == 0)
+		{
+			return null;
+		}
+		QtyCost pp = (QtyCost)lifo.get(lifo.size()-1);
+		s_log.finer(product.getName() + " = " + pp.Cost);
+		return pp.Cost;
+	}	//	calculateLiFo
+
+
+	/**************************************************************************
+	 *	MCost Qty-Cost Pair
+	 */
+	public static class QtyCost
+	{
+		/**
+		 * 	Constructor
+		 *	@param qty qty
+		 *	@param cost cost
+		 */
+		public QtyCost (BigDecimal qty, BigDecimal cost)
+		{
+			Qty = qty;
+			Cost = cost;
+		}
+		/** Qty		*/
+		public BigDecimal	Qty = null;
+		/** Cost	*/
+		public BigDecimal	Cost = null;
+
+		/**
+		 * 	String Representation
+		 *	@return info
+		 */
+		public String toString ()
+		{
+			StringBuffer sb = new StringBuffer ("Qty=").append(Qty)
+				.append (",Cost=").append (Cost);
+			return sb.toString ();
+		}	//	toString
+	}	//	QtyCost
+	
+	/**
+	 * 	Get/Create Cost Record.
+	 * 	CostingLevel is not validated
+	 *	@param product product
+	 *	@param M_AttributeSetInstance_ID costing level asi
+	 *	@param as accounting schema
+	 *	@param AD_Org_ID costing level org
+	 *	@param M_CostElement_ID element
+	 *	@return cost price or null
+	 *	@deprecated
+	 */
+	public static MCost get (MProduct product, int M_AttributeSetInstance_ID,
+		MAcctSchema as, int AD_Org_ID, int M_Warehouse_ID, int M_CostElement_ID, String trxName)
+	{
+		return MCost.getOrCreate(product, M_AttributeSetInstance_ID, as, AD_Org_ID, M_Warehouse_ID,  as.getM_CostType_ID(), M_CostElement_ID);
+	}
+	/**
+	 * 	Get/Create Cost Record.
+	 * 	CostingLevel is not validated
+	 *	@param product product
+	 *	@param M_AttributeSetInstance_ID costing level asi
+	 *	@param as accounting schema
+	 *	@param AD_Org_ID costing level org
+	 *	@param M_CostType_ID Cost Type
+	 *	@param M_CostElement_ID element
+	 *	@return cost price
+	 */
+	public static MCost getOrCreate (MProduct product, int M_AttributeSetInstance_ID,
+		MAcctSchema as , int AD_Org_ID, int M_Warehouse_ID,  int M_CostType_ID , int M_CostElement_ID)
+	{
+		MCost cost = MCost.getDimension(product, as.getC_AcctSchema_ID(), AD_Org_ID, M_Warehouse_ID, M_AttributeSetInstance_ID, M_CostType_ID, M_CostElement_ID);
+		if (cost == null)
+		{
+			cost = new MCost (product, M_AttributeSetInstance_ID,
+					as.getC_AcctSchema_ID(), AD_Org_ID, M_Warehouse_ID, M_CostType_ID, M_CostElement_ID,  product.get_TrxName());
+			cost.saveEx();
+			s_log.fine("No cost records found.  Creating cost: " + cost.toString());
+		}
+		else
+		{
+			s_log.fine("Cost exists: " + cost.toString());
+		}
+		return cost;	
+
+	}	//	get
+
+	/**	Logger	*/
+	private static CLogger 	s_log = CLogger.getCLogger (MCost.class);
+
+
+	/**************************************************************************
+	 * 	Standard Constructor
+	 *	@param ctx context
+	 *	@param ignored multi-key
+	 *	@param trxName trx
+	 */
+	public MCost (Properties ctx, int ignored, String trxName)
+	{
+		super (ctx, ignored, trxName);
+		if (ignored == 0)
+		{
+		//	setC_AcctSchema_ID (0);
+		//	setM_CostElement_ID (0);
+		//	setM_CostType_ID (0);
+		//	setM_Product_ID (0);
+			setM_AttributeSetInstance_ID(0);
+			//
+			setCurrentCostPrice (Env.ZERO);
+			setFutureCostPrice (Env.ZERO);
+			setCurrentQty (Env.ZERO);
+			setCumulatedAmt (Env.ZERO);
+			setCumulatedQty (Env.ZERO);
+		}
+		else
+			throw new IllegalArgumentException("Multi-Key");
+	}	//	MCost
+
+	/**
+	 * 	Load Constructor
+	 *	@param ctx context
+	 *	@param rs result set
+	 *	@param trxName trx
+	 */
+	public MCost (Properties ctx, ResultSet rs, String trxName)
+	{
+		super (ctx, rs, trxName);
+		m_manual = false;
+	}	//	MCost
+
+	/**
+	 * 	Parent Constructor
+	 *	@param product Product
+	 *	@param M_AttributeSetInstance_ID asi
+	 *	@param as Acct Schema
+	 *	@param AD_Org_ID org
+	 *	@param M_CostElement_ID cost element
+	 */
+	public MCost (MProduct product, int M_AttributeSetInstance_ID,
+		MAcctSchema as, int AD_Org_ID, int M_CostElement_ID)
+	{
+		this (product.getCtx(), 0, product.get_TrxName());
+		setClientOrg(product.getAD_Client_ID(), AD_Org_ID);
+		setC_AcctSchema_ID(as.getC_AcctSchema_ID());
+		setM_CostType_ID(as.getM_CostType_ID());
+		setM_Product_ID(product.getM_Product_ID());
+		setM_AttributeSetInstance_ID(M_AttributeSetInstance_ID);
+		setM_CostElement_ID(M_CostElement_ID);
+		//
+		m_manual = false;
+	}	//	MCost
+	
+	/**
+	 * 	Parent Constructor
+	 *	@param product Product
+	 * @param M_AttributeSetInstance_ID asi
+	 * @param as Acct Schema
+	 * @param AD_Org_ID org
+	 * @param M_Warehouse_ID warehouse
+	 * @param M_CostType_ID TODO
+	 * @param M_CostElement_ID cost element
+	 */
+	public MCost (MProduct product, int M_AttributeSetInstance_ID,
+		int C_AcctSchema_ID, int AD_Org_ID, int M_Warehouse_ID ,int M_CostType_ID, int M_CostElement_ID, String trxName)
+	{
+		this (product.getCtx(), 0, trxName);
+		setClientOrg(product.getAD_Client_ID(), AD_Org_ID);
+		setM_Warehouse_ID(M_Warehouse_ID);
+		setC_AcctSchema_ID(C_AcctSchema_ID);
+		setM_CostType_ID(M_CostType_ID);
+		setM_Product_ID(product.getM_Product_ID());
+		setM_AttributeSetInstance_ID(M_AttributeSetInstance_ID);
+		setM_CostElement_ID(M_CostElement_ID);
+		//
+		m_manual = false;
+	}	//	MCost
+
+	/** Data is entered Manually		*/
+	private boolean m_manual = true;
+
+	/**
+	 * 	Add Cumulative Amt/Qty and Current Qty
+	 *	@param amt amt
+	 *	@param qty qty
+	 */
+	public void add (BigDecimal amt, BigDecimal qty)
+	{
+		setCumulatedAmt(getCumulatedAmt().add(amt));
+		setCumulatedQty(getCumulatedQty().add(qty));
+		setCurrentQty(getCurrentQty().add(qty));
+	}	//	add
+
+	/**
+	 * 	Add Amt/Qty and calculate weighted average.
+	 * 	((OldAvg*OldQty)+(Price*Qty)) / (OldQty+Qty)
+	 *	@param amt total amt (price * qty)
+	 *	@param qty qty
+	 */
+	public void setWeightedAverage (BigDecimal amt, BigDecimal qty)
+	{
+		BigDecimal oldSum = getCurrentCostPrice().multiply(getCurrentQty());
+		BigDecimal newSum = amt;	//	is total already
+		BigDecimal sumAmt = oldSum.add(newSum);
+		BigDecimal sumQty = getCurrentQty().add(qty);
+		if (sumQty.signum() != 0)
+		{
+			BigDecimal cost = sumAmt.divide(sumQty, getPrecision(), RoundingMode.HALF_UP);
+			setCurrentCostPrice(cost);
+		}
+		//
+		setCumulatedAmt(getCumulatedAmt().add(amt));
+		setCumulatedQty(getCumulatedQty().add(qty));
+		setCurrentQty(getCurrentQty().add(qty));
+	}	//	setWeightedAverage
+
+	/**
+	 * 	Get Costing Precision
+	 *	@return precision (6)
+	 */
+	private int getPrecision()
+	{
+		MAcctSchema as = MAcctSchema.get(getCtx(), getC_AcctSchema_ID());
+		if (as != null)
+			return as.getCostingPrecision();
+		return 6;
+	}	//	gerPrecision
+
+	/**
+	 * 	Set Current Cost Price
+	 *	@param currentCostPrice if null set to 0
+	 */
+	public void setCurrentCostPrice (BigDecimal currentCostPrice)
+	{
+		if (currentCostPrice != null)
+			super.setCurrentCostPrice (currentCostPrice);
+		else
+			super.setCurrentCostPrice (Env.ZERO);
+	}	//	setCurrentCostPrice
+
+	/**
+	 * 	Get History Average (Amt/Qty)
+	 *	@return average if amt/aty <> 0 otherwise null
+	 */
+	public BigDecimal getHistoryAverage()
+	{
+		BigDecimal retValue = null;
+		if (getCumulatedQty().signum() != 0
+			&& getCumulatedAmt().signum() != 0)
+			retValue = getCumulatedAmt()
+				.divide(getCumulatedQty(), getPrecision(), RoundingMode.HALF_UP);
+		return retValue;
+	}	//	getHistoryAverage
+
+	/**
+	 * 	String Representation
+	 *	@return info
+	 */
+	public String toString ()
+	{
+		StringBuffer sb = new StringBuffer ("MCost[");
+		sb.append ("AD_Client_ID=").append (getAD_Client_ID());
+		if (getAD_Org_ID() != 0)
+			sb.append (",AD_Org_ID=").append (getAD_Org_ID());
+		if (getM_Warehouse_ID() != 0)
+			sb.append (",M_Warehouse_ID=").append (getM_Warehouse_ID());
+		sb.append (",M_Product_ID=").append (getM_Product_ID());
+		if (getM_AttributeSetInstance_ID() != 0)
+			sb.append (",AD_ASI_ID=").append (getM_AttributeSetInstance_ID());
+	//	sb.append (",C_AcctSchema_ID=").append (getC_AcctSchema_ID());
+	//	sb.append (",M_CostType_ID=").append (getM_CostType_ID());
+		sb.append (",M_CostElement_ID=").append (getM_CostElement_ID());
+		//
+		sb.append (", CurrentCost=").append (getCurrentCostPrice())
+			.append (", C.Amt=").append (getCumulatedAmt())
+			.append (",C.Qty=").append (getCumulatedQty())
+			.append ("]");
+		return sb.toString ();
+	}	//	toString
+
+	/**
+	 * 	Get Cost Element
+	 *	@return cost element
+	 */
+	public MCostElement getCostElement()
+	{
+		int M_CostElement_ID = getM_CostElement_ID();
+		if (M_CostElement_ID == 0)
+			return null;
+		return MCostElement.get(getCtx(), M_CostElement_ID);
+	}	//	getCostElement
+
+	/**
+	 * 	Before Save
+	 *	@param newRecord new
+	 *	@return true if can be saved
+	 */
+	protected boolean beforeSave (boolean newRecord)
+	{
+		//The method getCostElement() not should be cached because is a transaction
+		//MCostElement ce = getCostElement();
+		MCostElement ce = (MCostElement)getM_CostElement();
+		//	Check if data entry makes sense
+		if (m_manual)
+		{
+			MAcctSchema as = new MAcctSchema (getCtx(), getC_AcctSchema_ID(), null);
+			MProduct product = MProduct.get(getCtx(), getM_Product_ID());
+			String CostingLevel = product.getCostingLevel(as);
+			if (MAcctSchema.COSTINGLEVEL_Client.equals(CostingLevel))
+			{
+				if (getAD_Org_ID() != 0 || getM_AttributeSetInstance_ID() != 0)
+				{
+					log.saveError("CostingLevelClient", "");
+					return false;
+				}
+			}
+			else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(CostingLevel))
+			{
+				if (getM_AttributeSetInstance_ID() == 0
+					&& ce.isCostingMethod())
+				{
+					log.saveError("FillMandatory", Msg.getElement(getCtx(), "M_AttributeSetInstance_ID"));
+					return false;
+				}
+				if (getAD_Org_ID() != 0)
+					setAD_Org_ID(0);
+			}
+		}
+
+		//	Cannot enter calculated
+		if (m_manual && ce != null && ce.isCalculated())
+		{
+			log.saveError("Error", Msg.getElement(getCtx(), "IsCalculated"));
+			return false;
+		}
+		//	Percentage
+		if (ce != null)
+		{
+			if (ce.isCalculated()
+				|| MCostElement.COSTELEMENTTYPE_Material.equals(ce.getCostElementType())
+				&& getPercent() != 0)
+				setPercent(0);
+		}
+		if (getPercent() != 0)
+		{
+			if (getCurrentCostPrice().signum() != 0)
+				setCurrentCostPrice(Env.ZERO);
+			if (getFutureCostPrice().signum() != 0)
+				setFutureCostPrice(Env.ZERO);
+			if (getCumulatedAmt().signum() != 0)
+				setCumulatedAmt(Env.ZERO);
+			if (getCumulatedQty().signum() != 0)
+				setCumulatedQty(Env.ZERO);
+		}
+		return true;
+	}	//	beforeSave
+
+
+	/**
+	 * 	Before Delete
+	 *	@return true
+	 */
+	protected boolean beforeDelete ()
+	{
+		return true;
+	}	//	beforeDelete
+
+
+	/**
+	 * 	Test
+	 *	@param args ignored
+	 */
+	public static void main (String[] args)
+	{
+		/**
+		DELETE M_Cost c
+		WHERE EXISTS (SELECT * FROM M_CostElement ce
+		    WHERE c.M_CostElement_ID=ce.M_CostElement_ID AND ce.IsCalculated='Y')
+		/
+		UPDATE M_Cost
+		  SET CumulatedAmt=0, CumulatedQty=0
+		/
+		UPDATE M_CostDetail
+		  SET Processed='N'
+		WHERE Processed='Y'
+		/
+		COMMIT
+		/
+		**/
+
+		Adempiere.startup(true);
+		MClient client = MClient.get(Env.getCtx(), 11);	//	GardenWorld
+		//create(client);
+
+	}	//	main
+
+}	//	MCost

--- a/src/patches/org/compiere/model/MProductPO.java
+++ b/src/patches/org/compiere/model/MProductPO.java
@@ -48,7 +48,7 @@ public class MProductPO extends X_M_Product_PO
 	 * @param trxName
 	 * @return
 	 */
-	public static List<MProductPO> getByPartner(Properties ctx , Integer partnerId, Integer productId, String trxName)
+	public static List<MProductPO> getByPartnerAndOrg(Properties ctx , Integer partnerId, Integer productId, Integer orgId, String trxName)
 	{
 		List<Object> parameters = new ArrayList<>();
 		StringBuilder whereClause = new StringBuilder();
@@ -59,12 +59,13 @@ public class MProductPO extends X_M_Product_PO
 					parameters.add(Id);
 				});
 
-		whereClause.append(MProductPO.COLUMNNAME_M_Product_ID).append("=?");
+		whereClause.append(MProductPO.COLUMNNAME_M_Product_ID).append("=? AND AD_Org_ID IN (0, ?)");
 		parameters.add(productId);
+		parameters.add(orgId);
 		List<MProductPO> purchaseProducts = new Query(ctx, MProductPO.Table_Name, whereClause.toString() , trxName)
 				.setClient_ID()
 				.setParameters(parameters)
-				.setOrderBy(MProductPO.COLUMNNAME_IsCurrentVendor)
+				.setOrderBy(MProductPO.COLUMNNAME_IsCurrentVendor + ", " + MProductPO.COLUMNNAME_AD_Org_ID + " DESC")
 				.list();
 		if (purchaseProducts == null)
 			return new ArrayList<>();
@@ -72,6 +73,25 @@ public class MProductPO extends X_M_Product_PO
 			return purchaseProducts;
 
 	}
+
+	/**
+	 * 	Get current PO of Product
+	 * 	@param ctx context
+	 *	@param M_Product_ID product
+	 *	@param trxName transaction
+	 *	@return PO - current vendor first
+	 */
+	public static MProductPO[] getOfProductAndOrg (Properties ctx, int M_Product_ID, int orgId,String trxName)
+	{
+		final String whereClause = "M_Product_ID=? AND AD_Org_ID IN (0, ?)";
+		List<MProductPO> list = new Query(ctx, Table_Name, whereClause, trxName)
+									.setParameters(M_Product_ID, orgId)
+									.setOnlyActiveRecords(true)
+									.setOrderBy("IsCurrentVendor DESC, AD_Org_ID DESC")
+									.list();
+		return list.toArray(new MProductPO[list.size()]);
+	}	//	getOfProduct
+
 
 	/**
 	 * 	Get current PO of Product
@@ -118,12 +138,15 @@ public class MProductPO extends X_M_Product_PO
 	 * @param partnerId
 	 * @param trxName
 	 */
-	public MProductPO(Properties ctx , int productId , int partnerId , int currencyId , String trxName)
+	public MProductPO(Properties ctx , int productId , int partnerId , int currencyId, int orgId, String trxName)
 	{
 		super(ctx, 0 , trxName);
 		setM_Product_ID(productId);
 		setC_BPartner_ID(partnerId);
 		setC_Currency_ID(currencyId);
+		if (orgId > 0){
+			setAD_Org_ID(orgId);
+		}
 		setIsCurrentVendor (true);
 	}
 	

--- a/src/patches/org/compiere/process/ImportProduct.java
+++ b/src/patches/org/compiere/process/ImportProduct.java
@@ -1,0 +1,850 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 1999-2006 ComPiere, Inc. All Rights Reserved.                *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * ComPiere, Inc., 2620 Augustine Dr. #245, Santa Clara, CA 95054, USA        *
+ * or via info@compiere.org or http://www.compiere.org/license.html           *
+ *****************************************************************************/
+package org.compiere.process;
+
+import org.adempiere.core.domains.models.X_I_Product;
+import org.adempiere.core.domains.models.X_M_Product_Class;
+import org.adempiere.core.domains.models.X_M_Product_Classification;
+import org.adempiere.core.domains.models.X_M_Product_Group;
+import org.adempiere.model.ImportValidator;
+import org.adempiere.process.ImportProcess;
+import org.compiere.model.MProduct;
+import org.compiere.model.MProductPO;
+import org.compiere.model.MProductPrice;
+import org.compiere.model.MTable;
+import org.compiere.model.ModelValidationEngine;
+import org.compiere.util.DB;
+import org.compiere.util.Util;
+
+import java.math.BigDecimal;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.logging.Level;
+
+/**
+ *	Import Products from I_Product
+ *
+ * 	@author 	Jorg Janke
+ * 	@version 	$Id: ImportProduct.java,v 1.3 2006/07/30 00:51:01 jjanke Exp $
+ *
+ * @author Carlos Ruiz, globalqss
+ * 			<li>FR [ 2788278 ] Data Import Validator - migrate core processes
+ * 				https://sourceforge.net/tracker/?func=detail&aid=2788278&group_id=176962&atid=879335
+ *
+ * Since 3.8.0#001 - Added import of Product Class, Classification and Group fields. 
+ * 			See ADEMPIERE-213 https://adempiere.atlassian.net/browse/ADEMPIERE-213
+ */
+public class ImportProduct extends SvrProcess implements ImportProcess
+{
+	/**	Client to be imported to		*/
+	private int				m_AD_Client_ID = 0;
+	/**	Delete old Imported				*/
+	private boolean			m_deleteOldImported = false;
+
+	/** Effective						*/
+	private Timestamp		m_DateValue = null;
+	/** Pricelist to Update				*/
+	private int 			p_M_PriceList_Version_ID = 0;
+
+	/**
+	 *  Prepare - e.g., get Parameters.
+	 */
+	protected void prepare()
+	{
+		ProcessInfoParameter[] para = getParameter();
+		for (int i = 0; i < para.length; i++)
+		{
+			String name = para[i].getParameterName();
+			if (name.equals("AD_Client_ID"))
+				m_AD_Client_ID = ((BigDecimal)para[i].getParameter()).intValue();
+			else if (name.equals("DeleteOldImported"))
+				m_deleteOldImported = "Y".equals(para[i].getParameter());
+			else if (name.equals("M_PriceList_Version_ID"))
+				p_M_PriceList_Version_ID = para[i].getParameterAsInt();
+			else
+				log.log(Level.SEVERE, "Unknown Parameter: " + name);
+		}
+		if (m_DateValue == null)
+			m_DateValue = new Timestamp (System.currentTimeMillis());
+	}	//	prepare
+
+
+	/**
+	 *  Perform process.
+	 *  @return Message
+	 *  @throws Exception
+	 */
+	protected String doIt() throws Exception
+	{
+		StringBuffer sql = null;
+		int no = 0;
+		String clientCheck = getWhereClause();
+
+		//	****	Prepare	****
+
+		//	Delete Old Imported
+		if (m_deleteOldImported)
+		{
+			sql = new StringBuffer ("DELETE I_Product "
+				+ "WHERE I_IsImported='Y'").append(clientCheck);
+			no = DB.executeUpdate(sql.toString(), get_TrxName());
+			log.info("Delete Old Imported =" + no);
+		}
+
+		//	Set Client, Org, IaActive, Created/Updated, 	ProductType
+		sql = new StringBuffer ("UPDATE I_Product "
+			+ "SET AD_Client_ID = COALESCE (AD_Client_ID, ").append(m_AD_Client_ID).append("),"
+			+ " AD_Org_ID = COALESCE (AD_Org_ID, 0),"
+			+ " IsActive = COALESCE (IsActive, 'Y'),"
+			+ " Created = COALESCE (Created, SysDate),"
+			+ " CreatedBy = COALESCE (CreatedBy, 0),"
+			+ " Updated = COALESCE (Updated, SysDate),"
+			+ " UpdatedBy = COALESCE (UpdatedBy, 0),"
+			+ " ProductType = COALESCE (ProductType, 'I'),"
+			+ " I_ErrorMsg = ' ',"
+			+ " I_IsImported = 'N' "
+			+ "WHERE I_IsImported<>'Y' OR I_IsImported IS NULL");
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		log.info("Reset=" + no);
+
+		ModelValidationEngine.get().fireImportValidate(this, null, null, ImportValidator.TIMING_BEFORE_VALIDATE);
+
+		//	Set Optional BPartner
+		sql = new StringBuffer ("UPDATE I_Product i "
+			+ "SET C_BPartner_ID=(SELECT C_BPartner_ID FROM C_BPartner p"
+			+ " WHERE i.BPartner_Value=p.Value AND p.AD_Client_ID=").append(m_AD_Client_ID).append(") "
+			+ "WHERE C_BPartner_ID IS NULL"
+			+ " AND I_IsImported<>'Y'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		log.info("BPartner=" + no);
+		//
+		sql = new StringBuffer ("UPDATE I_Product "
+			+ "SET I_IsImported='E', I_ErrorMsg=I_ErrorMsg||'ERR=Invalid BPartner,' "
+			+ "WHERE C_BPartner_ID IS NULL AND BPartner_Value IS NOT NULL"
+			+ " AND I_IsImported<>'Y'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		if (no != 0)
+			log.warning("Invalid BPartner=" + no);
+
+
+		//	****	Find Product
+		//	EAN/UPC
+		sql = new StringBuffer ("UPDATE I_Product i "
+			+ "SET M_Product_ID=(SELECT M_Product_ID FROM M_Product p"
+			+ " WHERE i.UPC=p.UPC AND p.AD_Client_ID=").append(m_AD_Client_ID).append(") "
+			+ "WHERE M_Product_ID IS NULL"
+			+ " AND I_IsImported='N'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		log.info("Product Existing UPC=" + no);
+
+		//	Value
+		sql = new StringBuffer ("UPDATE I_Product i "
+			+ "SET M_Product_ID=(SELECT M_Product_ID FROM M_Product p"
+			+ " WHERE i.Value=p.Value AND p.AD_Client_ID=").append(m_AD_Client_ID).append(") "
+			+ "WHERE M_Product_ID IS NULL"
+			+ " AND I_IsImported='N'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		log.info("Product Existing Value=" + no);
+
+		//	BP ProdNo
+		sql = new StringBuffer ("UPDATE I_Product i "
+			+ "SET M_Product_ID=(SELECT M_Product_ID FROM M_Product_po p"
+			+ " WHERE i.C_BPartner_ID=p.C_BPartner_ID"
+			+ " AND p.IsCurrentVendor='Y'"
+			+ " AND i.VendorProductNo=p.VendorProductNo AND p.AD_Client_ID=").append(m_AD_Client_ID).append(") "
+			+ "WHERE M_Product_ID IS NULL"
+			+ " AND I_IsImported='N'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		log.info("Product Existing Vendor ProductNo=" + no);
+
+		//	Set Product Category
+		sql = new StringBuffer ("UPDATE I_Product "
+			+ "SET ProductCategory_Value=(SELECT MAX(Value) FROM M_Product_Category"
+			+ " WHERE IsDefault='Y' AND AD_Client_ID=").append(m_AD_Client_ID).append(") "
+			+ "WHERE ProductCategory_Value IS NULL AND M_Product_Category_ID IS NULL"
+			+ " AND M_Product_ID IS NULL"	//	set category only if product not found
+			+ " AND I_IsImported<>'Y'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		log.fine("Set Category Default Value=" + no);
+		//
+		sql = new StringBuffer ("UPDATE I_Product i "
+			+ "SET M_Product_Category_ID=(SELECT M_Product_Category_ID FROM M_Product_Category c"
+			+ " WHERE i.ProductCategory_Value=c.Value AND c.AD_Client_ID=").append(m_AD_Client_ID).append(") "
+			+ "WHERE ProductCategory_Value IS NOT NULL AND M_Product_Category_ID IS NULL"
+			+ " AND I_IsImported<>'Y'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		log.info("Set Category=" + no);
+
+		//	Since 3.8.1 - Set Product Class
+		sql = new StringBuffer ("UPDATE I_Product "
+			+ "SET ProductClass_Value=(SELECT MAX(Value) FROM M_Product_Class"
+			+ " WHERE IsDefault='Y' AND AD_Client_ID=").append(m_AD_Client_ID).append(") "
+			+ "WHERE ProductClass_Value IS NULL AND M_Product_Class_ID IS NULL"
+			+ " AND M_Product_ID IS NULL"	//	set class only if product not found
+			+ " AND I_IsImported<>'Y'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		log.fine("Set Class Default Value=" + no);
+		//
+		sql = new StringBuffer ("UPDATE I_Product i "
+			+ "SET M_Product_Class_ID=(SELECT M_Product_Class_ID FROM M_Product_Class c"
+			+ " WHERE i.ProductClass_Value=c.Value AND c.AD_Client_ID=").append(m_AD_Client_ID).append(") "
+			+ "WHERE ProductClass_Value IS NOT NULL AND M_Product_Class_ID IS NULL"
+			+ " AND I_IsImported<>'Y'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		log.info("Set Class=" + no);
+
+		//	Since 3.8.1 - Set Product Classification
+		sql = new StringBuffer ("UPDATE I_Product "
+			+ "SET ProductClassification_Value=(SELECT MAX(Value) FROM M_Product_Classification"
+			+ " WHERE IsDefault='Y' AND AD_Client_ID=").append(m_AD_Client_ID).append(") "
+			+ "WHERE ProductClassification_Value IS NULL AND M_Product_Classification_ID IS NULL"
+			+ " AND M_Product_ID IS NULL"	//	set Classification only if product not found
+			+ " AND I_IsImported<>'Y'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		log.fine("Set Classification Default Value=" + no);
+		//
+		sql = new StringBuffer ("UPDATE I_Product i "
+			+ "SET M_Product_Classification_ID=(SELECT M_Product_Classification_ID FROM M_Product_Classification c"
+			+ " WHERE i.ProductClassification_Value=c.Value AND c.AD_Client_ID=").append(m_AD_Client_ID).append(") "
+			+ "WHERE ProductClassification_Value IS NOT NULL AND M_Product_Classification_ID IS NULL"
+			+ " AND I_IsImported<>'Y'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		log.info("Set Classification=" + no);
+
+		//	Since 3.8.1 - Set Product Group
+		sql = new StringBuffer ("UPDATE I_Product "
+			+ "SET ProductGroup_Value=(SELECT MAX(Value) FROM M_Product_Group"
+			+ " WHERE IsDefault='Y' AND AD_Client_ID=").append(m_AD_Client_ID).append(") "
+			+ "WHERE ProductGroup_Value IS NULL AND M_Product_Group_ID IS NULL"
+			+ " AND M_Product_ID IS NULL"	//	set Group only if product not found
+			+ " AND I_IsImported<>'Y'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		log.fine("Set Group Default Value=" + no);
+		//
+		sql = new StringBuffer ("UPDATE I_Product i "
+			+ "SET M_Product_Group_ID=(SELECT M_Product_Group_ID FROM M_Product_Group c"
+			+ " WHERE i.ProductGroup_Value=c.Value AND c.AD_Client_ID=").append(m_AD_Client_ID).append(") "
+			+ "WHERE ProductGroup_Value IS NOT NULL AND M_Product_Group_ID IS NULL"
+			+ " AND I_IsImported<>'Y'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		log.info("Set Group=" + no);
+
+		//	Set Product Brand
+		sql = new StringBuffer ("UPDATE I_Product i "
+				+ "SET M_Brand_ID=(SELECT M_Brand_ID FROM M_Brand c"
+				+ " WHERE i.Brand_Value=c.Value AND c.AD_Client_ID=").append(m_AD_Client_ID).append(") "
+				+ "WHERE Brand_Value IS NOT NULL AND M_Brand_ID IS NULL"
+				+ " AND I_IsImported<>'Y'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		log.info("Set Brand=" + no);
+
+		//	Set Industry Sector
+		sql = new StringBuffer ("UPDATE I_Product i "
+				+ "SET M_Industry_Sector_ID=(SELECT M_Industry_Sector_ID FROM M_Industry_Sector c"
+				+ " WHERE i.IndustrySector_Value=c.Value AND c.AD_Client_ID=").append(m_AD_Client_ID).append(") "
+				+ "WHERE IndustrySector_Value IS NOT NULL AND M_Industry_Sector_ID IS NULL"
+				+ " AND I_IsImported<>'Y'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		log.info("Set Industry Sector=" + no);
+
+		//	Set Material Group
+		sql = new StringBuffer ("UPDATE I_Product i "
+				+ "SET M_Material_Group_ID=(SELECT M_Material_Group_ID FROM M_Material_Group c"
+				+ " WHERE i.MaterialGroup_Value=c.Value AND c.AD_Client_ID=").append(m_AD_Client_ID).append(") "
+				+ "WHERE MaterialGroup_Value IS NOT NULL AND M_Material_Group_ID IS NULL"
+				+ " AND I_IsImported<>'Y'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		log.info("Set Material Group=" + no);
+
+		//	Set Material Type
+		sql = new StringBuffer ("UPDATE I_Product i "
+				+ "SET M_Material_Type_ID=(SELECT M_Material_Type_ID FROM M_Material_Type c"
+				+ " WHERE i.MaterialType_Value=c.Value AND c.AD_Client_ID=").append(m_AD_Client_ID).append(") "
+				+ "WHERE MaterialType_Value IS NOT NULL AND M_Material_Type_ID IS NULL"
+				+ " AND I_IsImported<>'Y'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		log.info("Set Material Type=" + no);
+
+		//	Set Part Type
+		sql = new StringBuffer ("UPDATE I_Product i "
+				+ "SET M_PartType_ID=(SELECT M_PartType_ID FROM M_PartType c"
+				+ " WHERE i.PartType_Name=c.Name AND c.AD_Client_ID=").append(m_AD_Client_ID).append(") "
+				+ "WHERE PartType_Name IS NOT NULL AND M_PartType_ID IS NULL"
+				+ " AND I_IsImported<>'Y'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		log.info("Set Part Type=" + no);
+
+		//	Set Purchase Group
+		sql = new StringBuffer ("UPDATE I_Product i "
+				+ "SET M_Purchase_Group_ID=(SELECT M_Purchase_Group_ID FROM M_Purchase_Group c"
+				+ " WHERE i.PurchaseGroup_Value=c.Value AND c.AD_Client_ID=").append(m_AD_Client_ID).append(") "
+				+ "WHERE PurchaseGroup_Value IS NOT NULL AND M_Purchase_Group_ID IS NULL"
+				+ " AND I_IsImported<>'Y'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		log.info("Set Purchase Group=" + no);
+
+		//	Set Sales Group
+		sql = new StringBuffer ("UPDATE I_Product i "
+				+ "SET M_Sales_Group_ID=(SELECT M_Sales_Group_ID FROM M_Sales_Group c"
+				+ " WHERE i.SalesGroup_Value=c.Value AND c.AD_Client_ID=").append(m_AD_Client_ID).append(") "
+				+ "WHERE SalesGroup_Value IS NOT NULL AND M_Sales_Group_ID IS NULL"
+				+ " AND I_IsImported<>'Y'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		log.info("Set Sales Group=" + no);
+
+		//	Copy From Product if Import does not have value
+		String[] strFields = new String[] {"Value","Name","Description","DocumentNote","Help",
+			"UPC","SKU","Classification","ProductType",
+			"Discontinued","DiscontinuedBy","DiscontinuedAt","ImageURL","DescriptionURL"};
+		for (int i = 0; i < strFields.length; i++)
+		{
+			sql = new StringBuffer ("UPDATE I_Product i "
+				+ "SET ").append(strFields[i]).append(" = (SELECT ").append(strFields[i]).append(" FROM M_Product p"
+				+ " WHERE i.M_Product_ID=p.M_Product_ID AND p.AD_Client_ID=").append(m_AD_Client_ID).append(") "
+				+ "WHERE M_Product_ID IS NOT NULL"
+				+ " AND ").append(strFields[i]).append(" IS NULL"
+				+ " AND I_IsImported='N'").append(clientCheck);
+			no = DB.executeUpdate(sql.toString(), get_TrxName());
+			if (no != 0)
+				log.fine(strFields[i] + " - default from existing Product=" + no);
+		}
+		String[] numFields = new String[] {"C_UOM_ID","M_Product_Category_ID",
+			"M_Product_Class_ID", "M_Product_Classification_ID", "M_Product_Group_ID",
+			"Volume","Weight","ShelfWidth","ShelfHeight","ShelfDepth","UnitsPerPallet", "M_Brand_ID",
+			"M_Industry_Sector_ID", "M_Material_Group_ID", "M_Material_Type_ID", "M_PartType_ID",
+			"M_Purchase_Group_ID", "M_Sales_Group_ID"};
+		for (int i = 0; i < numFields.length; i++)
+		{
+			sql = new StringBuffer ("UPDATE I_PRODUCT i "
+				+ "SET ").append(numFields[i]).append(" = (SELECT ").append(numFields[i]).append(" FROM M_Product p"
+				+ " WHERE i.M_Product_ID=p.M_Product_ID AND p.AD_Client_ID=").append(m_AD_Client_ID).append(") "
+				+ "WHERE M_Product_ID IS NOT NULL"
+				+ " AND (").append(numFields[i]).append(" IS NULL OR ").append(numFields[i]).append("=0)"
+				+ " AND I_IsImported='N'").append(clientCheck);
+			no = DB.executeUpdate(sql.toString(), get_TrxName());
+			if (no != 0)
+				log.fine(numFields[i] + " default from existing Product=" + no);
+		}
+
+		//	Copy From Product_PO if Import does not have value
+		String[] strFieldsPO = new String[] {"UPC",
+			"PriceEffective","VendorProductNo","VendorCategory","Manufacturer",
+			"Discontinued","DiscontinuedBy", "DiscontinuedAt"};
+		for (int i = 0; i < strFieldsPO.length; i++)
+		{
+			sql = new StringBuffer ("UPDATE I_PRODUCT i "
+				+ "SET ").append(strFieldsPO[i]).append(" = (SELECT ").append(strFieldsPO[i])
+				.append(" FROM M_Product_PO p"
+				+ " WHERE i.M_Product_ID=p.M_Product_ID AND i.C_BPartner_ID=p.C_BPartner_ID"
+				+ " AND p.IsCurrentVendor='Y' AND p.AD_Client_ID=").append(m_AD_Client_ID).append(")"
+				+ " WHERE M_Product_ID IS NOT NULL AND C_BPartner_ID IS NOT NULL"
+				+ " AND ").append(strFieldsPO[i]).append(" IS NULL"
+				+ " AND I_IsImported='N'").append(clientCheck);
+			no = DB.executeUpdate(sql.toString(), get_TrxName());
+			if (no != 0)
+				log.fine(strFieldsPO[i] + " default from existing Product PO=" + no);
+		}
+		String[] numFieldsPO = new String[] {"C_UOM_ID","C_Currency_ID",
+			"PriceList","PricePO","RoyaltyAmt",
+			"Order_Min","Order_Pack","CostPerOrder","DeliveryTime_Promised"};
+		for (int i = 0; i < numFieldsPO.length; i++)
+		{
+			sql = new StringBuffer ("UPDATE I_PRODUCT i "
+				+ "SET ").append(numFieldsPO[i]).append(" = (SELECT ").append(numFieldsPO[i])
+				.append(" FROM M_Product_PO p"
+				+ " WHERE i.M_Product_ID=p.M_Product_ID AND i.C_BPartner_ID=p.C_BPartner_ID"
+				+ " AND p.IsCurrentVendor='Y' AND i.AD_Client_ID=p.AD_Client_ID)"
+				+ " WHERE M_Product_ID IS NOT NULL AND C_BPartner_ID IS NOT NULL"
+				+ " AND (").append(numFieldsPO[i]).append(" IS NULL OR ").append(numFieldsPO[i]).append("=0)"
+				+ " AND I_IsImported='N'").append(clientCheck);
+			no = DB.executeUpdate(sql.toString(), get_TrxName());
+			if (no != 0)
+				log.fine(numFieldsPO[i] + " default from existing Product PO=" + no);
+		}
+
+		//	Invalid Category
+		sql = new StringBuffer ("UPDATE I_Product "
+			+ "SET I_IsImported='E', I_ErrorMsg=I_ErrorMsg||'ERR=Invalid ProdCategory,' "
+			+ "WHERE M_Product_Category_ID IS NULL"
+			+ " AND I_IsImported<>'Y'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		if (no != 0)
+			log.warning("Invalid Category=" + no);
+
+		//	Set UOM (System/own)
+		sql = new StringBuffer ("UPDATE I_Product i "
+			+ "SET X12DE355 = "
+			+ "(SELECT MAX(X12DE355) FROM C_UOM u WHERE u.IsDefault='Y' AND u.AD_Client_ID IN (0,i.AD_Client_ID)) "
+			+ "WHERE X12DE355 IS NULL AND C_UOM_ID IS NULL"
+			+ " AND I_IsImported<>'Y'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		log.fine("Set UOM Default=" + no);
+		//
+		sql = new StringBuffer ("UPDATE I_Product i "
+			+ "SET C_UOM_ID = (SELECT C_UOM_ID FROM C_UOM u WHERE u.X12DE355=i.X12DE355 AND u.AD_Client_ID IN (0,i.AD_Client_ID)) "
+			+ "WHERE C_UOM_ID IS NULL"
+			+ " AND I_IsImported<>'Y'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		log.info("Set UOM=" + no);
+		//
+		sql = new StringBuffer ("UPDATE I_Product "
+			+ "SET I_IsImported='E', I_ErrorMsg=I_ErrorMsg||'ERR=Invalid UOM, ' "
+			+ "WHERE C_UOM_ID IS NULL"
+			+ " AND I_IsImported<>'Y'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		if (no != 0)
+			log.warning("Invalid UOM=" + no);
+
+
+		//	Set Currency
+		sql = new StringBuffer ("UPDATE I_Product i "
+			+ "SET ISO_Code=(SELECT ISO_Code FROM C_Currency c"
+			+ " INNER JOIN C_AcctSchema a ON (a.C_Currency_ID=c.C_Currency_ID)"
+			+ " INNER JOIN AD_ClientInfo ci ON (a.C_AcctSchema_ID=ci.C_AcctSchema1_ID)"
+			+ " WHERE ci.AD_Client_ID=i.AD_Client_ID) "
+			+ "WHERE C_Currency_ID IS NULL AND ISO_Code IS NULL"
+			+ " AND I_IsImported<>'Y'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		log.fine("Set Currency Default=" + no);
+		//
+		sql = new StringBuffer ("UPDATE I_Product i "
+			+ "SET C_Currency_ID=(SELECT C_Currency_ID FROM C_Currency c"
+			+ " WHERE i.ISO_Code=c.ISO_Code AND c.AD_Client_ID IN (0,i.AD_Client_ID)) "
+			+ "WHERE C_Currency_ID IS NULL"
+			+ " AND I_IsImported<>'Y'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		log.info("doIt- Set Currency=" + no);
+		//
+		sql = new StringBuffer ("UPDATE I_Product "
+			+ "SET I_IsImported='E', I_ErrorMsg=I_ErrorMsg||'ERR=Currency,' "
+			+ "WHERE C_Currency_ID IS NULL"
+			+ " AND I_IsImported<>'Y'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		if (no != 0)
+			log.warning("Invalid Currency=" + no);
+
+		//	Verify ProductType
+		sql = new StringBuffer ("UPDATE I_Product "
+			+ "SET I_IsImported='E', I_ErrorMsg=I_ErrorMsg||'ERR=Invalid ProductType,' "
+			+ "WHERE ProductType NOT IN ('E','I','R','S')"
+			+ " AND I_IsImported<>'Y'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		if (no != 0)
+			log.warning("Invalid ProductType=" + no);
+
+		//	Unique UPC/Value
+		sql = new StringBuffer ("UPDATE I_Product i "
+			+ "SET I_IsImported='E', I_ErrorMsg=I_ErrorMsg||'ERR=Value not unique,' "
+			+ "WHERE I_IsImported<>'Y'"
+			+ " AND Value IN (SELECT Value FROM I_Product ii WHERE ii.AD_Client_ID=").append(m_AD_Client_ID).append(" GROUP BY Value HAVING COUNT(*) > 1)").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		if (no != 0)
+			log.warning("Not Unique Value=" + no);
+		//
+		sql = new StringBuffer ("UPDATE I_Product i "
+			+ "SET I_IsImported='E', I_ErrorMsg=I_ErrorMsg||'ERR=UPC not unique,' "
+			+ "WHERE I_IsImported<>'Y'"
+			+ " AND UPC IN (SELECT UPC FROM I_Product ii WHERE ii.AD_Client_ID=").append(m_AD_Client_ID).append(" GROUP BY UPC HAVING COUNT(*) > 1)").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		if (no != 0)
+			log.warning("Not Unique UPC=" + no);
+
+		//	Mandatory Value
+		sql = new StringBuffer ("UPDATE I_Product i "
+			+ "SET I_IsImported='E', I_ErrorMsg=I_ErrorMsg||'ERR=No Mandatory Value,' "
+			+ "WHERE Value IS NULL"
+			+ " AND I_IsImported<>'Y'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		if (no != 0)
+			log.warning("No Mandatory Value=" + no);
+
+		//	Vendor Product No
+	//	sql = new StringBuffer ("UPDATE I_Product i "
+	//		+ "SET I_IsImported='E', I_ErrorMsg=I_ErrorMsg||'ERR=No Mandatory VendorProductNo,' "
+	//		+ "WHERE I_IsImported<>'Y'"
+	//		+ " AND VendorProductNo IS NULL AND (C_BPartner_ID IS NOT NULL OR BPartner_Value IS NOT NULL)").append(clientCheck);
+	//	no = DB.executeUpdate(sql.toString(), get_TrxName());
+	//	log.info(log.l3_Util, "No Mandatory VendorProductNo=" + no);
+		sql = new StringBuffer ("UPDATE I_Product "
+			+ "SET VendorProductNo=Value "
+			+ "WHERE C_BPartner_ID IS NOT NULL AND VendorProductNo IS NULL"
+			+ " AND I_IsImported='N'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		log.info("VendorProductNo Set to Value=" + no);
+		//
+		/*sql = new StringBuffer ("UPDATE I_Product i "
+			+ "SET I_IsImported='E', I_ErrorMsg=I_ErrorMsg||'ERR=VendorProductNo not unique,' "
+			+ "WHERE I_IsImported<>'Y'"
+			+ " AND C_BPartner_ID IS NOT NULL"
+			+ " AND (C_BPartner_ID, VendorProductNo) IN "
+			+ " (SELECT C_BPartner_ID, VendorProductNo FROM I_Product ii WHERE ii.AD_Client_ID=").append(m_AD_Client_ID).append(" GROUP BY C_BPartner_ID, VendorProductNo HAVING COUNT(*) > 1)")
+			.append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		if (no != 0)
+			log.warning("Not Unique VendorProductNo=" + no);
+		*/
+		//	Get Default Tax Category
+		int C_TaxCategory_ID = 0;
+		try
+		{
+			PreparedStatement pstmt = DB.prepareStatement
+				("SELECT C_TaxCategory_ID FROM C_TaxCategory WHERE IsDefault='Y'" + clientCheck, get_TrxName());
+			ResultSet rs = pstmt.executeQuery();
+			if (rs.next())
+				C_TaxCategory_ID = rs.getInt(1);
+			rs.close();
+			pstmt.close();
+		}
+		catch (SQLException e)
+		{
+			throw new Exception ("TaxCategory", e);
+		}
+		log.fine("C_TaxCategory_ID=" + C_TaxCategory_ID);
+
+		ModelValidationEngine.get().fireImportValidate(this, null, null, ImportValidator.TIMING_AFTER_VALIDATE);
+
+		commitEx();
+
+		//	-------------------------------------------------------------------
+		int noInsert = 0;
+		int noUpdate = 0;
+		int noInsertPO = 0;
+		int noUpdatePO = 0;
+
+		//  Check for new Product Class, Classification or Group
+
+
+		//	Go through Records
+		log.fine("start inserting/updating ...");
+		sql = new StringBuffer ("SELECT * FROM I_Product WHERE I_IsImported='N'")
+			.append(clientCheck);
+		try
+		{
+
+
+			//	Set Imported = Y
+			PreparedStatement pstmt_setImported = DB.prepareStatement
+				("UPDATE I_Product SET I_IsImported='Y', M_Product_ID=?, "
+				+ "Updated=SysDate, Processed='Y' WHERE I_Product_ID=?", get_TrxName());
+
+			//
+			PreparedStatement pstmt = DB.prepareStatement(sql.toString(), get_TrxName());
+			ResultSet rs = pstmt.executeQuery();
+			while (rs.next())
+			{
+				X_I_Product imp = new X_I_Product(getCtx(), rs, get_TrxName());
+				int I_Product_ID = imp.getI_Product_ID();
+				int M_Product_ID = imp.getM_Product_ID();
+				int C_BPartner_ID = imp.getC_BPartner_ID();
+				boolean newProduct = M_Product_ID == 0;
+				log.fine("I_Product_ID=" + I_Product_ID + ", M_Product_ID=" + M_Product_ID
+					+ ", C_BPartner_ID=" + C_BPartner_ID);
+
+				// Since 3.8.1 Check and add product Class, Classification and Group
+				Boolean saveNeeded = false;
+				// Class
+				if (imp.getM_Product_Class_ID() == 0
+						&& !Util.isEmpty(imp.getProductClass_Value())
+						&& !Util.isEmpty(imp.getProductClass_Name())) {
+					String value = imp.getProductClass_Value();
+					String whereClause = "VALUE= '" + value + "'";
+					// Have we already added it?
+					X_M_Product_Class pClass = MTable.get(getCtx(), X_M_Product_Class.Table_ID)
+						.createQuery(whereClause, get_TrxName())  // will lock the table
+						.setOnlyActiveRecords(true)
+						.setClient_ID()
+						.first();
+					if (pClass == null) {
+						pClass = new X_M_Product_Class(getCtx(), 0, get_TrxName());
+						pClass.setValue(imp.getProductClass_Value());
+						pClass.setName(imp.getProductClass_Name());
+						pClass.setIsActive(true);
+						pClass.setIsDefault(false);
+						pClass.saveEx();
+					}
+					imp.setM_Product_Class_ID(pClass.getM_Product_Class_ID());
+					pClass = null;
+					saveNeeded = true;
+				}
+				// Classification
+				if (imp.getM_Product_Classification_ID() == 0
+						&& !Util.isEmpty(imp.getProductClassification_Value())
+						&& !Util.isEmpty(imp.getProductClassification_Name())) {
+					String value = imp.getProductClassification_Value();
+					String whereClause = "VALUE= '" + value + "'";
+					// Have we already added it?
+					X_M_Product_Classification pClassification = MTable.get(getCtx(), X_M_Product_Classification.Table_ID)
+						.createQuery(whereClause, get_TrxName())  // will lock the table
+						.setOnlyActiveRecords(true)
+						.setClient_ID()
+						.first();
+					if (pClassification == null) {
+						pClassification = new X_M_Product_Classification(getCtx(), 0, get_TrxName());
+						pClassification.setValue(imp.getProductClassification_Value());
+						pClassification.setName(imp.getProductClassification_Name());
+						pClassification.setIsActive(true);
+						pClassification.setIsDefault(false);
+						pClassification.saveEx();
+					}
+					imp.setM_Product_Classification_ID(pClassification.getM_Product_Classification_ID());
+					pClassification = null;
+					saveNeeded = true;
+				}
+				// Group
+				if (imp.getM_Product_Group_ID() == 0
+						&& !Util.isEmpty(imp.getProductGroup_Value())
+						&& !Util.isEmpty(imp.getProductGroup_Name())) {
+					String value = imp.getProductGroup_Value();
+					String whereClause = "VALUE= '" + value + "'";
+					// Have we already added it?
+					X_M_Product_Group pGroup = MTable.get(getCtx(), X_M_Product_Group.Table_ID)
+						.createQuery(whereClause, get_TrxName())  // will lock the table
+						.setOnlyActiveRecords(true)
+						.setClient_ID()
+						.first();
+					if (pGroup == null) {
+						pGroup = new X_M_Product_Group(getCtx(), 0, get_TrxName());
+						pGroup.setValue(imp.getProductGroup_Value());
+						pGroup.setName(imp.getProductGroup_Name());
+						pGroup.setIsActive(true);
+						pGroup.setIsDefault(false);
+						pGroup.saveEx();
+					}
+					imp.setM_Product_Group_ID(pGroup.getM_Product_Group_ID());
+					pGroup = null;
+					saveNeeded = true;
+				}
+
+				if (saveNeeded)
+					imp.saveEx();
+
+				//	Product
+				if (newProduct)			//	Insert new Product
+				{
+					MProduct product = new MProduct(imp);
+					product.setC_TaxCategory_ID(C_TaxCategory_ID);
+					ModelValidationEngine.get().fireImportValidate(this, imp, product, ImportValidator.TIMING_AFTER_IMPORT);
+					if (product.save())
+					{
+						M_Product_ID = product.getM_Product_ID();
+						log.finer("Insert Product");
+						noInsert++;
+					}
+					else
+					{
+						StringBuffer sql0 = new StringBuffer ("UPDATE I_Product i "
+							+ "SET I_IsImported='E', I_ErrorMsg=I_ErrorMsg||").append(DB.TO_STRING("Insert Product failed"))
+							.append("WHERE I_Product_ID=").append(I_Product_ID);
+						DB.executeUpdate(sql0.toString(), get_TrxName());
+						continue;
+					}
+				}
+				else					//	Update Product
+				{
+					String sqlt = "UPDATE M_PRODUCT "
+						+ "SET (Value,Name,Description,DocumentNote,Help,"
+						+ "UPC,SKU,C_UOM_ID,M_Product_Category_ID,Classification,ProductType,"
+						+ "M_Product_Class_ID, M_Product_Classification_ID, M_Product_Group_ID,"
+						+ "Volume,Weight,ShelfWidth,ShelfHeight,ShelfDepth,UnitsPerPallet,"
+						+ "Discontinued,DiscontinuedBy, DiscontinuedAt, Updated,UpdatedBy, "
+						+ "M_Brand_ID, M_Industry_Sector_ID, M_Material_Group_ID, M_Material_Type_ID,"
+						+ "M_PartType_ID, M_Purchase_Group_ID, M_Sales_Group_ID)= "
+						+ "(SELECT Value,Name,Description,DocumentNote,Help,"
+						+ "UPC,SKU,C_UOM_ID,M_Product_Category_ID,Classification,ProductType,"
+						+ "M_Product_Class_ID, M_Product_Classification_ID, M_Product_Group_ID,"
+						+ "Volume,Weight,ShelfWidth,ShelfHeight,ShelfDepth,UnitsPerPallet,"
+						+ "Discontinued,DiscontinuedBy, DiscontinuedAt, SysDate,UpdatedBy, "
+						+ "M_Brand_ID, M_Industry_Sector_ID, M_Material_Group_ID, M_Material_Type_ID,"
+						+ "M_PartType_ID, M_Purchase_Group_ID, M_Sales_Group_ID"
+						+ " FROM I_Product WHERE I_Product_ID="+I_Product_ID+") "
+						+ "WHERE M_Product_ID="+M_Product_ID;
+					PreparedStatement pstmt_updateProduct = DB.prepareStatement
+						(sqlt, get_TrxName());
+
+					//jz pstmt_updateProduct.setInt(1, I_Product_ID);
+					//   pstmt_updateProduct.setInt(2, M_Product_ID);
+					try
+					{
+						no = pstmt_updateProduct.executeUpdate();
+						log.finer("Update Product = " + no);
+						noUpdate++;
+					}
+					catch (SQLException ex)
+					{
+						log.warning("Update Product - " + ex.toString());
+						StringBuffer sql0 = new StringBuffer ("UPDATE I_Product i "
+							+ "SET I_IsImported='E', I_ErrorMsg=I_ErrorMsg||").append(DB.TO_STRING("Update Product: " + ex.toString()))
+							.append("WHERE I_Product_ID=").append(I_Product_ID);
+						DB.executeUpdate(sql0.toString(), get_TrxName());
+						continue;
+					}
+					pstmt_updateProduct.close();
+				}
+
+				//	Do we have PO Info
+				if (C_BPartner_ID != 0)
+				{
+					no = 0;
+					//	If Product existed, Try to Update first
+					if (!newProduct)
+					{
+						String sqlt = "UPDATE M_Product_PO "
+							+ "SET (IsCurrentVendor,C_UOM_ID,C_Currency_ID,UPC,"
+							+ "PriceList,PricePO,RoyaltyAmt,PriceEffective,"
+							+ "VendorProductNo,VendorCategory,Manufacturer,"
+							+ "Discontinued,DiscontinuedBy, DiscontinuedAt, Order_Min,Order_Pack,"
+							+ "CostPerOrder,DeliveryTime_Promised,Updated,UpdatedBy)= "
+							+ "(SELECT CAST('Y' AS CHAR),C_UOM_ID,C_Currency_ID,UPC,"    //jz fix EDB unknown datatype error
+							+ "PriceList,PricePO,RoyaltyAmt,PriceEffective,"
+							+ "VendorProductNo,VendorCategory,Manufacturer,"
+							+ "Discontinued,DiscontinuedBy, DiscontinuedAt, Order_Min,Order_Pack,"
+							+ "CostPerOrder,DeliveryTime_Promised,SysDate,UpdatedBy"
+							+ " FROM I_Product"
+							+ " WHERE I_Product_ID="+I_Product_ID+") "
+							+ "WHERE M_Product_ID="+M_Product_ID+" AND C_BPartner_ID="+C_BPartner_ID;
+						PreparedStatement pstmt_updateProductPO = DB.prepareStatement
+							(sqlt, get_TrxName());
+						//jz pstmt_updateProductPO.setInt(1, I_Product_ID);
+						// pstmt_updateProductPO.setInt(2, M_Product_ID);
+						// pstmt_updateProductPO.setInt(3, C_BPartner_ID);
+						try
+						{
+							no = pstmt_updateProductPO.executeUpdate();
+							log.finer("Update Product_PO = " + no);
+							noUpdatePO++;
+						}
+						catch (SQLException ex)
+						{
+							log.warning("Update Product_PO - " + ex.toString());
+							noUpdate--;
+							rollback();
+							StringBuffer sql0 = new StringBuffer ("UPDATE I_Product i "
+								+ "SET I_IsImported='E', I_ErrorMsg=I_ErrorMsg||").append(DB.TO_STRING("Update Product_PO: " + ex.toString()))
+								.append("WHERE I_Product_ID=").append(I_Product_ID);
+							DB.executeUpdate(sql0.toString(), get_TrxName());
+							continue;
+						}
+						pstmt_updateProductPO.close();
+					}
+					if (no == 0)		//	Insert PO
+					{
+
+						MProductPO productPO = new MProductPO(getCtx(), M_Product_ID,C_BPartner_ID, imp.getC_Currency_ID(), imp.getAD_Org_ID(), get_TrxName());
+						productPO.setC_UOM_ID(imp.getC_UOM_ID());
+						productPO.setUPC(imp.getUPC());
+						productPO.setPriceList(imp.getPriceList());
+						productPO.setPricePO(imp.getPricePO());
+						productPO.setRoyaltyAmt(imp.getRoyaltyAmt());
+						productPO.setPriceEffective(imp.getPriceEffective());
+						productPO.setVendorProductNo(imp.getVendorProductNo());
+						productPO.setVendorCategory(imp.getVendorCategory());
+						productPO.setManufacturer(imp.getManufacturer());
+						productPO.setDiscontinued(imp.isDiscontinued());
+						productPO.setDiscontinuedBy(imp.getDiscontinuedBy());
+						productPO.setDiscontinuedAt(imp.getDiscontinuedAt());
+						productPO.setOrder_Min(BigDecimal.valueOf(imp.getOrder_Min()));
+						productPO.setOrder_Pack(BigDecimal.valueOf(imp.getOrder_Pack()));
+						productPO.setCostPerOrder(imp.getCostPerOrder());
+						productPO.setDeliveryTime_Promised(imp.getDeliveryTime_Promised());
+						try
+						{
+							productPO.saveEx();
+							log.finer("Insert Product_PO");
+							noInsertPO++;
+						}
+						catch (Exception ex)
+						{
+							log.warning("Insert Product_PO - " + ex.toString());
+							noInsert--;			//	assume that product also did not exist
+							rollback();
+							StringBuffer sql0 = new StringBuffer ("UPDATE I_Product i "
+								+ "SET I_IsImported='E', I_ErrorMsg=I_ErrorMsg||").append(DB.TO_STRING("Insert Product_PO: " + ex.toString()))
+								.append("WHERE I_Product_ID=").append(I_Product_ID);
+							DB.executeUpdate(sql0.toString(), get_TrxName());
+							continue;
+						}
+					}
+				}	//	C_BPartner_ID != 0
+
+				//	Price List
+				if (p_M_PriceList_Version_ID != 0)
+				{
+					BigDecimal PriceList = imp.getPriceList();
+					BigDecimal PriceStd = imp.getPriceStd();
+					BigDecimal PriceLimit = imp.getPriceLimit();
+					if (PriceStd.signum() != 0 || PriceLimit.signum() != 0 || PriceList.signum() != 0)
+					{
+						MProductPrice pp = MProductPrice.get(getCtx(),
+							p_M_PriceList_Version_ID, M_Product_ID, get_TrxName());
+						if (pp == null)
+							pp = new MProductPrice (getCtx(),
+								p_M_PriceList_Version_ID, M_Product_ID, get_TrxName());
+						pp.setPrices(PriceList, PriceStd, PriceLimit);
+						ModelValidationEngine.get().fireImportValidate(this, imp, pp, ImportValidator.TIMING_AFTER_IMPORT);
+						pp.saveEx();
+					}
+				}
+
+				//	Update I_Product
+				pstmt_setImported.setInt(1, M_Product_ID);
+				pstmt_setImported.setInt(2, I_Product_ID);
+				no = pstmt_setImported.executeUpdate();
+				//
+				commitEx();
+			}	//	for all I_Product
+			rs.close();
+			pstmt.close();
+
+			//
+			//	pstmt_insertProduct.close();
+			// pstmt_updateProduct.close();
+			// pstmt_updateProductPO.close();
+			pstmt_setImported.close();
+			//
+		}
+		catch (SQLException e)
+		{
+		}
+
+		//	Set Error to indicator to not imported
+		sql = new StringBuffer ("UPDATE I_Product "
+			+ "SET I_IsImported='N', Updated=SysDate "
+			+ "WHERE I_IsImported<>'Y'").append(clientCheck);
+		no = DB.executeUpdate(sql.toString(), get_TrxName());
+		addLog (0, null, new BigDecimal (no), "@Errors@");
+		addLog (0, null, new BigDecimal (noInsert), "@M_Product_ID@: @Inserted@");
+		addLog (0, null, new BigDecimal (noUpdate), "@M_Product_ID@: @Updated@");
+		addLog (0, null, new BigDecimal (noInsertPO), "@M_Product_ID@ @Purchase@: @Inserted@");
+		addLog (0, null, new BigDecimal (noUpdatePO), "@M_Product_ID@ @Purchase@: @Updated@");
+		return "";
+	}	//	doIt
+
+
+	@Override
+	public String getImportTableName() {
+		return X_I_Product.Table_Name;
+	}
+
+
+	@Override
+	public String getWhereClause() {
+		return " AND AD_Client_ID=" + m_AD_Client_ID;
+	}
+
+}	//	ImportProduct

--- a/src/patches/org/compiere/process/InventoryValue.java
+++ b/src/patches/org/compiere/process/InventoryValue.java
@@ -1,0 +1,294 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 1999-2006 ComPiere, Inc. All Rights Reserved.                *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * ComPiere, Inc., 2620 Augustine Dr. #245, Santa Clara, CA 95054, USA        *
+ * or via info@compiere.org or http://www.compiere.org/license.html           *
+ *****************************************************************************/
+package org.compiere.process;
+
+import org.compiere.model.MAcctSchema;
+import org.compiere.model.MClient;
+import org.compiere.model.MWarehouse;
+import org.compiere.util.DB;
+
+import java.sql.Timestamp;
+
+
+/**
+ *  Inventory Valuation.
+ *  Process to fill T_InventoryValue
+ *
+ *  @author     Jorg Janke
+ *  @version    $Id: InventoryValue.java,v 1.2 2006/07/30 00:51:02 jjanke Exp $
+ *  @author 	Michael Judd (mjudd) Akuna Ltd - BF [ 2685127 ]
+ *  
+ */
+public class InventoryValue extends SvrProcess
+{
+	/** Price List Used         */
+	private int         p_M_PriceList_Version_ID;
+	/** Valuation Date          */
+	private Timestamp   p_DateValue;
+	/** Warehouse               */
+	private int         p_M_Warehouse_ID;
+	/** Currency                */
+	private int         p_C_Currency_ID;
+	/** Optional Cost Element	*/
+	private int			p_M_CostElement_ID;
+
+	/**
+	 *  Prepare - get Parameters.
+	 */
+	protected void prepare()
+	{
+		ProcessInfoParameter[] para = getParameter();
+		for (int i = 0; i < para.length; i++)
+		{
+			String name = para[i].getParameterName();
+			if (para[i].getParameter() == null)
+				;
+			else if (name.equals("M_PriceList_Version_ID"))
+				p_M_PriceList_Version_ID = para[i].getParameterAsInt();
+			else if (name.equals("DateValue"))
+				p_DateValue = (Timestamp)para[i].getParameter();
+			else if (name.equals("M_Warehouse_ID"))
+				p_M_Warehouse_ID = para[i].getParameterAsInt();
+			else if (name.equals("C_Currency_ID"))
+				p_C_Currency_ID = para[i].getParameterAsInt();
+			else if (name.equals("M_CostElement_ID"))
+				p_M_CostElement_ID = para[i].getParameterAsInt();
+		}
+		if (p_DateValue == null)
+			p_DateValue = new Timestamp (System.currentTimeMillis());
+	}   //  prepare
+
+	/**
+	 *  Perform process.
+	 *  <pre>
+	 *  - Fill Table with QtyOnHand for Warehouse and Valuation Date
+	 *  - Perform Price Calculations
+	 *  </pre>
+	 * @return Message
+	 * @throws Exception
+	 */
+	protected String doIt() throws Exception
+	{
+		log.info("M_Warehouse_ID=" + p_M_Warehouse_ID
+			+ ",C_Currency_ID=" + p_C_Currency_ID
+			+ ",DateValue=" + p_DateValue
+			+ ",M_PriceList_Version_ID=" + p_M_PriceList_Version_ID
+			+ ",M_CostElement_ID=" + p_M_CostElement_ID);
+		
+		MWarehouse wh = MWarehouse.get(getCtx(), p_M_Warehouse_ID);
+		MClient c = MClient.get(getCtx(), wh.getAD_Client_ID());
+		MAcctSchema as = c.getAcctSchema();
+		
+		//  Delete (just to be sure)
+		StringBuffer sql = new StringBuffer ("DELETE T_InventoryValue WHERE AD_PInstance_ID=");
+		sql.append(getAD_PInstance_ID());
+		int no = DB.executeUpdateEx(sql.toString(), get_TrxName());
+
+		//	Insert Standard Costs
+		sql = new StringBuffer ("INSERT INTO T_InventoryValue "
+			+ "(AD_PInstance_ID, M_Warehouse_ID, M_Product_ID, M_AttributeSetInstance_ID,"
+			+ " AD_Client_ID, AD_Org_ID, CostStandard) "
+			+ "SELECT ").append(getAD_PInstance_ID())
+			.append(", w.M_Warehouse_ID, c.M_Product_ID, c.M_AttributeSetInstance_ID,"
+			+ " w.AD_Client_ID, w.AD_Org_ID, c.CurrentCostPrice "
+			+ "FROM M_Warehouse w"
+			+ " INNER JOIN AD_ClientInfo ci ON (w.AD_Client_ID=ci.AD_Client_ID)"
+			+ " INNER JOIN C_AcctSchema acs ON (ci.C_AcctSchema1_ID=acs.C_AcctSchema_ID)"
+			+ " INNER JOIN M_Cost c ON (acs.C_AcctSchema_ID=c.C_AcctSchema_ID AND acs.M_CostType_ID=c.M_CostType_ID AND c.AD_Org_ID IN (0, w.AD_Org_ID))"
+			+ " INNER JOIN M_CostElement ce ON (c.M_CostElement_ID=ce.M_CostElement_ID AND ce.CostingMethod='S' AND ce.CostElementType='M') "
+			+ "WHERE w.M_Warehouse_ID=").append(p_M_Warehouse_ID);
+		int noInsertStd = DB.executeUpdateEx(sql.toString(), get_TrxName());
+		log.fine("Inserted Std=" + noInsertStd);
+		if (noInsertStd == 0)
+			return "No Standard Costs found";
+
+		//	Insert addl Costs
+		int noInsertCost = 0;
+		if (p_M_CostElement_ID != 0)
+		{
+			sql = new StringBuffer ("INSERT INTO T_InventoryValue "
+				+ "(AD_PInstance_ID, M_Warehouse_ID, M_Product_ID, M_AttributeSetInstance_ID,"
+				+ " AD_Client_ID, AD_Org_ID, CostStandard, Cost, M_CostElement_ID) "
+				+ "SELECT ").append(getAD_PInstance_ID())
+				.append(", w.M_Warehouse_ID, c.M_Product_ID, c.M_AttributeSetInstance_ID,"
+				+ " w.AD_Client_ID, w.AD_Org_ID, 0, c.CurrentCostPrice, c.M_CostElement_ID "
+				+ "FROM M_Warehouse w"
+				+ " INNER JOIN AD_ClientInfo ci ON (w.AD_Client_ID=ci.AD_Client_ID)"
+				+ " INNER JOIN C_AcctSchema acs ON (ci.C_AcctSchema1_ID=acs.C_AcctSchema_ID)"
+				+ " INNER JOIN M_Cost c ON (acs.C_AcctSchema_ID=c.C_AcctSchema_ID AND acs.M_CostType_ID=c.M_CostType_ID AND c.AD_Org_ID IN (0, w.AD_Org_ID)) "
+				+ "WHERE w.M_Warehouse_ID=").append(p_M_Warehouse_ID)
+				.append(" AND c.M_CostElement_ID=").append(p_M_CostElement_ID)
+				.append(" AND NOT EXISTS (SELECT * FROM T_InventoryValue iv "
+					+ "WHERE iv.AD_PInstance_ID=").append(getAD_PInstance_ID())
+					.append(" AND iv.M_Warehouse_ID=w.M_Warehouse_ID"
+					+ " AND iv.M_Product_ID=c.M_Product_ID"
+					+ " AND iv.M_AttributeSetInstance_ID=c.M_AttributeSetInstance_ID)");
+			noInsertCost = DB.executeUpdateEx(sql.toString(), get_TrxName());
+			log.fine("Inserted Cost=" + noInsertCost);
+			//	Update Std Cost Records
+			sql = new StringBuffer ("UPDATE T_InventoryValue iv "
+				+ "SET (Cost, M_CostElement_ID)="
+					+ "(SELECT c.CurrentCostPrice, c.M_CostElement_ID "
+					+ "FROM M_Warehouse w"
+					+ " INNER JOIN AD_ClientInfo ci ON (w.AD_Client_ID=ci.AD_Client_ID)"
+					+ " INNER JOIN C_AcctSchema acs ON (ci.C_AcctSchema1_ID=acs.C_AcctSchema_ID)"
+					+ " INNER JOIN M_Cost c ON (acs.C_AcctSchema_ID=c.C_AcctSchema_ID"
+						+ " AND acs.M_CostType_ID=c.M_CostType_ID AND c.AD_Org_ID IN (0, w.AD_Org_ID)) "
+					+ "WHERE c.M_CostElement_ID=" + p_M_CostElement_ID
+					+ " AND iv.M_Warehouse_ID=w.M_Warehouse_ID"
+					+ " AND iv.M_Product_ID=c.M_Product_ID"
+					+ " AND iv.M_AttributeSetInstance_ID=c.M_AttributeSetInstance_ID) "
+				+ "WHERE EXISTS (SELECT * FROM T_InventoryValue ivv "
+					+ "WHERE ivv.AD_PInstance_ID=" + getAD_PInstance_ID()
+					+ " AND ivv.M_CostElement_ID IS NULL)");
+			int noUpdatedCost = DB.executeUpdateEx(sql.toString(), get_TrxName());
+			log.fine("Updated Cost=" + noUpdatedCost);
+		}		
+		if ((noInsertStd+noInsertCost) == 0)
+			return "No Costs found";
+		
+		//  Update Constants
+		//  YYYY-MM-DD HH24:MI:SS.mmmm  JDBC Timestamp format
+		String myDate = p_DateValue.toString();
+		sql = new StringBuffer ("UPDATE T_InventoryValue SET ")
+			.append("DateValue=TO_DATE('").append(myDate.substring(0,10))
+			.append(" 23:59:59','YYYY-MM-DD HH24:MI:SS'),")
+			.append("M_PriceList_Version_ID=").append(p_M_PriceList_Version_ID).append(",")
+			.append("C_Currency_ID=").append(p_C_Currency_ID)
+			.append(" WHERE AD_PInstance_ID=" + getAD_PInstance_ID());
+		no = DB.executeUpdateEx(sql.toString(), get_TrxName());
+		log.fine("Constants=" + no);
+
+		//  Get current QtyOnHand with ASI
+		sql = new StringBuffer ("UPDATE T_InventoryValue iv SET QtyOnHand = "
+				+ "(SELECT SUM(QtyOnHand) FROM M_Storage s"
+				+ " INNER JOIN M_Locator l ON (l.M_Locator_ID=s.M_Locator_ID) "
+				+ "WHERE iv.M_Product_ID=s.M_Product_ID"
+				+ " AND iv.M_Warehouse_ID=l.M_Warehouse_ID"
+				+ " AND iv.M_AttributeSetInstance_ID=s.M_AttributeSetInstance_ID) "
+			+ "WHERE AD_PInstance_ID=").append(getAD_PInstance_ID())
+			.append(" AND iv.M_AttributeSetInstance_ID<>0");
+		no = DB.executeUpdateEx(sql.toString(), get_TrxName());
+		log.fine("QtHand with ASI=" + no);
+		//  Get current QtyOnHand without ASI
+		sql = new StringBuffer ("UPDATE T_InventoryValue iv SET QtyOnHand = "
+				+ "(SELECT SUM(QtyOnHand) FROM M_Storage s"
+				+ " INNER JOIN M_Locator l ON (l.M_Locator_ID=s.M_Locator_ID) "
+				+ "WHERE iv.M_Product_ID=s.M_Product_ID"
+				+ " AND iv.M_Warehouse_ID=l.M_Warehouse_ID) "
+			+ "WHERE iv.AD_PInstance_ID=").append(getAD_PInstance_ID())
+			.append(" AND iv.M_AttributeSetInstance_ID=0");
+		no = DB.executeUpdateEx(sql.toString(), get_TrxName());
+		log.fine("QtHand w/o ASI=" + no);
+		
+		//  Adjust for Valuation Date
+		sql = new StringBuffer("UPDATE T_InventoryValue iv "
+			+ "SET QtyOnHand="
+				+ "(SELECT iv.QtyOnHand - NVL(SUM(t.MovementQty), 0) "
+				+ "FROM M_Transaction t"
+				+ " INNER JOIN M_Locator l ON (t.M_Locator_ID=l.M_Locator_ID) "
+				+ "WHERE t.M_Product_ID=iv.M_Product_ID"
+				+ " AND t.M_AttributeSetInstance_ID=iv.M_AttributeSetInstance_ID"
+				+ " AND t.MovementDate > iv.DateValue"
+				+ " AND l.M_Warehouse_ID=iv.M_Warehouse_ID) "
+			+ "WHERE iv.M_AttributeSetInstance_ID<>0" 
+			+ " AND iv.AD_PInstance_ID=").append(getAD_PInstance_ID());
+		no = DB.executeUpdateEx(sql.toString(), get_TrxName());
+		log.fine("Update with ASI=" + no);
+		//
+		sql = new StringBuffer("UPDATE T_InventoryValue iv "
+			+ "SET QtyOnHand="
+				+ "(SELECT iv.QtyOnHand - NVL(SUM(t.MovementQty), 0) "
+				+ "FROM M_Transaction t"
+				+ " INNER JOIN M_Locator l ON (t.M_Locator_ID=l.M_Locator_ID) "
+				+ "WHERE t.M_Product_ID=iv.M_Product_ID"
+				+ " AND t.MovementDate > iv.DateValue"
+				+ " AND l.M_Warehouse_ID=iv.M_Warehouse_ID) "
+			+ "WHERE iv.M_AttributeSetInstance_ID=0 "
+			+ "AND iv.AD_PInstance_ID=").append(getAD_PInstance_ID());
+
+		no = DB.executeUpdateEx(sql.toString(), get_TrxName());
+		log.fine("Update w/o ASI=" + no);
+		
+		//  Delete Records w/o OnHand Qty
+		sql = new StringBuffer("DELETE T_InventoryValue "
+			+ "WHERE (QtyOnHand=0 OR QtyOnHand IS NULL) AND AD_PInstance_ID=").append(getAD_PInstance_ID());
+		int noQty = DB.executeUpdateEx (sql.toString(), get_TrxName());
+		log.fine("NoQty Deleted=" + noQty);
+
+		//  Update Prices
+		sql = new StringBuffer("UPDATE T_InventoryValue iv "
+			+ "SET PricePO = "
+				+ "(SELECT currencyConvert (po.PriceList,po.C_Currency_ID,iv.C_Currency_ID,iv.DateValue,null, po.AD_Client_ID,po.AD_Org_ID)"
+				+ " FROM M_Product_PO po WHERE po.M_Product_ID=iv.M_Product_ID"
+				+ " AND po.IsCurrentVendor='Y' AND po.AD_Org_ID IN (0, po.AD_Org_ID) ORDER BY po.AD_Org_ID DESC Limit 1), "
+			+ "PriceList = "
+				+ "(SELECT currencyConvert(pp.PriceList,pl.C_Currency_ID,iv.C_Currency_ID,iv.DateValue,null, pl.AD_Client_ID,pl.AD_Org_ID)"
+				+ " FROM M_PriceList pl, M_PriceList_Version plv, M_ProductPrice pp"
+				+ " WHERE pp.M_Product_ID=iv.M_Product_ID AND pp.M_PriceList_Version_ID=iv.M_PriceList_Version_ID"
+				+ " AND pp.M_PriceList_Version_ID=plv.M_PriceList_Version_ID"
+				+ " AND plv.M_PriceList_ID=pl.M_PriceList_ID), "
+			+ "PriceStd = "
+				+ "(SELECT currencyConvert(pp.PriceStd,pl.C_Currency_ID,iv.C_Currency_ID,iv.DateValue,null, pl.AD_Client_ID,pl.AD_Org_ID)"
+				+ " FROM M_PriceList pl, M_PriceList_Version plv, M_ProductPrice pp"
+				+ " WHERE pp.M_Product_ID=iv.M_Product_ID AND pp.M_PriceList_Version_ID=iv.M_PriceList_Version_ID"
+				+ " AND pp.M_PriceList_Version_ID=plv.M_PriceList_Version_ID"
+				+ " AND plv.M_PriceList_ID=pl.M_PriceList_ID), "
+			+ "PriceLimit = "
+				+ "(SELECT currencyConvert(pp.PriceLimit,pl.C_Currency_ID,iv.C_Currency_ID,iv.DateValue,null, pl.AD_Client_ID,pl.AD_Org_ID)"
+				+ " FROM M_PriceList pl, M_PriceList_Version plv, M_ProductPrice pp"
+				+ " WHERE pp.M_Product_ID=iv.M_Product_ID AND pp.M_PriceList_Version_ID=iv.M_PriceList_Version_ID"
+				+ " AND pp.M_PriceList_Version_ID=plv.M_PriceList_Version_ID"
+				+ " AND plv.M_PriceList_ID=pl.M_PriceList_ID)"
+				+ " WHERE iv.AD_PInstance_ID=").append(getAD_PInstance_ID());
+
+		no = DB.executeUpdateEx (sql.toString(), get_TrxName());
+		String msg = "";
+		if (no == 0)
+			msg = "No Prices";
+
+		//	Convert if different Currency
+		if (as.getC_Currency_ID() != p_C_Currency_ID)
+		{
+			sql = new StringBuffer ("UPDATE T_InventoryValue iv "
+				+ "SET CostStandard= "
+					+ "(SELECT currencyConvert(iv.CostStandard,acs.C_Currency_ID,iv.C_Currency_ID,iv.DateValue,null, iv.AD_Client_ID,iv.AD_Org_ID) "
+					+ "FROM C_AcctSchema acs WHERE acs.C_AcctSchema_ID=" + as.getC_AcctSchema_ID() + "),"
+				+ "	Cost= "
+					+ "(SELECT currencyConvert(iv.Cost,acs.C_Currency_ID,iv.C_Currency_ID,iv.DateValue,null, iv.AD_Client_ID,iv.AD_Org_ID) "
+					+ "FROM C_AcctSchema acs WHERE acs.C_AcctSchema_ID=" + as.getC_AcctSchema_ID() + ") "
+				+ "WHERE iv.AD_PInstance_ID=" + getAD_PInstance_ID());
+			no = DB.executeUpdateEx (sql.toString(), get_TrxName());
+			log.fine("Converted=" + no);
+		}
+		
+		//  Update Values
+		no = DB.executeUpdateEx("UPDATE T_InventoryValue SET "
+			+ "PricePOAmt = QtyOnHand * PricePO, "
+			+ "PriceListAmt = QtyOnHand * PriceList, "
+			+ "PriceStdAmt = QtyOnHand * PriceStd, "
+			+ "PriceLimitAmt = QtyOnHand * PriceLimit, "
+			+ "CostStandardAmt = QtyOnHand * CostStandard, "
+			+ "CostAmt = QtyOnHand * Cost "
+			+ "WHERE AD_PInstance_ID=" + getAD_PInstance_ID()
+			, get_TrxName());
+		log.fine("Calculation=" + no);
+		//
+		return msg;
+	}   //  doIt
+
+}   //  InventoryValue

--- a/src/patches/org/compiere/process/OrderPOCreate.java
+++ b/src/patches/org/compiere/process/OrderPOCreate.java
@@ -1,0 +1,295 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 1999-2006 ComPiere, Inc. All Rights Reserved.                *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * ComPiere, Inc., 2620 Augustine Dr. #245, Santa Clara, CA 95054, USA        *
+ * or via info@compiere.org or http://www.compiere.org/license.html           *
+ *****************************************************************************/
+package org.compiere.process;
+
+import org.adempiere.core.domains.models.I_C_Order;
+import org.compiere.model.MBPartner;
+import org.compiere.model.MOrder;
+import org.compiere.model.MOrderLine;
+import org.compiere.model.MOrgInfo;
+import org.compiere.model.Query;
+import org.compiere.util.AdempiereUserError;
+import org.compiere.util.DB;
+import org.compiere.util.Util;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+
+/**
+ *	Generate PO from Sales Order
+ *	
+ *  @author Jorg Janke
+ *  @version $Id: OrderPOCreate.java,v 1.2 2006/07/30 00:51:01 jjanke Exp $
+ *  
+ *  Contributor: Carlos Ruiz - globalqss
+ *      Fix [1709952] - Process: "Generate PO from Sales order" bug
+ *  @contributor: author https://github.com/homebeaver
+ */
+public class OrderPOCreate extends OrderPOCreateAbstract {
+	
+	/**	Order Counter	*/
+	private int counter = 0;
+	
+	/**
+	 *  Prepare - e.g., get Parameters.
+	 */
+	protected void prepare() {
+		super.prepare();
+		// called from order window w/o parameters
+		if (getTable_ID() == MOrder.Table_ID && getRecord_ID() > 0 ) {
+			setOrderId(getRecord_ID());
+		}
+	}	//	prepare
+
+	/**
+	 *  Perform process.
+	 *  @return Message 
+	 *  @throws Exception if not successful
+	 */
+	protected String doIt() throws Exception {
+		log.info("DateOrdered=" + getDateOrdered() + " - " + getDateOrderedTo() 
+			+ " - C_BPartner_ID=" + getBPartnerId() + " - Vendor_ID=" + getVendorId()
+			+ " - IsDropShip=" + getIsDropShip() + " - C_Order_ID=" + getOrderId());
+		if (getOrderId() == 0
+			&& getDateOrdered() == null && getDateOrderedTo() == null
+			&& getBPartnerId() == 0 && getVendorId() == 0)
+			throw new AdempiereUserError("@FillMandatory@ @AD_Process_Para_ID@");
+		//	Parameters
+		List<Object> parameters = new ArrayList<>();
+		// see https://github.com/adempiere/adempiere/issues/1649
+		StringBuffer whereClause = new StringBuffer("IsSOTrx = 'Y' AND DocStatus IN('IP', 'CO')");
+		//	No Duplicates
+		whereClause.append(" AND NOT EXISTS (SELECT 1 FROM C_OrderLine ol WHERE ol.C_Order_ID=C_Order.C_Order_ID AND ol.Link_OrderLine_ID IS NOT NULL)");
+		if (getOrderId() != 0) {
+			whereClause.append(" AND C_Order.C_Order_ID=?");
+			parameters.add(getOrderId());
+		} else {
+			if (getBPartnerId() != 0) {
+				whereClause.append(" AND C_Order.C_BPartner_ID=?");
+				parameters.add(getBPartnerId());
+			}
+			//	For vendor
+			if (getVendorId() != 0) {
+				whereClause.append(" AND EXISTS (SELECT 1 FROM C_OrderLine ol "
+						+ "INNER JOIN M_Product_PO po ON (ol.M_Product_ID = po.M_Product_ID) "
+						+ "WHERE C_Order.C_Order_ID = ol.C_Order_ID AND po.C_BPartner_ID=?)");
+				parameters.add(getVendorId());
+			}
+			//	For Times
+			if (getDateOrdered() != null && getDateOrderedTo() != null) {
+				whereClause.append(" AND TRUNC(C_Order.DateOrdered, 'DD') BETWEEN ? AND ?");
+				parameters.add(getDateOrdered());
+				parameters.add(getDateOrderedTo());
+			} else if (getDateOrdered() != null && getDateOrderedTo() == null) {
+				whereClause.append(" AND TRUNC(C_Order.DateOrdered, 'DD') >= ?");
+				parameters.add(getDateOrdered());
+			} else if (getDateOrdered() == null && getDateOrderedTo() != null) {
+				whereClause.append(" AND TRUNC(C_Order.DateOrdered, 'DD') <= ?");
+				parameters.add(getDateOrderedTo());
+			}
+		}
+		//	Get from Std Query
+		new Query(getCtx(), I_C_Order.Table_Name, whereClause.toString(), get_TrxName())
+			.setClient_ID()
+			.setParameters(parameters)
+			.<MOrder>list().stream().forEach(order -> {
+				counter += createPOFromSO(order);
+		});
+		//	
+		return "@Created@ " + counter;
+	}	//	doIt
+	
+	/**
+	 * 	Create PO From SO
+	 *	@param salesOrder sales order
+	 *	@return number of POs created
+	 */
+	private int createPOFromSO (MOrder salesOrder) {
+		log.info(salesOrder.toString());
+		MOrderLine[] salesOrderLines = salesOrder.getLines(true, null);
+		if (salesOrderLines == null 
+				|| salesOrderLines.length == 0) {
+			log.warning("No Lines - " + salesOrder);
+			return 0;
+		}
+		//	
+		MOrder purchaseOrder;
+		if(salesOrder.getDropShip_BPartner_ID() > 0) {
+			purchaseOrder = createFromSOInfo(salesOrder, salesOrderLines);
+		} else {
+			purchaseOrder = createFromProductPOInfo(salesOrder, salesOrderLines);
+		}
+		//	Set Reference to PO
+		if (counter == 1 && purchaseOrder != null) {
+			salesOrder.setLink_Order_ID(purchaseOrder.getC_Order_ID());
+			salesOrder.saveEx();
+		}
+		return counter;
+	}	//	createPOFromSO
+	
+	/**
+	 * Create from Sales Order Info
+	 * @param salesOrder
+	 * @param salesOrderLines
+	 * @return Purchase Order Generated
+	 */
+	private MOrder createFromSOInfo(MOrder salesOrder, MOrderLine[] salesOrderLines) {
+		MOrder purchaseOrder = createPOForVendor(salesOrder.getDropShip_BPartner_ID(), salesOrder);
+		addLog(0, null, null, purchaseOrder.getDocumentNo());
+		counter++;
+		createLines(purchaseOrder, salesOrderLines, -1);
+		//	Generated
+		return purchaseOrder;
+	}
+	
+	/**
+	 * Create from Product PO Info
+	 * @param salesOrder
+	 * @param salesOrderLines
+	 * @return Purchase Order generated
+	 */
+	private MOrder createFromProductPOInfo(MOrder salesOrder, MOrderLine[] salesOrderLines) {
+		//	Order Lines with a Product which has a current vendor 
+		String sql = "SELECT MIN(po.C_BPartner_ID), po.M_Product_ID "
+			+ "FROM M_Product_PO po"
+			+ " INNER JOIN C_OrderLine ol ON (po.M_Product_ID=ol.M_Product_ID) "
+			+ "WHERE ol.C_Order_ID=? AND po.IsCurrentVendor='Y' "
+			+ " AND po.AD_Org_ID IN (0, ?)"
+			+ ((getVendorId() > 0) ? " AND po.C_BPartner_ID=? " : "")
+			+ "GROUP BY po.M_Product_ID "
+			+ "ORDER BY po.AD_Org_ID DESC, 1";
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		MOrder purchaseOrder = null;
+		try {
+			pstmt = DB.prepareStatement (sql, get_TrxName());
+			pstmt.setInt(1, salesOrder.getC_Order_ID());
+			if (getVendorId() != 0){
+				pstmt.setInt (2, getVendorId());
+				pstmt.setInt(3, salesOrder.getAD_Org_ID());
+			} else {
+				pstmt.setInt(2, salesOrder.getAD_Org_ID());
+			}
+
+			rs = pstmt.executeQuery ();
+			while (rs.next()) {
+				//	New Order
+				int bPartnerId = rs.getInt(1);
+				if (purchaseOrder == null 
+						|| purchaseOrder.getBill_BPartner_ID() != bPartnerId) {
+					purchaseOrder = createPOForVendor(rs.getInt(1), salesOrder);
+					addLog(0, null, null, purchaseOrder.getDocumentNo());
+					counter++;
+				}
+				//	Line
+				int productId = rs.getInt(2);
+				createLines(purchaseOrder, salesOrderLines, productId);
+			}
+ 		} catch (Exception e) {
+			log.log(Level.SEVERE, sql, e);
+		} finally {
+			DB.close(rs, pstmt);
+			rs = null; pstmt = null;
+		}
+		//	Default
+		return purchaseOrder;
+	}
+	
+	/**
+	 *	Create PO for Vendor
+	 *	@param bPartnerId vendor
+	 *	@param salesOrder sales order
+	 */
+	public MOrder createPOForVendor(int bPartnerId, MOrder salesOrder) {
+		MOrder purchaseOrder = new MOrder (getCtx(), 0, get_TrxName());
+		purchaseOrder.setClientOrg(salesOrder.getAD_Client_ID(), salesOrder.getAD_Org_ID());
+		purchaseOrder.setIsSOTrx(false);
+		purchaseOrder.setC_DocTypeTarget_ID();
+		//
+		purchaseOrder.setDescription(salesOrder.getDescription());
+		purchaseOrder.setPOReference(salesOrder.getDocumentNo());
+		purchaseOrder.setPriorityRule(salesOrder.getPriorityRule());
+		purchaseOrder.setSalesRep_ID(salesOrder.getSalesRep_ID());
+		purchaseOrder.setM_Warehouse_ID(salesOrder.getM_Warehouse_ID());
+		//	Set Vendor
+		MBPartner vendor = new MBPartner (getCtx(), bPartnerId, get_TrxName());
+		purchaseOrder.setBPartner(vendor);
+		//	Drop Ship
+		if (!Util.isEmpty(getIsDropShip())) {
+			purchaseOrder.setIsDropShip(getIsDropShip().equals("Y"));
+			if (salesOrder.isDropShip() && salesOrder.getDropShip_BPartner_ID() != 0 ){
+				purchaseOrder.setDropShip_BPartner_ID(salesOrder.getDropShip_BPartner_ID());
+				purchaseOrder.setDropShip_Location_ID(salesOrder.getDropShip_Location_ID());
+				purchaseOrder.setDropShip_User_ID(salesOrder.getDropShip_User_ID());
+			} else {
+				purchaseOrder.setDropShip_BPartner_ID(salesOrder.getC_BPartner_ID());
+				purchaseOrder.setDropShip_Location_ID(salesOrder.getC_BPartner_Location_ID());
+				purchaseOrder.setDropShip_User_ID(salesOrder.getAD_User_ID());
+			}
+			// get default drop ship warehouse
+			MOrgInfo orginfo = MOrgInfo.get(getCtx(), purchaseOrder.getAD_Org_ID(), get_TrxName());
+			if (orginfo.getDropShip_Warehouse_ID() != 0 )
+				purchaseOrder.setM_Warehouse_ID(orginfo.getDropShip_Warehouse_ID());
+			else
+				log.log(Level.SEVERE, "Must specify drop ship warehouse in org info.");
+		}
+		//	References
+		purchaseOrder.setC_Activity_ID(salesOrder.getC_Activity_ID());
+		purchaseOrder.setC_Campaign_ID(salesOrder.getC_Campaign_ID());
+		purchaseOrder.setC_Project_ID(salesOrder.getC_Project_ID());
+		purchaseOrder.setUser1_ID(salesOrder.getUser1_ID());
+		purchaseOrder.setUser2_ID(salesOrder.getUser2_ID());
+		purchaseOrder.setUser3_ID(salesOrder.getUser3_ID());
+		purchaseOrder.setUser4_ID(salesOrder.getUser4_ID());
+		//
+		purchaseOrder.saveEx();
+		return purchaseOrder;
+	}	//	createPOForVendor
+	
+	/**
+	 * Create Lines for Purchase Order
+	 * @param purchaseOrder
+	 * @param salesOrderLines
+	 * @param productId
+	 */
+	private void createLines(MOrder purchaseOrder, MOrderLine[] salesOrderLines, int productId) {
+		for (MOrderLine line : salesOrderLines) {
+			if (line.getM_Product_ID() == productId
+					|| productId < 0) {
+				MOrderLine poLine = new MOrderLine (purchaseOrder);
+				poLine.setLink_OrderLine_ID(line.getC_OrderLine_ID());
+				poLine.setM_Product_ID(line.getM_Product_ID());
+				poLine.setC_Charge_ID(line.getC_Charge_ID());
+				poLine.setM_AttributeSetInstance_ID(line.getM_AttributeSetInstance_ID());
+				poLine.setC_UOM_ID(line.getC_UOM_ID());
+				poLine.setQtyEntered(line.getQtyEntered());
+				poLine.setQtyOrdered(line.getQtyOrdered());
+				poLine.setDescription(line.getDescription());
+				poLine.setDatePromised(line.getDatePromised());
+				poLine.setPrice();
+				poLine.saveEx();
+				//	Set link to source
+				line.setLink_OrderLine_ID(poLine.getC_OrderLine_ID());
+				line.saveEx();
+			}
+		}
+	}
+	
+}	//	doIt

--- a/src/patches/org/compiere/process/ReplenishReport.java
+++ b/src/patches/org/compiere/process/ReplenishReport.java
@@ -1,0 +1,752 @@
+package org.compiere.process;
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 1999-2006 ComPiere, Inc. All Rights Reserved.                *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * ComPiere, Inc., 2620 Augustine Dr. #245, Santa Clara, CA 95054, USA        *
+ * or via info@compiere.org or http://www.compiere.org/license.html           *
+ * Contributor(s): Chris Farley - northernbrewer                              *
+ *****************************************************************************/
+
+
+import org.adempiere.core.domains.models.X_DD_Order;
+import org.adempiere.core.domains.models.X_DD_OrderLine;
+import org.adempiere.core.domains.models.X_T_Replenish;
+import org.adempiere.exceptions.AdempiereException;
+import org.compiere.model.MBPartner;
+import org.compiere.model.MBPartnerLocation;
+import org.compiere.model.MClient;
+import org.compiere.model.MDocType;
+import org.compiere.model.MMovement;
+import org.compiere.model.MMovementLine;
+import org.compiere.model.MOrder;
+import org.compiere.model.MOrderLine;
+import org.compiere.model.MOrg;
+import org.compiere.model.MProduct;
+import org.compiere.model.MRequisition;
+import org.compiere.model.MRequisitionLine;
+import org.compiere.model.MStorage;
+import org.compiere.model.MWarehouse;
+import org.compiere.model.Query;
+import org.compiere.util.AdempiereSystemError;
+import org.compiere.util.AdempiereUserError;
+import org.compiere.util.DB;
+import org.compiere.util.Env;
+import org.compiere.util.Msg;
+import org.compiere.util.ReplenishInterface;
+import org.compiere.util.Util;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Level;
+
+/**
+ *	Replenishment Report
+ *	
+ *  @author Jorg Janke
+ *  @version $Id: ReplenishReport.java,v 1.2 2006/07/30 00:51:01 jjanke Exp $
+ *  
+ *  Carlos Ruiz globalqss - integrate bug fixing from Chris Farley
+ *    [ 1619517 ] Replenish report fails when no records in m_storage
+ */
+public class ReplenishReport extends ReplenishReportAbstract {
+	/** Return Info				*/
+	private String	m_info = "";
+	
+	/**
+	 *  Prepare - e.g., get Parameters.
+	 */
+	protected void prepare() {
+		super.prepare();
+	}	//	prepare
+
+	/**
+	 *  Perform process.
+	 *  @return Message 
+	 *  @throws Exception if not successful
+	 */
+	protected String doIt() throws Exception {
+		log.info("M_Warehouse_ID=" + getWarehouseId() 
+			+ ", C_BPartner_ID=" + getBPartnerId() 
+			+ " - ReplenishmentCreate=" + getReplenishmentCreate()
+			+ ", C_DocType_ID=" + getDocTypeId());
+		if (getReplenishmentCreate() != null && getDocTypeId() == 0)
+			throw new AdempiereUserError("@FillMandatory@ @C_DocType_ID@");
+		
+		//	
+		if(!isSelection()) {
+			MWarehouse warehouse = MWarehouse.get(getCtx(), getWarehouseId());
+			if (warehouse.get_ID() == 0) {
+				throw new AdempiereSystemError("@FillMandatory@ @M_Warehouse_ID@");
+			}
+			prepareTable();
+			fillTable(warehouse);
+		}
+		//
+		if (getReplenishmentCreate() == null) {
+			return "OK";
+		}
+		//
+		MDocType documentType = MDocType.get(getCtx(), getDocTypeId());
+		if (!documentType.getDocBaseType().equals(getReplenishmentCreate())) {
+			throw new AdempiereSystemError("@C_DocType_ID@=" + documentType.getName() + " <> " + getReplenishmentCreate());
+		}
+		//
+		if (getReplenishmentCreate().equals("POO"))
+			createPO();
+		else if (getReplenishmentCreate().equals("POR"))
+			createRequisition();
+		else if (getReplenishmentCreate().equals("MMM"))
+			createMovements();
+		else if (getReplenishmentCreate().equals("DOO"))
+			createDO();
+		return m_info;
+	}	//	doIt
+	
+	/**
+	 * Get from Smart Browser Selection
+	 * @param isMandatoryBusinessPartner
+	 * @return
+	 */
+	private List<X_T_Replenish> getReplenishFromSmartBrowser(boolean isMandatoryBusinessPartner) {
+		List<X_T_Replenish> replenishList = new ArrayList<X_T_Replenish>();
+		for(Integer key : getSelectionKeys()) { 
+			BigDecimal qtyToOrdered = getSelectionAsBigDecimal(key, "SBR_QtyToOrder");
+			int bPartnerId = getSelectionAsInt(key, "SBR_C_BPartner_ID");
+			if(qtyToOrdered == null
+					|| qtyToOrdered.compareTo(Env.ZERO) <= 0) {
+				continue;
+			}
+			//	Validate Distribution Orders
+			if(isMandatoryBusinessPartner) {
+				if(bPartnerId <= 0) {
+					continue;
+				}
+			}
+			//	
+			X_T_Replenish replenish = new X_T_Replenish(getCtx(), 0, get_TrxName());
+			replenish.setAD_PInstance_ID(getAD_PInstance_ID());
+			replenish.setM_Warehouse_ID(getSelectionAsInt(key, "SBR_M_Warehouse_ID"));
+			replenish.setM_Product_ID(getSelectionAsInt(key, "SBR_M_Product_ID"));
+			replenish.setAD_Org_ID(getSelectionAsInt(key, "SBR_AD_Org_ID"));
+			replenish.setReplenishType(getSelectionAsString(key, "SBR_ReplenishType"));
+			replenish.setLevel_Min(getSelectionAsBigDecimal(key, "SBR_Level_Min"));
+			replenish.setLevel_Max(getSelectionAsBigDecimal(key, "SBR_Level_max"));
+			replenish.setC_BPartner_ID(bPartnerId);
+			replenish.setOrder_Min(getSelectionAsBigDecimal(key, "SBR_Order_Min"));
+			replenish.setOrder_Pack(getSelectionAsBigDecimal(key, "SBR_Order_Pack"));
+			replenish.setQtyToOrder(qtyToOrdered);
+			replenish.setReplenishmentCreate(getReplenishmentCreate());
+			replenish.setM_WarehouseSource_ID(getSelectionAsInt(key, "SBR_M_WarehouseSource_ID"));
+			replenish.setC_DocType_ID(getDocTypeId());
+			replenishList.add(replenish);
+		}
+		//	Default return
+		return replenishList;
+	}
+
+	/**
+	 * 	Prepare/Check Replenishment Table
+	 */
+	private void prepareTable()
+	{
+		//	Level_Max must be >= Level_Max
+		String sql = "UPDATE M_Replenish"
+			+ " SET Level_Max = Level_Min "
+			+ "WHERE Level_Max < Level_Min";
+		int no = DB.executeUpdate(sql, get_TrxName());
+		if (no != 0)
+			log.fine("Corrected Max_Level=" + no);
+		
+
+	}	//	prepareTable
+
+	/**
+	 * 	Fill Table
+	 * 	@param wh warehouse
+	 */
+	private void fillTable (MWarehouse wh) throws Exception
+	{
+		String sql = "INSERT INTO T_Replenish "
+			+ "(AD_PInstance_ID, M_Warehouse_ID, M_Product_ID, AD_Client_ID, AD_Org_ID,"
+			+ " ReplenishType, Level_Min, Level_Max,"
+			+ " C_BPartner_ID, Order_Min, Order_Pack, QtyToOrder, ReplenishmentCreate) "
+			+ "SELECT " + getAD_PInstance_ID() 
+				+ ", r.M_Warehouse_ID, r.M_Product_ID, r.AD_Client_ID, r.AD_Org_ID,"
+			+ " r.ReplenishType, r.Level_Min, r.Level_Max,"
+			+ " po.C_BPartner_ID, po.Order_Min, po.Order_Pack, 0, ";
+		if (getReplenishmentCreate() == null)
+			sql += "null";
+		else
+			sql += "'" + getReplenishmentCreate() + "'";
+		sql += " FROM M_Replenish r"
+				+ " INNER JOIN M_Warehouse w ON (r.M_Warehouse_ID = w.M_Warehouse_ID)"
+				+ " LEFT JOIN LATERAL ("
+				+ "     SELECT po.C_BPartner_ID, po.Order_Min, po.Order_Pack "
+				+ "     FROM M_Product_PO po "
+				+ "     WHERE po.M_Product_ID= r.M_Product_ID "
+				+ "       AND po.IsCurrentVendor='Y'"
+				+ "       AND po.IsActive = 'Y' "
+				+ "       AND po.AD_Org_ID IN (0, w.AD_Org_ID) "
+				+ "     ORDER BY po.AD_Org_ID DESC "
+				+ "     LIMIT 1"
+				+ " ) po ON true "
+				+ "WHERE r.ReplenishType<>'0'"
+				+ " AND r.IsActive='Y'"
+				+ " AND r.M_Warehouse_ID=" + getWarehouseId()
+				+ " AND po.M_Product_ID IS NOT NULL";
+		if (getBPartnerId() != 0)
+			sql += " AND po.C_BPartner_ID=" + getBPartnerId();
+		int no = DB.executeUpdate(sql, get_TrxName());
+		log.finest(sql);
+		log.fine("Insert (1) #" + no);
+		
+		if (getBPartnerId() == 0)
+		{
+			sql = "INSERT INTO T_Replenish "
+				+ "(AD_PInstance_ID, M_Warehouse_ID, M_Product_ID, AD_Client_ID, AD_Org_ID,"
+				+ " ReplenishType, Level_Min, Level_Max,"
+				+ " C_BPartner_ID, Order_Min, Order_Pack, QtyToOrder, ReplenishmentCreate) "
+				+ "SELECT " + getAD_PInstance_ID()
+				+ ", r.M_Warehouse_ID, r.M_Product_ID, r.AD_Client_ID, r.AD_Org_ID,"
+				+ " r.ReplenishType, r.Level_Min, r.Level_Max,"
+			    + " 0, 1, 1, 0, ";
+			if (getReplenishmentCreate() == null)
+				sql += "null";
+			else
+				sql += "'" + getReplenishmentCreate() + "'";
+			sql	+= " FROM M_Replenish r "
+				+ "WHERE r.ReplenishType<>'0' AND r.IsActive='Y'"
+				+ " AND r.M_Warehouse_ID=" + getWarehouseId()
+				+ " AND NOT EXISTS (SELECT * FROM T_Replenish t "
+					+ "WHERE r.M_Product_ID=t.M_Product_ID"
+					+ " AND AD_PInstance_ID=" + getAD_PInstance_ID() + ")";
+			no = DB.executeUpdate(sql, get_TrxName());
+			log.fine("Insert (BP) #" + no);
+		}
+		
+		sql = "UPDATE T_Replenish t SET "
+			+ "QtyOnHand = (SELECT COALESCE(SUM(QtyOnHand),0) FROM M_Storage s, M_Locator l WHERE t.M_Product_ID=s.M_Product_ID"
+				+ " AND l.M_Locator_ID=s.M_Locator_ID AND l.M_Warehouse_ID=t.M_Warehouse_ID),"
+			+ "QtyReserved = (SELECT COALESCE(SUM(QtyReserved),0) FROM M_Storage s, M_Locator l WHERE t.M_Product_ID=s.M_Product_ID"
+				+ " AND l.M_Locator_ID=s.M_Locator_ID AND l.M_Warehouse_ID=t.M_Warehouse_ID),"
+			+ "QtyOrdered = (SELECT COALESCE(SUM(QtyOrdered),0) FROM M_Storage s, M_Locator l WHERE t.M_Product_ID=s.M_Product_ID"
+				+ " AND l.M_Locator_ID=s.M_Locator_ID AND l.M_Warehouse_ID=t.M_Warehouse_ID)";
+		if (getDocTypeId() != 0)
+			sql += ", C_DocType_ID=" + getDocTypeId();
+		sql += " WHERE AD_PInstance_ID=" + getAD_PInstance_ID();
+		no = DB.executeUpdate(sql, get_TrxName());
+		if (no != 0)
+			log.fine("Update #" + no);
+
+		//	Delete inactive products and replenishments
+		sql = "DELETE T_Replenish r "
+			+ "WHERE (EXISTS (SELECT * FROM M_Product p "
+				+ "WHERE p.M_Product_ID=r.M_Product_ID AND p.IsActive='N')"
+			+ " OR EXISTS (SELECT * FROM M_Replenish rr "
+				+ " WHERE rr.M_Product_ID=r.M_Product_ID AND rr.IsActive='N'"
+				+ " AND rr.M_Warehouse_ID=" + getWarehouseId() + " ))"
+			+ " AND AD_PInstance_ID=" + getAD_PInstance_ID();
+		no = DB.executeUpdate(sql, get_TrxName());
+		if (no != 0)
+			log.fine("Delete Inactive=" + no);
+	 
+		//	Ensure Data consistency
+		sql = "UPDATE T_Replenish SET QtyOnHand = 0 WHERE QtyOnHand IS NULL";
+		no = DB.executeUpdate(sql, get_TrxName());
+		sql = "UPDATE T_Replenish SET QtyReserved = 0 WHERE QtyReserved IS NULL";
+		no = DB.executeUpdate(sql, get_TrxName());
+		sql = "UPDATE T_Replenish SET QtyOrdered = 0 WHERE QtyOrdered IS NULL";
+		no = DB.executeUpdate(sql, get_TrxName());
+
+		//	Set Minimum / Maximum Maintain Level
+		//	X_M_Replenish.REPLENISHTYPE_ReorderBelowMinimumLevel
+		sql = "UPDATE T_Replenish"
+			+ " SET QtyToOrder = CASE WHEN QtyOnHand - QtyReserved + QtyOrdered <= Level_Min "
+			+ " THEN Level_Max - QtyOnHand + QtyReserved - QtyOrdered "
+			+ " ELSE 0 END "
+			+ "WHERE ReplenishType='1'" 
+			+ " AND AD_PInstance_ID=" + getAD_PInstance_ID();
+		no = DB.executeUpdate(sql, get_TrxName());
+		if (no != 0)
+			log.fine("Update Type-1=" + no);
+		//
+		//	X_M_Replenish.REPLENISHTYPE_MaintainMaximumLevel
+		sql = "UPDATE T_Replenish"
+			+ " SET QtyToOrder = Level_Max - QtyOnHand + QtyReserved - QtyOrdered "
+			+ "WHERE ReplenishType='2'" 
+			+ " AND AD_PInstance_ID=" + getAD_PInstance_ID();
+		no = DB.executeUpdate(sql, get_TrxName());
+		if (no != 0)
+			log.fine("Update Type-2=" + no);
+	
+
+		//	Minimum Order Quantity
+		sql = "UPDATE T_Replenish"
+			+ " SET QtyToOrder = Order_Min "
+			+ "WHERE QtyToOrder < Order_Min"
+			+ " AND QtyToOrder > 0" 
+			+ " AND AD_PInstance_ID=" + getAD_PInstance_ID();
+		no = DB.executeUpdate(sql, get_TrxName());
+		if (no != 0)
+			log.fine("Set MinOrderQty=" + no);
+
+		//	Even dividable by Pack
+		sql = "UPDATE T_Replenish"
+			+ " SET QtyToOrder = QtyToOrder - MOD(QtyToOrder, Order_Pack) + Order_Pack "
+			+ "WHERE MOD(QtyToOrder, Order_Pack) <> 0"
+			+ " AND QtyToOrder > 0"
+			+ " AND AD_PInstance_ID=" + getAD_PInstance_ID();
+		no = DB.executeUpdate(sql, get_TrxName());
+		if (no != 0)
+			log.fine("Set OrderPackQty=" + no);
+		
+		//	Source from other warehouse
+		if (wh.getM_WarehouseSource_ID() != 0)
+		{
+			sql = "UPDATE T_Replenish"
+				+ " SET M_WarehouseSource_ID=" + wh.getM_WarehouseSource_ID() 
+				+ " WHERE AD_PInstance_ID=" + getAD_PInstance_ID();
+			no = DB.executeUpdate(sql, get_TrxName());
+			if (no != 0)
+				log.fine("Set Source Warehouse=" + no);
+		}
+		//	Check Source Warehouse
+		sql = "UPDATE T_Replenish"
+			+ " SET M_WarehouseSource_ID = NULL " 
+			+ "WHERE M_Warehouse_ID=M_WarehouseSource_ID"
+			+ " AND AD_PInstance_ID=" + getAD_PInstance_ID();
+		no = DB.executeUpdate(sql, get_TrxName());
+		if (no != 0)
+			log.fine("Set same Source Warehouse=" + no);
+		
+		//	Custom Replenishment
+		String className = wh.getReplenishmentClass();
+		if (className != null && className.length() > 0)
+		{	
+			//	Get Replenishment Class
+			ReplenishInterface custom = null;
+			try
+			{
+				Class<?> clazz = Class.forName(className);
+				custom = (ReplenishInterface)clazz.newInstance();
+			}
+			catch (Exception e)
+			{
+				throw new AdempiereUserError("No custom Replenishment class "
+						+ className + " - " + e.toString());
+			}
+
+			List<X_T_Replenish> replenishList = getReplenish("ReplenishType='9'", false);
+			for (X_T_Replenish replenish : replenishList) {
+				if (replenish.getReplenishType().equals(X_T_Replenish.REPLENISHTYPE_Custom))
+				{
+					BigDecimal qto = null;
+					try
+					{
+						qto = custom.getQtyToOrder(wh, replenish);
+					}
+					catch (Exception e)
+					{
+						log.log(Level.SEVERE, custom.toString(), e);
+					}
+					if (qto == null)
+						qto = Env.ZERO;
+					replenish.setQtyToOrder(qto);
+					replenish.saveEx();
+				}
+			}
+		}
+		//	Delete rows where nothing to order
+		sql = "DELETE T_Replenish "
+			+ "WHERE QtyToOrder < 1"
+		    + " AND AD_PInstance_ID=" + getAD_PInstance_ID();
+		no = DB.executeUpdate(sql, get_TrxName());
+		if (no != 0)
+			log.fine("Delete No QtyToOrder=" + no);
+	}	//	fillTable
+
+	/**
+	 * 	Create PO's
+	 */
+	private void createPO()
+	{
+		int noOrders = 0;
+		String info = "";
+		//
+		MOrder order = null;
+		MWarehouse warehouse = null;
+		List<X_T_Replenish> replenishList = getReplenish("M_WarehouseSource_ID IS NULL", true);
+		for (X_T_Replenish replenish : replenishList) {
+			if (warehouse == null || warehouse.getM_Warehouse_ID() != replenish.getM_Warehouse_ID())
+				warehouse = MWarehouse.get(getCtx(), replenish.getM_Warehouse_ID());
+			//
+			if (order == null 
+				|| order.getC_BPartner_ID() != replenish.getC_BPartner_ID()
+				|| order.getM_Warehouse_ID() != replenish.getM_Warehouse_ID())
+			{
+				order = new MOrder(getCtx(), 0, get_TrxName());
+				order.setIsSOTrx(false);
+				order.setC_DocTypeTarget_ID(getDocTypeId());
+				MBPartner businessPartner = new MBPartner(getCtx(), replenish.getC_BPartner_ID(), get_TrxName());
+				order.setBPartner(businessPartner);
+				order.setSalesRep_ID(getAD_User_ID());
+				order.setDescription(Msg.getMsg(getCtx(), "Replenishment"));
+				//	Set Org/WH
+				order.setAD_Org_ID(warehouse.getAD_Org_ID());
+				order.setM_Warehouse_ID(warehouse.getM_Warehouse_ID());
+				order.saveEx();
+				log.fine(order.toString());
+				noOrders++;
+				info += " - " + order.getDocumentNo();
+			}
+			MOrderLine line = new MOrderLine (order);
+			line.setM_Product_ID(replenish.getM_Product_ID());
+			line.setQty(replenish.getQtyToOrder());
+			line.setPrice();
+			line.saveEx();
+		}
+		m_info = "#" + noOrders + info;
+		log.info(m_info);
+	}	//	createPO
+	
+	/**
+	 * 	Create Requisition
+	 */
+	private void createRequisition()
+	{
+		int noReqs = 0;
+		String info = "";
+		//
+		MRequisition requisition = null;
+		MWarehouse warehouse = null;
+		List<X_T_Replenish> replenishList = getReplenish("M_WarehouseSource_ID IS NULL", false);
+		for (X_T_Replenish replenish : replenishList) {
+			if (warehouse == null || warehouse.getM_Warehouse_ID() != replenish.getM_Warehouse_ID())
+				warehouse = MWarehouse.get(getCtx(), replenish.getM_Warehouse_ID());
+			//
+			if (requisition == null
+				|| requisition.getM_Warehouse_ID() != replenish.getM_Warehouse_ID())
+			{
+				requisition = new MRequisition (getCtx(), 0, get_TrxName());
+				requisition.setAD_User_ID (getAD_User_ID());
+				requisition.setC_DocType_ID(getDocTypeId());
+				requisition.setDescription(Msg.getMsg(getCtx(), "Replenishment"));
+				//	Set Org/WH
+				requisition.setAD_Org_ID(warehouse.getAD_Org_ID());
+				requisition.setM_Warehouse_ID(warehouse.getM_Warehouse_ID());
+				requisition.saveEx();
+				log.fine(requisition.toString());
+				noReqs++;
+				info += " - " + requisition.getDocumentNo();
+			}
+			//
+			MRequisitionLine line = new MRequisitionLine(requisition);
+			line.setM_Product_ID(replenish.getM_Product_ID());
+			line.setC_BPartner_ID(replenish.getC_BPartner_ID());
+			line.setQty(replenish.getQtyToOrder());
+			line.setPrice();
+			line.saveEx();
+		}
+		m_info = "#" + noReqs + info;
+		log.info(m_info);
+	}	//	createRequisition
+
+	/**
+	 * 	Create Inventory Movements
+	 */
+	private void createMovements()
+	{
+		int noMoves = 0;
+		String info = "";
+		//
+		MClient client = null;
+		MMovement move = null;
+		int M_Warehouse_ID = 0;
+		int M_WarehouseSource_ID = 0;
+		MWarehouse whSource = null;
+		MWarehouse wh = null;
+		List<X_T_Replenish> replenishList = getReplenish("M_WarehouseSource_ID IS NOT NULL", false);
+		for (X_T_Replenish replenish : replenishList){
+			if (whSource == null || whSource.getM_WarehouseSource_ID() != replenish.getM_WarehouseSource_ID())
+				whSource = MWarehouse.get(getCtx(), replenish.getM_WarehouseSource_ID());
+			if (wh == null || wh.getM_Warehouse_ID() != replenish.getM_Warehouse_ID())
+				wh = MWarehouse.get(getCtx(), replenish.getM_Warehouse_ID());
+			if (client == null || client.getAD_Client_ID() != whSource.getAD_Client_ID())
+				client = MClient.get(getCtx(), whSource.getAD_Client_ID());
+			//
+			if (move == null
+				|| M_WarehouseSource_ID != replenish.getM_WarehouseSource_ID()
+				|| M_Warehouse_ID != replenish.getM_Warehouse_ID())
+			{
+				M_WarehouseSource_ID = replenish.getM_WarehouseSource_ID();
+				M_Warehouse_ID = replenish.getM_Warehouse_ID();
+				
+				move = new MMovement (getCtx(), 0, get_TrxName());
+				move.setC_DocType_ID(getDocTypeId());
+				move.setDescription(Msg.getMsg(getCtx(), "Replenishment")
+					+ ": " + whSource.getName() + "->" + wh.getName());
+				//	Set Org
+				move.setAD_Org_ID(whSource.getAD_Org_ID());
+				move.saveEx();
+				log.fine(move.toString());
+				noMoves++;
+				info += " - " + move.getDocumentNo();
+			}
+			//	To
+			int M_LocatorTo_ID = wh.getDefaultLocator().getM_Locator_ID();
+			//	From: Look-up Storage
+			MProduct product = MProduct.get(getCtx(), replenish.getM_Product_ID());
+			String MMPolicy = product.getMMPolicy();
+			MStorage[] storages = MStorage.getWarehouse(getCtx(), whSource.getM_Warehouse_ID(), replenish.getM_Product_ID(), 
+					0, null, MClient.MMPOLICY_FiFo.equals(MMPolicy), false, 0, get_TrxName());
+			//
+			BigDecimal target = replenish.getQtyToOrder();
+			for (int j = 0; j < storages.length; j++)
+			{
+				MStorage storage = storages[j];
+				if (storage.getQtyOnHand().signum() <= 0)
+					continue;
+				BigDecimal moveQty = target;
+				if (storage.getQtyOnHand().compareTo(moveQty) < 0)
+					moveQty = storage.getQtyOnHand();
+				//
+				MMovementLine line = new MMovementLine(move);
+				line.setM_Product_ID(replenish.getM_Product_ID());
+				line.setMovementQty(moveQty);
+				if (replenish.getQtyToOrder().compareTo(moveQty) != 0)
+					line.setDescription("Total: " + replenish.getQtyToOrder());
+				line.setM_Locator_ID(storage.getM_Locator_ID());		//	from
+				line.setM_AttributeSetInstance_ID(storage.getM_AttributeSetInstance_ID());
+				line.setM_LocatorTo_ID(M_LocatorTo_ID);					//	to
+				line.setM_AttributeSetInstanceTo_ID(storage.getM_AttributeSetInstance_ID());
+				line.saveEx();
+				//
+				target = target.subtract(moveQty);
+				if (target.signum() == 0)
+					break;
+			}
+		}
+		if (replenishList.size() == 0)
+		{
+			m_info = "@M_WarehouseSource_ID@ @NotFound@";
+			log.warning(m_info);
+		}
+		else
+		{
+			m_info = "#" + noMoves + info;
+			log.info(m_info);
+		}
+	}	//	Create Inventory Movements
+	
+	/**
+	 * 	Create Distribution Order
+	 */
+	private void createDO() throws Exception
+	{
+		int noMoves = 0;
+		String info = "";
+		//
+		MClient client = null;
+		X_DD_Order order = null;
+		int M_Warehouse_ID = 0;
+		int M_WarehouseSource_ID = 0;
+		MWarehouse whSource = null;
+		MWarehouse wh = null;
+		List<X_T_Replenish> replenishList = getReplenish("M_WarehouseSource_ID IS NOT NULL", false);
+		for (X_T_Replenish replenish : replenishList) {
+			if (whSource == null || whSource.getM_WarehouseSource_ID() != replenish.getM_WarehouseSource_ID())
+				whSource = MWarehouse.get(getCtx(), replenish.getM_WarehouseSource_ID());
+			if (wh == null || wh.getM_Warehouse_ID() != replenish.getM_Warehouse_ID())
+				wh = MWarehouse.get(getCtx(), replenish.getM_Warehouse_ID());
+			if (client == null || client.getAD_Client_ID() != whSource.getAD_Client_ID())
+				client = MClient.get(getCtx(), whSource.getAD_Client_ID());
+			//
+			if (order == null
+				|| M_WarehouseSource_ID != replenish.getM_WarehouseSource_ID()
+				|| M_Warehouse_ID != replenish.getM_Warehouse_ID())
+			{
+				M_WarehouseSource_ID = replenish.getM_WarehouseSource_ID();
+				M_Warehouse_ID = replenish.getM_Warehouse_ID();
+				
+				order = new X_DD_Order(getCtx(), 0, get_TrxName());
+				order.setC_DocType_ID(getDocTypeId());
+				order.setDescription(Msg.getMsg(getCtx(), "Replenishment")
+					+ ": " + whSource.getName() + "->" + wh.getName());
+				//	Set Org
+				order.setAD_Org_ID(whSource.getAD_Org_ID());
+				// Set Org Trx
+				MOrg orgTrx = MOrg.get(getCtx(), wh.getAD_Org_ID());
+				order.setAD_OrgTrx_ID(orgTrx.getAD_Org_ID());
+				int bPartnerId = orgTrx.getLinkedC_BPartner_ID(get_TrxName()); 
+				if (bPartnerId == 0)
+					throw new AdempiereUserError("@C_BPartner_ID@ @AD_Org_ID@ @FillMandatory@ ");
+				MBPartner bp = new MBPartner(getCtx(),bPartnerId,get_TrxName());
+				// Set BPartner Link to Org
+				setBusinessPartner(order, bp);
+				order.setDateOrdered(new Timestamp(System.currentTimeMillis()));
+				order.setDeliveryRule(MOrder.DELIVERYRULE_Availability);
+				order.setDeliveryViaRule(MOrder.DELIVERYVIARULE_Delivery);
+				order.setPriorityRule(MOrder.PRIORITYRULE_Medium);
+				order.setIsInDispute(false);
+				order.setIsApproved(false);
+				order.setIsDropShip(false);
+				order.setIsDelivered(false);
+				order.setIsInTransit(false);
+				order.setIsPrinted(false);
+				order.setIsSelected(false);
+				order.setIsSOTrx(false);
+				// Warehouse in Transit
+				MWarehouse[] whsInTransit  = MWarehouse.getForOrg(getCtx(), whSource.getAD_Org_ID());
+				for (MWarehouse whInTransit:whsInTransit)
+				{
+					if(whInTransit.isInTransit())	
+					order.setM_Warehouse_ID(whInTransit.getM_Warehouse_ID());
+				}
+				if (order.get_ValueAsInt("M_Warehouse_ID")==0)
+					throw new AdempiereUserError("@M_Warehouse_ID@ @InTransit@ @FillMandatory@ ");
+				
+				order.saveEx();
+				log.fine(order.toString());
+				noMoves++;
+				info += " - " + order.get_ValueAsString("DocumentNo");
+			}
+		
+			//	To
+			int M_LocatorTo_ID = wh.getDefaultLocator().getM_Locator_ID();
+			int M_Locator_ID = whSource.getDefaultLocator().getM_Locator_ID();
+			if(M_LocatorTo_ID == 0 || M_Locator_ID==0)
+			throw new AdempiereUserError(Msg.translate(getCtx(), "M_Locator_ID")+" @FillMandatory@ ");
+			//	
+			X_DD_OrderLine line = getDistributionOrderLineInstanceFromParent(order);
+			line.setM_Product_ID(replenish.getM_Product_ID());
+			line.setQtyEntered(replenish.getQtyToOrder());
+			line.setQtyOrdered(replenish.getQtyToOrder());
+			if (replenish.getQtyToOrder().compareTo(replenish.getQtyToOrder()) != 0) {
+				line.setDescription("Total: " + replenish.getQtyToOrder());
+			}
+			line.setM_Locator_ID(M_Locator_ID);		//	from
+			line.setM_AttributeSetInstance_ID(0);
+			line.setM_LocatorTo_ID(M_LocatorTo_ID);					//	to
+			line.setM_AttributeSetInstanceTo_ID(0);
+			line.setIsInvoiced(false);
+			line.saveEx();
+			
+		}
+		if (replenishList.size() == 0) {
+			m_info = "No Source Warehouse";
+			log.warning(m_info);
+		}
+		else
+		{
+			m_info = "#" + noMoves + info;
+			log.info(m_info);
+		}
+	}	//	create Distribution Order
+
+	/**
+	 * Set Business Partner Reference
+	 * @param referenceToSet
+	 * @param bp
+	 */
+	private void setBusinessPartner(X_DD_Order referenceToSet, MBPartner bp) {
+		if (bp == null)
+			return;
+
+		referenceToSet.setC_BPartner_ID(bp.getC_BPartner_ID());
+		//	Defaults Payment Term
+		int ii = 0;
+		if (referenceToSet.isSOTrx())
+			ii = bp.getC_PaymentTerm_ID();
+		else
+			ii = bp.getPO_PaymentTerm_ID();
+		
+		//	Default Price List
+		if (referenceToSet.isSOTrx())
+			ii = bp.getM_PriceList_ID();
+		else
+			ii = bp.getPO_PriceList_ID();
+		//	Default Delivery/Via Rule
+		String ss = bp.getDeliveryRule();
+		if (ss != null)
+			referenceToSet.setDeliveryRule(ss);
+		ss = bp.getDeliveryViaRule();
+		if (ss != null)
+			referenceToSet.setDeliveryViaRule(ss);
+		//	Default Invoice/Payment Rule
+		ss = bp.getInvoiceRule();
+
+		if (referenceToSet.getSalesRep_ID() == 0)
+		{
+			ii = Env.getAD_User_ID(referenceToSet.getCtx());
+			if (ii != 0)
+				referenceToSet.setSalesRep_ID(ii);
+		}
+
+		List<MBPartnerLocation> partnerLocations = Arrays.asList(bp.getLocations(false));
+		// search the Ship To Location
+		MBPartnerLocation partnerLocation = partnerLocations.stream() 			// create steam
+				.filter( pl -> pl.isShipTo()).reduce((first , last ) -> last) 	// get of last Ship to location
+				.orElseGet(() -> partnerLocations.stream() 								// if not exist Ship to location else get first partner location
+							.findFirst()										// if not exist partner location then throw an exception
+							.orElseThrow(() -> new AdempiereException("@IsShipTo@ @NotFound@"))
+				);
+
+		referenceToSet.setC_BPartner_Location_ID(partnerLocation.getC_BPartner_Location_ID());
+		//	
+		Arrays.asList(bp.getContacts(false))
+				.stream()
+				.findFirst()
+				.ifPresent(user -> referenceToSet.setAD_User_ID(user.getAD_User_ID()));
+	}
+	
+	/**
+	 * Get Instance of Distribution Order Line from Distribution Order
+	 * @param distributionOrder
+	 * @return
+	 */
+	private X_DD_OrderLine getDistributionOrderLineInstanceFromParent(X_DD_Order distributionOrder) {
+		X_DD_OrderLine distributionOrderLine = new X_DD_OrderLine(distributionOrder.getCtx(), 0, distributionOrder.get_TrxName());
+		distributionOrderLine.setDD_Order_ID(distributionOrder.get_ID());
+		distributionOrderLine.setAD_Org_ID(distributionOrder.getAD_Org_ID());
+		distributionOrderLine.setDateOrdered(distributionOrder.getDateOrdered());
+		distributionOrderLine.setDatePromised(distributionOrder.getDatePromised());
+		return distributionOrderLine;
+	}
+	
+	/**
+	 * 	Get Replenish Records
+	 *	@return replenish
+	 */
+	private List<X_T_Replenish> getReplenish(String where, boolean isMandatoryBusinessPartner) {
+		if(isSelection()) {
+			return getReplenishFromSmartBrowser(isMandatoryBusinessPartner);
+		}
+		//	For Standard Process
+		StringBuilder localWhere = new StringBuilder("AD_PInstance_ID=?");
+		if(isMandatoryBusinessPartner) {
+			localWhere.append(" AND ").append(" C_BPartner_ID > 0");
+		}
+		if (!Util.isEmpty(where)) {
+			localWhere.append(" AND ").append(where);
+		}
+		//	
+		List<X_T_Replenish> list = new Query(getCtx(), X_T_Replenish.Table_Name, localWhere.toString(), get_TrxName())
+			.setParameters(getAD_PInstance_ID())
+			.setOrderBy("M_Warehouse_ID, M_WarehouseSource_ID, C_BPartner_ID")
+			.list();
+		return list;
+	}	//	getReplenish
+}	//	Replenish

--- a/src/patches/org/compiere/process/RequisitionPOCreate.java
+++ b/src/patches/org/compiere/process/RequisitionPOCreate.java
@@ -1,0 +1,457 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 1999-2006 ComPiere, Inc. All Rights Reserved.                *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * ComPiere, Inc., 2620 Augustine Dr. #245, Santa Clara, CA 95054, USA        *
+ * or via info@compiere.org or http://www.compiere.org/license.html           *
+ *****************************************************************************/
+package org.compiere.process;
+
+import org.adempiere.exceptions.NoVendorForProductException;
+import org.apache.commons.collections4.keyvalue.MultiKey;
+import org.compiere.model.MBPartner;
+import org.compiere.model.MCharge;
+import org.compiere.model.MOrder;
+import org.compiere.model.MOrderLine;
+import org.compiere.model.MProduct;
+import org.compiere.model.MProductPO;
+import org.compiere.model.MRequisition;
+import org.compiere.model.MRequisitionLine;
+import org.compiere.model.POResultSet;
+import org.compiere.model.Query;
+import org.compiere.util.AdempiereUserError;
+import org.compiere.util.DB;
+import org.compiere.util.Msg;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * 	Create PO from Requisition 
+ *	
+ *	
+ *  @author Jorg Janke
+ *  @version $Id: RequisitionPOCreate.java,v 1.2 2006/07/30 00:51:01 jjanke Exp $
+ *  
+ *  @author Teo Sarca, www.arhipac.ro
+ *  		<li>BF [ 2609760 ] RequisitionPOCreate not using DateRequired
+ *  		<li>BF [ 2605888 ] CreatePOfromRequisition creates more PO than needed
+ *  		<li>BF [ 2811718 ] Create PO from Requsition without any parameter teminate in NPE
+ *  			http://sourceforge.net/tracker/?func=detail&atid=879332&aid=2811718&group_id=176962
+ *  		<li>FR [ 2844074  ] Requisition PO Create - more selection fields
+ *  			https://sourceforge.net/tracker/?func=detail&aid=2844074&group_id=176962&atid=879335
+ *  @author victor.perez@e-evolution.com, e-Evolution.SC
+ *  		<li> #1894 Converting a requisition to purchase order through a Smart Browser
+ *  		<li> https://github.com/adempiere/adempiere/issues/1894
+ */
+public class RequisitionPOCreate extends RequisitionPOCreateAbstract
+{
+	/** Order				*/
+	private MOrder purchaseOrder = null;
+	/** Order Line			*/
+	private MOrderLine purcaseOrderLine = null;
+	/** Orders Cache : (C_BPartner_ID, DateRequired, M_PriceList_ID) -> MOrder */
+	private HashMap<MultiKey, MOrder> purchaseOrdersCache = new HashMap<MultiKey, MOrder>();
+	
+	/**
+	 *  Prepare - e.g., get Parameters.
+	 */
+	protected void prepare()
+	{
+		super.prepare();
+	}	//	prepare
+	
+	/**
+	 * 	Process
+	 *	@return info
+	 *	@throws Exception
+	 */
+	protected String doIt() throws Exception
+	{
+		// Processing Requisition Lines from Smart Browser M_Requisition_Create_PO_From_Requisition
+		if (getSelectionKeys()!=null && getSelectionKeys().size() > 0) {
+			for ( int requisitionLineId : getSelectionKeys()) {
+				MRequisitionLine requisitionLine = new MRequisitionLine(getCtx(), requisitionLineId, get_TrxName());
+					process(requisitionLine);
+			}
+			//Close Orders
+			closeOrder();
+			return "";
+		}
+
+		//	Specific
+		if (getRequisitionId() != 0)
+		{
+			log.info("M_Requisition_ID=" + getRequisitionId());
+			MRequisition requisition = new MRequisition(getCtx(), getRequisitionId(), get_TrxName());
+			if (!MRequisition.DOCSTATUS_Completed.equals(requisition.getDocStatus()))
+			{
+				throw new AdempiereUserError("@DocStatus@ = " + requisition.getDocStatus());
+			}
+			MRequisitionLine[] requisitionLines = requisition.getLines();
+			for (int i = 0; i < requisitionLines.length; i++)
+			{
+				if (requisitionLines[i].getC_OrderLine_ID() == 0)
+				{
+					process (requisitionLines[i]);
+				}
+			}
+			closeOrder();
+			return "";
+		}	//	single Requisition
+		
+		//	
+		log.info("AD_Org_ID=" + getOrgId()
+			+ ", M_Warehouse_ID=" + getWarehouseId()
+			+ ", DateDoc=" + getDateDoc() + "/" + getDateDocTo()
+			+ ", DateRequired=" + getDateRequired()+ "/" + getDateRequiredTo()
+			+ ", PriorityRule=" + getPriorityRule()
+			+ ", AD_User_ID=" + getUserId()
+			+ ", M_Product_ID=" + getProductId()
+			+ ", ConsolidateDocument" + isConsolidateDocument());
+		
+		ArrayList<Object> params = new ArrayList<Object>();
+		StringBuffer whereClause = new StringBuffer("C_OrderLine_ID IS NULL");
+		if (getOrgId() > 0)
+		{
+			whereClause.append(" AND AD_Org_ID=?");
+			params.add(getOrgId());
+		}
+		if (getProductId() > 0)
+		{
+			whereClause.append(" AND M_Product_ID=?");
+			params.add(getProductId());
+		}
+		else if (getProductCategoryId() > 0)
+		{
+			whereClause.append(" AND EXISTS (SELECT 1 FROM M_Product p WHERE M_RequisitionLine.M_Product_ID=p.M_Product_ID")
+				.append(" AND p.M_Product_Category_ID=?)");
+			params.add(getProductCategoryId());
+		}
+		
+		if (getBPGroupId() > 0)
+		{
+			whereClause.append(" AND (")
+			.append("M_RequisitionLine.C_BPartner_ID IS NULL")
+			.append(" OR EXISTS (SELECT 1 FROM C_BPartner bp WHERE M_RequisitionLine.C_BPartner_ID=bp.C_BPartner_ID AND bp.C_BP_Group_ID=?)")
+			.append(")");
+			params.add(getBPGroupId());
+		}
+		
+		//
+		//	Requisition Header
+		whereClause.append(" AND EXISTS (SELECT 1 FROM M_Requisition r WHERE M_RequisitionLine.M_Requisition_ID=r.M_Requisition_ID")
+			.append(" AND r.DocStatus=?");
+		params.add(MRequisition.DOCSTATUS_Completed);
+		if (getWarehouseId() > 0)
+		{
+			whereClause.append(" AND r.M_Warehouse_ID=?");
+			params.add(getWarehouseId());
+		}
+		if (getDateDoc() != null)
+		{
+			whereClause.append(" AND r.DateDoc >= ?");
+			params.add(getDateDoc());
+		}
+		if (getDateDocTo()!= null)
+		{
+			whereClause.append(" AND r.DateDoc <= ?");
+			params.add(getDateDocTo());
+		}
+		if (getDateRequired() != null)
+		{
+			whereClause.append(" AND r.DateRequired >= ?");
+			params.add(getDateRequired());
+		}
+		if (getDateRequiredTo() != null)
+		{
+			whereClause.append(" AND r.DateRequired <= ?");
+			params.add(getDateRequiredTo());
+		}
+		if (getPriorityRule() != null)
+		{
+			whereClause.append(" AND r.PriorityRule >= ?");
+			params.add(getPriorityRule());
+		}
+		if (getUserId() > 0)
+		{
+			whereClause.append(" AND r.AD_User_ID=?");
+			params.add(getUserId());
+		}
+		whereClause.append(")"); // End Requisition Header
+		//
+		// ORDER BY clause
+		StringBuffer orderClause = new StringBuffer();
+		if (!isConsolidateDocument())
+		{
+			orderClause.append("M_Requisition_ID, ");
+		}
+		orderClause.append("(SELECT DateRequired FROM M_Requisition r WHERE M_RequisitionLine.M_Requisition_ID=r.M_Requisition_ID),");
+		orderClause.append("M_Product_ID, C_Charge_ID, M_AttributeSetInstance_ID");
+		
+		POResultSet<MRequisitionLine> rs = new Query(getCtx(), MRequisitionLine.Table_Name, whereClause.toString(), get_TrxName())
+											.setParameters(params)
+											.setOrderBy(orderClause.toString())
+											.setClient_ID()
+											.scroll();
+		try
+		{
+			while (rs.hasNext())
+			{
+				process(rs.next());
+			}
+		}
+		finally
+		{
+			DB.close(rs); rs = null;
+		}
+		closeOrder();
+		return "";
+	}	//	doit
+	
+	private int requisitionId = 0;
+	private int productId = 0;
+	private int attributeSetInstanceId = 0;
+	/** BPartner				*/
+	private MBPartner businessPartner = null;
+	
+	/**
+	 * 	Process Line
+	 *	@param requisitionLine request line
+	 * 	@throws Exception
+	 */
+	private void process (MRequisitionLine requisitionLine) throws Exception
+	{
+		if (requisitionLine.getM_Product_ID() == 0 && requisitionLine.getC_Charge_ID() == 0)
+		{
+			log.warning("Ignored Line" + requisitionLine.getLine()
+				+ " " + requisitionLine.getDescription()
+				+ " - " + requisitionLine.getLineNetAmt());
+			return;
+		}
+		
+		if (!isConsolidateDocument() && requisitionLine.getM_Requisition_ID() != requisitionId)
+		{
+			closeOrder();
+		}
+		if (purcaseOrderLine == null
+			|| requisitionLine.getM_Product_ID() != productId
+			|| requisitionLine.getM_AttributeSetInstance_ID() != attributeSetInstanceId
+			|| requisitionLine.getC_Charge_ID() != 0		//	single line per charge
+			|| purchaseOrder == null
+			|| purchaseOrder.getDatePromised().compareTo(requisitionLine.getDateRequired()) != 0
+			)
+		{
+			newLine(requisitionLine);
+			// No Order Line was produced (vendor was not valid/allowed) => SKIP
+			if (purcaseOrderLine == null)
+				return;
+		}
+
+		//	Update Order Line
+		purcaseOrderLine.setQty(purcaseOrderLine.getQtyOrdered().add(requisitionLine.getQty()));
+		//	Update Requisition Line
+		requisitionLine.setC_OrderLine_ID(purcaseOrderLine.getC_OrderLine_ID());
+		requisitionLine.saveEx();
+	}	//	process
+	
+	/**
+	 * 	Create new Order
+	 *	@param requisitionLine request line
+	 *	@param partnerId b.partner
+	 * 	@throws Exception
+	 */
+	private void newOrder(MRequisitionLine requisitionLine, int partnerId) throws Exception
+	{
+		if (purchaseOrder != null)
+		{
+			closeOrder();
+		}
+		
+		//	BPartner
+		if (businessPartner == null || partnerId != businessPartner.get_ID())
+		{
+			businessPartner = MBPartner.get(getCtx(), partnerId);
+		}
+		
+		
+		//	Order
+		Timestamp dateRequired = requisitionLine.getDateRequired();
+		int priceListId = requisitionLine.getParent().getM_PriceList_ID();
+		MultiKey key = new MultiKey(partnerId, dateRequired, priceListId);
+		purchaseOrder = purchaseOrdersCache.get(key);
+		if (purchaseOrder == null)
+		{
+			purchaseOrder = new MOrder(getCtx(), 0, get_TrxName());
+			purchaseOrder.setAD_Org_ID(requisitionLine.getAD_Org_ID());
+			purchaseOrder.setM_Warehouse_ID(requisitionLine.getParent().getM_Warehouse_ID());
+			purchaseOrder.setDatePromised(dateRequired);
+			purchaseOrder.setIsSOTrx(false);
+			if(getDocTypeId() > 0) {
+				purchaseOrder.setC_DocTypeTarget_ID(getDocTypeId());
+			} else {
+				purchaseOrder.setC_DocTypeTarget_ID();
+			}
+			purchaseOrder.setBPartner(businessPartner);
+			purchaseOrder.setM_PriceList_ID(priceListId);
+			//	default po document type
+			if (!isConsolidateDocument())
+			{
+				purchaseOrder.setDescription(Msg.getElement(getCtx(), "M_Requisition_ID")
+					+ ": " + requisitionLine.getParent().getDocumentNo());
+			}
+			
+			//	Prepare Save
+			purchaseOrder.saveEx();
+			// Put to cache
+			purchaseOrdersCache.put(key, purchaseOrder);
+		}
+		requisitionId = requisitionLine.getM_Requisition_ID();
+	}	//	newOrder
+
+	/**
+	 * 	Close Order
+	 * 	@throws Exception
+	 */
+	private void closeOrder() throws Exception
+	{
+		if (purcaseOrderLine != null)
+		{
+			purcaseOrderLine.saveEx();
+		}
+		if (purchaseOrder != null)
+		{
+			purchaseOrder.load(get_TrxName());
+			addLog(0, null, purchaseOrder.getGrandTotal(), purchaseOrder.getDocumentNo());
+		}
+		purchaseOrder = null;
+		purcaseOrderLine = null;
+	}	//	closeOrder
+
+	
+	/**
+	 * 	New Order Line (different Product)
+	 *	@param requisitionLine request line
+	 * 	@throws Exception
+	 */
+	private void newLine(MRequisitionLine requisitionLine) throws Exception
+	{
+		if (purcaseOrderLine != null)
+		{
+			purcaseOrderLine.saveEx();
+		}
+		purcaseOrderLine = null;
+		MProduct product = MProduct.get(getCtx(), requisitionLine.getM_Product_ID());
+
+		//	Get Business Partner
+		int partnerId = requisitionLine.getC_BPartner_ID();
+		if (partnerId != 0)
+		{
+			;
+		}
+		else if (requisitionLine.getC_Charge_ID() != 0)
+		{
+			MCharge charge = MCharge.get(getCtx(), requisitionLine.getC_Charge_ID());
+			partnerId = charge.getC_BPartner_ID();
+			if (partnerId == 0)
+			{
+				throw new AdempiereUserError("No Vendor for Charge " + charge.getName());
+			}
+		}
+		else
+		{
+			// Find Strategic Vendor for Product
+			// TODO: refactor
+			MProductPO[] pproductPurchaseInfo = MProductPO.getOfProductAndOrg(getCtx(), product.getM_Product_ID(), requisitionLine.getAD_Org_ID(), null);
+			for (int i = 0; i < pproductPurchaseInfo.length; i++)
+			{
+				if (pproductPurchaseInfo[i].isCurrentVendor() && pproductPurchaseInfo[i].getC_BPartner_ID() != 0)
+				{
+					partnerId = pproductPurchaseInfo[i].getC_BPartner_ID();
+					break;
+				}
+			}
+			if (partnerId == 0 && pproductPurchaseInfo.length > 0)
+			{
+				partnerId = pproductPurchaseInfo[0].getC_BPartner_ID();
+			}
+			if (partnerId == 0)
+			{
+				throw new NoVendorForProductException(product.getName());
+			}
+		}
+		
+		if (!isGenerateForVendor(partnerId))
+		{
+			log.info("Skip for partner "+partnerId);
+			return;
+		}
+
+		//	New Order - Different Vendor
+		if (purchaseOrder == null
+			|| purchaseOrder.getC_BPartner_ID() != partnerId)
+		{
+			newOrder(requisitionLine, partnerId);
+		}
+		
+		//	No Order Line
+		purcaseOrderLine = new MOrderLine(purchaseOrder);
+		purcaseOrderLine.setDatePromised(requisitionLine.getDateRequired());
+		if (product != null)
+		{
+			purcaseOrderLine.setProduct(product);
+			purcaseOrderLine.setM_AttributeSetInstance_ID(requisitionLine.getM_AttributeSetInstance_ID());
+		}
+		else
+		{
+			purcaseOrderLine.setC_Charge_ID(requisitionLine.getC_Charge_ID());
+			purcaseOrderLine.setPriceActual(requisitionLine.getPriceActual());
+		}
+		purcaseOrderLine.setAD_Org_ID(requisitionLine.getAD_Org_ID());
+		if(requisitionLine.getC_Tax_ID() > 0) {
+			purcaseOrderLine.setC_Tax_ID(requisitionLine.getC_Tax_ID());
+		}
+		
+		//	Prepare Save
+		productId = requisitionLine.getM_Product_ID();
+		attributeSetInstanceId = requisitionLine.getM_AttributeSetInstance_ID();
+		purcaseOrderLine.saveEx();
+	}	//	newLine
+
+	/**
+	 * Do we need to generate Purchase Orders for given Vendor 
+	 * @param partnerId
+	 * @return true if it's allowed
+	 */
+	private boolean isGenerateForVendor(int partnerId)
+	{
+		// No filter group was set => generate for all vendors
+		if (getBPGroupId() <= 0)
+			return true;
+		
+		if (m_excludedVendors.contains(partnerId))
+			return false;
+		//
+		boolean match = new Query(getCtx(), MBPartner.Table_Name, "C_BPartner_ID=? AND C_BP_Group_ID=?", get_TrxName())
+		.setParameters(partnerId, getBPGroupId())
+		.match();
+		if (!match)
+		{
+			m_excludedVendors.add(partnerId);
+		}
+		return match;
+	}
+	private List<Integer> m_excludedVendors = new ArrayList<Integer>();
+	
+}	//	RequisitionPOCreate

--- a/src/patches/org/compiere/process/T_InventoryValue_Create.java
+++ b/src/patches/org/compiere/process/T_InventoryValue_Create.java
@@ -1,0 +1,239 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 1999-2006 ComPiere, Inc. All Rights Reserved.                *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * ComPiere, Inc., 2620 Augustine Dr. #245, Santa Clara, CA 95054, USA        *
+ * or via info@compiere.org or http://www.compiere.org/license.html           *
+ * Portions created by Carlos Ruiz are Copyright (C) 2005 QSS Ltda.
+ * Contributor(s): Carlos Ruiz (globalqss)
+ *****************************************************************************/
+package org.compiere.process;
+
+import org.compiere.util.AdempiereUserError;
+import org.compiere.util.CLogger;
+import org.compiere.util.DB;
+import org.compiere.util.ValueNamePair;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.util.logging.Level;
+
+/**
+ * Title:	Inventory Valuation Temporary Table
+ *	
+ *  @author Carlos Ruiz (globalqss)
+ *  @version $Id: T_InventoryValue_Create.java,v 1.0 2005/09/21 20:29:00 globalqss Exp $
+ */
+public class T_InventoryValue_Create extends SvrProcess
+{
+
+	/** The Parameters		*/
+	private int p_M_PriceList_Version_ID;
+	private Timestamp p_DateValue;
+	private int p_M_Warehouse_ID;
+	private int p_C_Currency_ID;
+	/** The Record						*/
+	private int		p_Record_ID = 0;
+	/** The Instance					*/
+	private int     p_PInstance_ID;
+	
+	/**
+	 *  Prepare - e.g., get Parameters.
+	 */
+	protected void prepare()
+	{
+		ProcessInfoParameter[] para = getParameter();
+		for (int i = 0; i < para.length; i++)
+		{
+			String name = para[i].getParameterName();
+			if (para[i].getParameter() == null)
+				;			
+			else if (name.equals("M_PriceList_Version_ID"))
+				p_M_PriceList_Version_ID = para[i].getParameterAsInt();
+			else if (name.equals("DateValue"))
+				p_DateValue = (Timestamp)para[i].getParameter();
+			else if (name.equals("M_Warehouse_ID"))
+				p_M_Warehouse_ID = para[i].getParameterAsInt();
+			else if (name.equals("C_Currency_ID"))
+				p_C_Currency_ID = para[i].getParameterAsInt();
+			else
+				log.log(Level.SEVERE, "Unknown Parameter: " + name);
+		}
+		p_Record_ID = getRecord_ID();
+		p_PInstance_ID = getAD_PInstance_ID();
+	}	//	prepare
+
+	/**
+	 * 	Process
+	 *	@return message
+	 *	@throws Exception
+	 */
+	protected String doIt() throws Exception
+	{
+		String sqlupd;
+		String sqlins;
+		int cntu = 0;
+		int cnti = 0;
+
+		log.info("Inventory Valuation Temporary Table");
+
+		// Clear
+		//	v_ResultStr := 'ClearTable';
+		//	DELETE T_InventoryValue WHERE M_Warehouse_ID=p_M_Warehouse_ID;
+		//	COMMIT;		
+		
+		// Insert Products
+		sqlins = "INSERT INTO T_InventoryValue "
+		       + "(AD_Client_ID,AD_Org_ID, AD_PInstance_ID, M_Warehouse_ID,M_Product_ID) "
+		       + "SELECT AD_Client_ID,AD_Org_ID," + p_PInstance_ID + "," + p_M_Warehouse_ID + ",M_Product_ID "
+		       + "FROM M_Product "
+		       + "WHERE IsStocked='Y'";
+		cnti = DB.executeUpdate(sqlins, get_TrxName());
+		if (cnti == 0) {
+			return "@Created@ = 0";
+		}
+		if (cnti < 0) {
+			raiseError("InsertStockedProducts:ERROR", sqlins);
+		}
+		
+		// Update Constants
+        // En Oracle SET DateValue = TRUNC(?) + 0.9993, equivale a sumar 23:59 a la fecha
+		p_DateValue.setHours(23);
+		p_DateValue.setMinutes(59);
+		p_DateValue.setSeconds(0);
+		sqlupd = "UPDATE T_InventoryValue "
+		       + "SET DateValue = ?, "
+		       +     "M_PriceList_Version_ID = ? , "
+		       +     "C_Currency_ID = ? "
+		       + "WHERE M_Warehouse_ID = ?";
+		PreparedStatement pstmt = null;
+		try {
+			pstmt = DB.prepareStatement(sqlupd, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_UPDATABLE, get_TrxName());
+			pstmt.setTimestamp(1, p_DateValue);
+			pstmt.setInt(2, p_M_PriceList_Version_ID);
+			pstmt.setInt(3, p_C_Currency_ID);
+			pstmt.setInt(4, p_M_Warehouse_ID);
+			cntu = pstmt.executeUpdate();
+			if (cntu < 0) {
+				raiseError("UpdateConstants:ERROR", sqlupd);
+			}
+		} catch (Exception exception) {
+			log.severe(exception.getMessage());
+		} finally {
+			DB.close(pstmt);
+			pstmt = null;
+		}
+		
+		// Get current QtyOnHand
+		sqlupd = "UPDATE T_InventoryValue "
+	           + "SET QtyOnHand = (SELECT SUM(QtyOnHand) FROM M_Storage s, M_Locator l "
+	           + "WHERE T_InventoryValue.M_Product_ID=s.M_Product_ID "
+	           + "AND l.M_Locator_ID=s.M_Locator_ID "
+	           + "AND l.M_Warehouse_ID=T_InventoryValue.M_Warehouse_ID) "
+	           + "WHERE T_InventoryValue.M_Warehouse_ID = " + p_M_Warehouse_ID;		
+		cntu = DB.executeUpdate(sqlupd, get_TrxName());
+		if (cntu < 0) {
+			raiseError("GetQtyOnHand:ERROR", sqlupd);
+		}
+		
+		// Adjust for Valuation Date
+		sqlupd = "UPDATE T_InventoryValue " 
+	           + "SET QtyOnHand = "
+	           + "(SELECT T_InventoryValue.QtyOnHand - NVL(SUM(t.MovementQty), 0) " 
+	           + "FROM M_Transaction t, M_Locator l "
+	           + "WHERE t.M_Product_ID=T_InventoryValue.M_Product_ID " 
+	           // + "AND t.M_AttributeSetInstance_ID=T_InventoryValue.M_AttributeSetInstance_ID "
+	           + "AND t.MovementDate > T_InventoryValue.DateValue "
+	           + "AND t.M_Locator_ID=l.M_Locator_ID "
+	           + "AND l.M_Warehouse_ID=T_InventoryValue.M_Warehouse_ID) "
+	           + "WHERE	T_InventoryValue.M_Warehouse_ID = " + p_M_Warehouse_ID;		
+		cntu = DB.executeUpdate(sqlupd, get_TrxName());
+		if (cntu < 0) {
+			raiseError("AdjustQtyOnHand:ERROR", sqlupd);
+		}
+		
+		// Delete Records w/o OnHand Qty
+		sqlupd = "DELETE T_InventoryValue " 
+	           + "WHERE QtyOnHand=0 "
+	           + "OR QtyOnHand IS NULL";		
+		cntu = DB.executeUpdate(sqlupd, get_TrxName());
+		if (cntu < 0) {
+			raiseError("DeleteZeroQtyOnHand:ERROR", sqlupd);
+		}
+		
+		// Update Prices
+		sqlupd = "UPDATE T_InventoryValue "
+	           + "SET PricePO = "
+	           + "(SELECT currencyConvert (po.PriceList,po.C_Currency_ID,T_InventoryValue.C_Currency_ID,T_InventoryValue.DateValue, null, T_InventoryValue.AD_Client_ID, T_InventoryValue.AD_Org_ID) "
+	           + "FROM M_Product_PO po WHERE po.M_Product_ID=T_InventoryValue.M_Product_ID "
+	           + "AND po.IsCurrentVendor='Y' AND po.IsActive='Y' "
+				+ "AND po.AD_Org_ID IN (0, T_InventoryValue.AD_Org_ID) "
+				+ "ORDER BY po.AD_Org_ID DESC LIMIT 1), "
+	           + "PriceList = "
+	           + "(SELECT currencyConvert(pp.PriceList,pl.C_Currency_ID,T_InventoryValue.C_Currency_ID,T_InventoryValue.DateValue, null, T_InventoryValue.AD_Client_ID, T_InventoryValue.AD_Org_ID) "
+	           + "FROM M_PriceList pl, M_PriceList_Version plv, M_ProductPrice pp "
+	           + "WHERE pp.M_Product_ID=T_InventoryValue.M_Product_ID AND pp.M_PriceList_Version_ID=T_InventoryValue.M_PriceList_Version_ID "
+	           + "AND pp.M_PriceList_Version_ID=plv.M_PriceList_Version_ID "
+	           + "AND plv.M_PriceList_ID=pl.M_PriceList_ID), "
+	           + "PriceStd = " 
+	           + "(SELECT currencyConvert(pp.PriceStd,pl.C_Currency_ID,T_InventoryValue.C_Currency_ID,T_InventoryValue.DateValue, null, T_InventoryValue.AD_Client_ID, T_InventoryValue.AD_Org_ID) "
+	           + "FROM M_PriceList pl, M_PriceList_Version plv, M_ProductPrice pp "
+	           + "WHERE pp.M_Product_ID=T_InventoryValue.M_Product_ID AND pp.M_PriceList_Version_ID=T_InventoryValue.M_PriceList_Version_ID "
+	           + "AND pp.M_PriceList_Version_ID=plv.M_PriceList_Version_ID "
+	           + "AND plv.M_PriceList_ID=pl.M_PriceList_ID), " 
+	           + "PriceLimit = " 
+	           + "(SELECT currencyConvert(pp.PriceLimit,pl.C_Currency_ID,T_InventoryValue.C_Currency_ID,T_InventoryValue.DateValue, null, T_InventoryValue.AD_Client_ID, T_InventoryValue.AD_Org_ID) "
+	           + "FROM M_PriceList pl, M_PriceList_Version plv, M_ProductPrice pp "
+	           + "WHERE pp.M_Product_ID=T_InventoryValue.M_Product_ID AND pp.M_PriceList_Version_ID=T_InventoryValue.M_PriceList_Version_ID "
+	           + "AND pp.M_PriceList_Version_ID=plv.M_PriceList_Version_ID "
+	           + "AND plv.M_PriceList_ID=pl.M_PriceList_ID), "
+	           + "CostStandard = " 
+	           + "(SELECT currencyConvert(pc.CurrentCostPrice,acs.C_Currency_ID,T_InventoryValue.C_Currency_ID,T_InventoryValue.DateValue, null, T_InventoryValue.AD_Client_ID, T_InventoryValue.AD_Org_ID) "
+	           + "FROM AD_ClientInfo ci, C_AcctSchema acs, M_Product_Costing pc "
+	           + "WHERE T_InventoryValue.AD_Client_ID=ci.AD_Client_ID AND ci.C_AcctSchema1_ID=acs.C_AcctSchema_ID "
+	           + "AND acs.C_AcctSchema_ID=pc.C_AcctSchema_ID "
+	           + "AND T_InventoryValue.M_Product_ID=pc.M_Product_ID) "
+	           + "WHERE	T_InventoryValue.M_Warehouse_ID = " + p_M_Warehouse_ID;		
+		cntu = DB.executeUpdate(sqlupd, get_TrxName());
+		if (cntu < 0) {
+			raiseError("GetPrices:ERROR", sqlupd);
+		}
+		
+		// Update Values
+		sqlupd = "UPDATE T_InventoryValue " 
+	           + "SET PricePOAmt = QtyOnHand * PricePO, " 
+	           + "PriceListAmt = QtyOnHand * PriceList, " 
+	           + "PriceStdAmt = QtyOnHand * PriceStd, " 
+	           + "PriceLimitAmt = QtyOnHand * PriceLimit, " 
+	           + "CostStandardAmt = QtyOnHand * CostStandard "
+	           + "WHERE	M_Warehouse_ID = " + p_M_Warehouse_ID;
+		cntu = DB.executeUpdate(sqlupd, get_TrxName());
+		if (cntu < 0) {
+			raiseError("UpdateValue:ERROR", sqlupd);
+		}
+		
+		DB.commit(true, get_TrxName());
+		return "@Created@ = " + cntu;		
+	}	//	doIt
+	
+	private void raiseError(String string, String sql) throws Exception {
+		DB.rollback(false, get_TrxName());
+		String msg = string;
+		ValueNamePair pp = CLogger.retrieveError();
+		if (pp != null)
+			msg = pp.getName() + " - ";
+		msg += sql;
+		throw new AdempiereUserError (msg);
+	}
+	
+}	//	T_InventoryValue_Create

--- a/src/patches/org/compiere/production/process/ReplenishReportProduction.java
+++ b/src/patches/org/compiere/production/process/ReplenishReportProduction.java
@@ -1,0 +1,828 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 1999-2006 ComPiere, Inc. All Rights Reserved.                *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * ComPiere, Inc., 2620 Augustine Dr. #245, Santa Clara, CA 95054, USA        *
+ * or via info@compiere.org or http://www.compiere.org/license.html           *
+ * Contributor(s): Chris Farley - northernbrewer                              *
+ *****************************************************************************/
+package org.compiere.production.process;
+
+import org.adempiere.core.domains.models.X_T_Replenish;
+import org.compiere.model.MBPartner;
+import org.compiere.model.MClient;
+import org.compiere.model.MDocType;
+import org.compiere.model.MMovement;
+import org.compiere.model.MMovementLine;
+import org.compiere.model.MOrder;
+import org.compiere.model.MOrderLine;
+import org.compiere.model.MOrg;
+import org.compiere.model.MProduct;
+import org.compiere.model.MProduction;
+import org.compiere.model.MRequisition;
+import org.compiere.model.MRequisitionLine;
+import org.compiere.model.MStorage;
+import org.compiere.model.MWarehouse;
+import org.compiere.process.DocAction;
+import org.compiere.process.ProcessInfoParameter;
+import org.compiere.process.SvrProcess;
+import org.compiere.util.AdempiereSystemError;
+import org.compiere.util.AdempiereUserError;
+import org.compiere.util.DB;
+import org.compiere.util.Env;
+import org.compiere.util.Msg;
+import org.compiere.util.ReplenishInterface;
+import org.eevolution.distribution.model.MDDOrder;
+import org.eevolution.distribution.model.MDDOrderLine;
+
+import java.math.BigDecimal;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.logging.Level;
+
+/**
+ *	Replenishment Report
+ *	
+ *  @author Jorg Janke
+ *  @version $Id: ReplenishReport.java,v 1.2 2006/07/30 00:51:01 jjanke Exp $
+ *  
+ *  Carlos Ruiz globalqss - integrate bug fixing from Chris Farley
+ *    [ 1619517 ] Replenish report fails when no records in m_storage
+ *  @author Mario Calderon, mario.calderon@westfalia-it.com, Systemhaus Westfalia, http://www.westfalia-it.com
+ *	@author Yamel Senih, ysenih@erpcya.com, ERPCyA http://www.erpcya.com
+ * 		<a href="https://github.com/adempiere/adempiere/issues/648">
+ * 		@see FR [ 648 ] Add Support to document Action on Standard Production window</a>
+ */
+public class ReplenishReportProduction extends SvrProcess
+{
+	/** Warehouse				*/
+	private int		p_M_Warehouse_ID = 0;
+	/**	Optional BPartner		*/
+	private int		p_C_BPartner_ID = 0;
+	/** Create (POO)Purchse Order or (POR)Requisition or (MMM)Movements */
+	private String	p_ReplenishmentCreate = null;
+	/** Document Type			*/
+	private int		p_C_DocType_ID = 0;
+	/** Return Info				*/
+	private String	m_info = "";
+	private int p_M_Product_Category_ID = 0;
+	private String isKanban = null;
+	
+	/**
+	 *  Prepare - e.g., get Parameters.
+	 */
+	protected void prepare()
+	{
+		ProcessInfoParameter[] para = getParameter();
+		for (int i = 0; i < para.length; i++)
+		{
+			String name = para[i].getParameterName();
+			if (para[i].getParameter() == null)
+				;
+			else if (name.equals("M_Warehouse_ID"))
+				p_M_Warehouse_ID = para[i].getParameterAsInt();
+			else if (name.equals("C_BPartner_ID"))
+				p_C_BPartner_ID = para[i].getParameterAsInt();
+			else if (name.equals("M_Product_Category_ID"))
+				p_M_Product_Category_ID = para[i].getParameterAsInt();
+			else if (name.equals("IsKanban"))
+				isKanban = (String) para[i].getParameter();
+			else if (name.equals("ReplenishmentCreate"))
+				p_ReplenishmentCreate = (String)para[i].getParameter();
+			else if (name.equals("C_DocType_ID"))
+				p_C_DocType_ID = para[i].getParameterAsInt();
+			else
+				log.log(Level.SEVERE, "Unknown Parameter: " + name);
+		}
+	}	//	prepare
+
+	/**
+	 *  Perform process.
+	 *  @return Message 
+	 *  @throws Exception if not successful
+	 */
+	protected String doIt() throws Exception
+	{
+		log.info("M_Warehouse_ID=" + p_M_Warehouse_ID 
+			+ ", C_BPartner_ID=" + p_C_BPartner_ID 
+			+ " - ReplenishmentCreate=" + p_ReplenishmentCreate
+			+ ", C_DocType_ID=" + p_C_DocType_ID);
+		if (p_ReplenishmentCreate != null && p_C_DocType_ID == 0 && !p_ReplenishmentCreate.equals("PRD"))
+			throw new AdempiereUserError("@FillMandatory@ @C_DocType_ID@");
+		
+		MWarehouse wh = MWarehouse.get(getCtx(), p_M_Warehouse_ID);
+		if (wh.get_ID() == 0)  
+			throw new AdempiereSystemError("@FillMandatory@ @M_Warehouse_ID@");
+		//
+		prepareTable();
+		fillTable(wh);
+		//
+		if (p_ReplenishmentCreate == null)
+			return "OK";
+		//
+		MDocType dt = MDocType.get(getCtx(), p_C_DocType_ID);
+		if (!p_ReplenishmentCreate.equals("PRD") && !dt.getDocBaseType().equals(p_ReplenishmentCreate) )
+			throw new AdempiereSystemError("@C_DocType_ID@=" + dt.getName() + " <> " + p_ReplenishmentCreate);
+		//
+		if (p_ReplenishmentCreate.equals("POO"))
+			createPO();
+		else if (p_ReplenishmentCreate.equals("POR"))
+			createRequisition();
+		else if (p_ReplenishmentCreate.equals("MMM"))
+			createMovements();
+		else if (p_ReplenishmentCreate.equals("DOO"))
+			createDO();
+		else if (p_ReplenishmentCreate.equals("PRD"))
+			createProduction();
+		return m_info;
+	}	//	doIt
+
+	/**
+	 * 	Prepare/Check Replenishment Table
+	 */
+	private void prepareTable()
+	{
+		//	Level_Max must be >= Level_Max
+		String sql = "UPDATE M_Replenish"
+			+ " SET Level_Max = Level_Min "
+			+ "WHERE Level_Max < Level_Min";
+		int no = DB.executeUpdate(sql, get_TrxName());
+		if (no != 0)
+			log.fine("Corrected Max_Level=" + no);
+
+	}	//	prepareTable
+
+	/**
+	 * 	Fill Table
+	 * 	@param wh warehouse
+	 */
+	@SuppressWarnings("deprecation")
+	private void fillTable (MWarehouse wh) throws Exception
+	{
+		String sql = "INSERT INTO T_Replenish "
+			+ "(AD_PInstance_ID, M_Warehouse_ID, M_Product_ID, AD_Client_ID, AD_Org_ID,"
+			+ " ReplenishType, Level_Min, Level_Max,"
+			+ " C_BPartner_ID, Order_Min, Order_Pack, QtyToOrder, ReplenishmentCreate) "
+			+ "SELECT " + getAD_PInstance_ID() 
+				+ ", r.M_Warehouse_ID, r.M_Product_ID, r.AD_Client_ID, r.AD_Org_ID,"
+			+ " r.ReplenishType, r.Level_Min, r.Level_Max,"
+			+ " po.C_BPartner_ID, po.Order_Min, po.Order_Pack, 0, ";
+		if (p_ReplenishmentCreate == null)
+			sql += "null";
+		else
+			sql += "'" + p_ReplenishmentCreate + "'";
+		sql += " FROM M_Replenish r"
+			+ " INNER JOIN M_Warehouse w ON (r.M_Warehouse_ID = w.M_Warehouse_ID)"
+			+ " INNER JOIN M_Product p ON (p.M_Product_ID=r.M_Product_ID)"
+			+ " LEFT JOIN LATERAL ("
+			+ "     SELECT ppo.C_BPartner_ID, ppo.Order_Min, ppo.Order_Pack "
+			+ "     FROM M_Product_PO ppo "
+			+ "     WHERE ppo.M_Product_ID = r.M_Product_ID "
+			+ "       AND ppo.IsCurrentVendor='Y'"
+			+ "       AND ppo.IsActive = 'Y' "
+			+ "       AND ppo.AD_Org_ID IN (0, w.AD_Org_ID) "
+			+ "     ORDER BY ppo.AD_Org_ID DESC "
+			+ "     LIMIT 1"
+			+ " ) po ON true "
+			+ " WHERE r.ReplenishType<>'0'"
+			+ " AND r.IsActive='Y'"
+			+ " AND r.M_Warehouse_ID=" + p_M_Warehouse_ID
+			+ " AND po.C_BPartner_ID IS NOT NULL";
+		if (p_C_BPartner_ID != 0)
+			sql += " AND po.C_BPartner_ID=" + p_C_BPartner_ID;
+		if ( p_M_Product_Category_ID != 0 )
+			sql += " AND p.M_Product_Category_ID=" + p_M_Product_Category_ID;
+		if ( isKanban != null )
+			sql += " AND p.IsKanban = '" + isKanban + "' ";
+		int no = DB.executeUpdate(sql, get_TrxName());
+		log.finest(sql);
+		log.fine("Insert (1) #" + no);
+		
+		if (p_C_BPartner_ID == 0)
+		{
+			sql = "INSERT INTO T_Replenish "
+				+ "(AD_PInstance_ID, M_Warehouse_ID, M_Product_ID, AD_Client_ID, AD_Org_ID,"
+				+ " ReplenishType, Level_Min, Level_Max,"
+				+ " C_BPartner_ID, Order_Min, Order_Pack, QtyToOrder, ReplenishmentCreate) "
+				+ "SELECT " + getAD_PInstance_ID()
+				+ ", r.M_Warehouse_ID, r.M_Product_ID, r.AD_Client_ID, r.AD_Org_ID,"
+				+ " r.ReplenishType, r.Level_Min, r.Level_Max,"
+			    + " 0, 1, 1, 0, ";
+			if (p_ReplenishmentCreate == null)
+				sql += "null";
+			else
+				sql += "'" + p_ReplenishmentCreate + "'";
+			sql	+= " FROM M_Replenish r "
+				+ " INNER JOIN M_Product p ON (p.M_Product_ID=r.M_Product_ID) "
+				+ "WHERE r.ReplenishType<>'0' AND r.IsActive='Y'"
+				+ " AND r.M_Warehouse_ID=" + p_M_Warehouse_ID
+				+ " AND NOT EXISTS (SELECT * FROM T_Replenish t "
+					+ "WHERE r.M_Product_ID=t.M_Product_ID"
+					+ " AND AD_PInstance_ID=" + getAD_PInstance_ID() + ")";
+			if ( p_M_Product_Category_ID != 0 )
+				sql += " AND p.M_Product_Category_ID=" + p_M_Product_Category_ID;
+			if ( isKanban != null )
+				sql += " AND p.IsKanban = '" + isKanban + "' ";
+			no = DB.executeUpdate(sql, get_TrxName());
+			log.fine("Insert (BP) #" + no);
+		}
+		
+		sql = "UPDATE T_Replenish t SET "
+			+ "QtyOnHand = (SELECT COALESCE(SUM(QtyOnHand),0) FROM M_Storage s, M_Locator l WHERE t.M_Product_ID=s.M_Product_ID"
+				+ " AND l.M_Locator_ID=s.M_Locator_ID AND l.M_Warehouse_ID=t.M_Warehouse_ID),"
+			+ "QtyReserved = (SELECT COALESCE(SUM(QtyReserved),0) FROM M_Storage s, M_Locator l WHERE t.M_Product_ID=s.M_Product_ID"
+				+ " AND l.M_Locator_ID=s.M_Locator_ID AND l.M_Warehouse_ID=t.M_Warehouse_ID),"
+			+ "QtyOrdered = (SELECT COALESCE(SUM(QtyOrdered),0) FROM M_Storage s, M_Locator l WHERE t.M_Product_ID=s.M_Product_ID"
+				+ " AND l.M_Locator_ID=s.M_Locator_ID AND l.M_Warehouse_ID=t.M_Warehouse_ID)";
+		if (p_C_DocType_ID != 0)
+			sql += ", C_DocType_ID=" + p_C_DocType_ID;
+		sql += " WHERE AD_PInstance_ID=" + getAD_PInstance_ID();
+		no = DB.executeUpdate(sql, get_TrxName());
+		if (no != 0)
+			log.fine("Update #" + no);
+		
+		// add production lines
+		sql = "UPDATE T_Replenish t SET "
+			+ "QtyReserved = QtyReserved - COALESCE((SELECT COALESCE(SUM(MovementQty),0) FROM M_ProductionLine p, M_Locator l WHERE t.M_Product_ID=p.M_Product_ID"
+				+ " AND l.M_Locator_ID=p.M_Locator_ID AND l.M_Warehouse_ID=t.M_Warehouse_ID AND MovementQty < 0 AND p.Processed = 'N'),0),"
+			+ "QtyOrdered = QtyOrdered + COALESCE((SELECT COALESCE(SUM(MovementQty),0) FROM M_ProductionLine p, M_Locator l WHERE t.M_Product_ID=p.M_Product_ID"
+				+ " AND l.M_Locator_ID=p.M_Locator_ID AND l.M_Warehouse_ID=t.M_Warehouse_ID AND MovementQty > 0 AND p.Processed = 'N'),0)";
+		if (p_C_DocType_ID != 0)
+			sql += ", C_DocType_ID=" + p_C_DocType_ID;
+		sql += " WHERE AD_PInstance_ID=" + getAD_PInstance_ID();
+		no = DB.executeUpdate(sql, get_TrxName());
+		if (no != 0)
+			log.fine("Update #" + no);
+		
+
+		//	Delete inactive products and replenishments
+		sql = "DELETE T_Replenish r "
+			+ "WHERE (EXISTS (SELECT * FROM M_Product p "
+				+ "WHERE p.M_Product_ID=r.M_Product_ID AND p.IsActive='N')"
+			+ " OR EXISTS (SELECT * FROM M_Replenish rr "
+				+ " WHERE rr.M_Product_ID=r.M_Product_ID AND rr.IsActive='N'"
+				+ " AND rr.M_Warehouse_ID=" + p_M_Warehouse_ID + " ))"
+			+ " AND AD_PInstance_ID=" + getAD_PInstance_ID();
+		no = DB.executeUpdate(sql, get_TrxName());
+		if (no != 0)
+			log.fine("Delete Inactive=" + no);
+	 
+		//	Ensure Data consistency
+		sql = "UPDATE T_Replenish SET QtyOnHand = 0 WHERE QtyOnHand IS NULL";
+		no = DB.executeUpdate(sql, get_TrxName());
+		sql = "UPDATE T_Replenish SET QtyReserved = 0 WHERE QtyReserved IS NULL";
+		no = DB.executeUpdate(sql, get_TrxName());
+		sql = "UPDATE T_Replenish SET QtyOrdered = 0 WHERE QtyOrdered IS NULL";
+		no = DB.executeUpdate(sql, get_TrxName());
+
+		//	Set Minimum / Maximum Maintain Level
+		//	X_M_Replenish.REPLENISHTYPE_ReorderBelowMinimumLevel
+		sql = "UPDATE T_Replenish"
+			+ " SET QtyToOrder = CASE WHEN QtyOnHand - QtyReserved + QtyOrdered <= Level_Min "
+			+ " THEN Level_Max - QtyOnHand + QtyReserved - QtyOrdered "
+			+ " ELSE 0 END "
+			+ "WHERE ReplenishType='1'" 
+			+ " AND AD_PInstance_ID=" + getAD_PInstance_ID();
+		no = DB.executeUpdate(sql, get_TrxName());
+		if (no != 0)
+			log.fine("Update Type-1=" + no);
+		//
+		//	X_M_Replenish.REPLENISHTYPE_MaintainMaximumLevel
+		sql = "UPDATE T_Replenish"
+			+ " SET QtyToOrder = Level_Max - QtyOnHand + QtyReserved - QtyOrdered "
+			+ "WHERE ReplenishType='2'" 
+			+ " AND AD_PInstance_ID=" + getAD_PInstance_ID();
+		no = DB.executeUpdate(sql, get_TrxName());
+		if (no != 0)
+			log.fine("Update Type-2=" + no);
+	
+
+		//	Minimum Order Quantity
+		sql = "UPDATE T_Replenish"
+			+ " SET QtyToOrder = Order_Min "
+			+ "WHERE QtyToOrder < Order_Min"
+			+ " AND QtyToOrder > 0" 
+			+ " AND AD_PInstance_ID=" + getAD_PInstance_ID();
+		no = DB.executeUpdate(sql, get_TrxName());
+		if (no != 0)
+			log.fine("Set MinOrderQty=" + no);
+
+		//	Even dividable by Pack
+		sql = "UPDATE T_Replenish"
+			+ " SET QtyToOrder = QtyToOrder - MOD(QtyToOrder, Order_Pack) + Order_Pack "
+			+ "WHERE MOD(QtyToOrder, Order_Pack) <> 0"
+			+ " AND QtyToOrder > 0"
+			+ " AND AD_PInstance_ID=" + getAD_PInstance_ID();
+		no = DB.executeUpdate(sql, get_TrxName());
+		if (no != 0)
+			log.fine("Set OrderPackQty=" + no);
+		
+		//	Source from other warehouse
+		if (wh.getM_WarehouseSource_ID() != 0)
+		{
+			sql = "UPDATE T_Replenish"
+				+ " SET M_WarehouseSource_ID=" + wh.getM_WarehouseSource_ID() 
+				+ " WHERE AD_PInstance_ID=" + getAD_PInstance_ID();
+			no = DB.executeUpdate(sql, get_TrxName());
+			if (no != 0)
+				log.fine("Set Source Warehouse=" + no);
+		}
+		//	Check Source Warehouse
+		sql = "UPDATE T_Replenish"
+			+ " SET M_WarehouseSource_ID = NULL " 
+			+ "WHERE M_Warehouse_ID=M_WarehouseSource_ID"
+			+ " AND AD_PInstance_ID=" + getAD_PInstance_ID();
+		no = DB.executeUpdate(sql, get_TrxName());
+		if (no != 0)
+			log.fine("Set same Source Warehouse=" + no);
+		
+		//	Custom Replenishment
+		String className = wh.getReplenishmentClass();
+		if (className != null && className.length() > 0)
+		{	
+			//	Get Replenishment Class
+			ReplenishInterface custom = null;
+			try
+			{
+				Class<?> clazz = Class.forName(className);
+				custom = (ReplenishInterface)clazz.newInstance();
+			}
+			catch (Exception e)
+			{
+				throw new AdempiereUserError("No custom Replenishment class "
+						+ className + " - " + e.toString());
+			}
+
+			X_T_Replenish[] replenishs = getReplenish("ReplenishType='9'");
+			for (int i = 0; i < replenishs.length; i++)
+			{
+				X_T_Replenish replenish = replenishs[i];
+				if (replenish.getReplenishType().equals(X_T_Replenish.REPLENISHTYPE_Custom))
+				{
+					BigDecimal qto = null;
+					try
+					{
+						qto = custom.getQtyToOrder(wh, replenish);
+					}
+					catch (Exception e)
+					{
+						log.log(Level.SEVERE, custom.toString(), e);
+					}
+					if (qto == null)
+						qto = Env.ZERO;
+					replenish.setQtyToOrder(qto);
+					replenish.save();
+				}
+			}
+		}
+		//	Delete rows where nothing to order
+		sql = "DELETE T_Replenish "
+			+ "WHERE QtyToOrder < 1"
+		    + " AND AD_PInstance_ID=" + getAD_PInstance_ID();
+		no = DB.executeUpdate(sql, get_TrxName());
+		if (no != 0)
+			log.fine("Delete No QtyToOrder=" + no);
+			
+	}	//	fillTable
+
+	/**
+	 * 	Create PO's
+	 */
+	private void createPO()
+	{
+		int noOrders = 0;
+		String info = "";
+		//
+		MOrder order = null;
+		MWarehouse wh = null;
+		X_T_Replenish[] replenishs = getReplenish("M_WarehouseSource_ID IS NULL AND C_BPartner_ID > 0");
+		for (int i = 0; i < replenishs.length; i++)
+		{
+			X_T_Replenish replenish = replenishs[i];
+			if (wh == null || wh.getM_Warehouse_ID() != replenish.getM_Warehouse_ID())
+				wh = MWarehouse.get(getCtx(), replenish.getM_Warehouse_ID());
+			//
+			if (order == null 
+				|| order.getC_BPartner_ID() != replenish.getC_BPartner_ID()
+				|| order.getM_Warehouse_ID() != replenish.getM_Warehouse_ID())
+			{
+				order = new MOrder(getCtx(), 0, get_TrxName());
+				order.setIsSOTrx(false);
+				order.setC_DocTypeTarget_ID(p_C_DocType_ID);
+				MBPartner bp = new MBPartner(getCtx(), replenish.getC_BPartner_ID(), get_TrxName());
+				order.setBPartner(bp);
+				order.setSalesRep_ID(getAD_User_ID());
+				order.setDescription(Msg.getMsg(getCtx(), "Replenishment"));
+				//	Set Org/WH
+				order.setAD_Org_ID(wh.getAD_Org_ID());
+				order.setM_Warehouse_ID(wh.getM_Warehouse_ID());
+				if (!order.save())
+					return;
+				log.fine(order.toString());
+				noOrders++;
+				info += " - " + order.getDocumentNo();
+			}
+			MOrderLine line = new MOrderLine (order);
+			line.setM_Product_ID(replenish.getM_Product_ID());
+			line.setQty(replenish.getQtyToOrder());
+			line.setPrice();
+			line.save();
+		}
+		m_info = "#" + noOrders + info;
+		log.info(m_info);
+	}	//	createPO
+	
+	/**
+	 * 	Create Requisition
+	 */
+	private void createRequisition()
+	{
+		int noReqs = 0;
+		String info = "";
+		//
+		MRequisition requisition = null;
+		MWarehouse wh = null;
+		X_T_Replenish[] replenishs = getReplenish("M_WarehouseSource_ID IS NULL AND C_BPartner_ID > 0");
+		for (int i = 0; i < replenishs.length; i++)
+		{
+			X_T_Replenish replenish = replenishs[i];
+			if (wh == null || wh.getM_Warehouse_ID() != replenish.getM_Warehouse_ID())
+				wh = MWarehouse.get(getCtx(), replenish.getM_Warehouse_ID());
+			//
+			if (requisition == null
+				|| requisition.getM_Warehouse_ID() != replenish.getM_Warehouse_ID())
+			{
+				requisition = new MRequisition (getCtx(), 0, get_TrxName());
+				requisition.setAD_User_ID (getAD_User_ID());
+				requisition.setC_DocType_ID(p_C_DocType_ID);
+				requisition.setDescription(Msg.getMsg(getCtx(), "Replenishment"));
+				//	Set Org/WH
+				requisition.setAD_Org_ID(wh.getAD_Org_ID());
+				requisition.setM_Warehouse_ID(wh.getM_Warehouse_ID());
+				if (!requisition.save())
+					return;
+				log.fine(requisition.toString());
+				noReqs++;
+				info += " - " + requisition.getDocumentNo();
+			}
+			//
+			MRequisitionLine line = new MRequisitionLine(requisition);
+			line.setM_Product_ID(replenish.getM_Product_ID());
+			line.setC_BPartner_ID(replenish.getC_BPartner_ID());
+			line.setQty(replenish.getQtyToOrder());
+			line.setPrice();
+			line.save();
+		}
+		m_info = "#" + noReqs + info;
+		log.info(m_info);
+	}	//	createRequisition
+
+	/**
+	 * 	Create Inventory Movements
+	 */
+	private void createMovements()
+	{
+		int noMoves = 0;
+		String info = "";
+		//
+		MClient client = null;
+		MMovement move = null;
+		int M_Warehouse_ID = 0;
+		int M_WarehouseSource_ID = 0;
+		MWarehouse whSource = null;
+		MWarehouse wh = null;
+		X_T_Replenish[] replenishs = getReplenish("M_WarehouseSource_ID IS NOT NULL AND C_BPartner_ID > 0");
+		for (int i = 0; i < replenishs.length; i++)
+		{
+			X_T_Replenish replenish = replenishs[i];
+			if (whSource == null || whSource.getM_WarehouseSource_ID() != replenish.getM_WarehouseSource_ID())
+				whSource = MWarehouse.get(getCtx(), replenish.getM_WarehouseSource_ID());
+			if (wh == null || wh.getM_Warehouse_ID() != replenish.getM_Warehouse_ID())
+				wh = MWarehouse.get(getCtx(), replenish.getM_Warehouse_ID());
+			if (client == null || client.getAD_Client_ID() != whSource.getAD_Client_ID())
+				client = MClient.get(getCtx(), whSource.getAD_Client_ID());
+			//
+			if (move == null
+				|| M_WarehouseSource_ID != replenish.getM_WarehouseSource_ID()
+				|| M_Warehouse_ID != replenish.getM_Warehouse_ID())
+			{
+				M_WarehouseSource_ID = replenish.getM_WarehouseSource_ID();
+				M_Warehouse_ID = replenish.getM_Warehouse_ID();
+				
+				move = new MMovement (getCtx(), 0, get_TrxName());
+				move.setC_DocType_ID(p_C_DocType_ID);
+				move.setDescription(Msg.getMsg(getCtx(), "Replenishment")
+					+ ": " + whSource.getName() + "->" + wh.getName());
+				//	Set Org
+				move.setAD_Org_ID(whSource.getAD_Org_ID());
+				if (!move.save())
+					return;
+				log.fine(move.toString());
+				noMoves++;
+				info += " - " + move.getDocumentNo();
+			}
+			//	To
+			int M_LocatorTo_ID = wh.getDefaultLocator().getM_Locator_ID();
+			//	From: Look-up Storage
+			MProduct product = MProduct.get(getCtx(), replenish.getM_Product_ID());
+			String MMPolicy = product.getMMPolicy();
+			MStorage[] storages = MStorage.getWarehouse(getCtx(), whSource.getM_Warehouse_ID(), 
+					replenish.getM_Product_ID(), 0, 
+					null, MClient.MMPOLICY_FiFo.equals(MMPolicy), false, 0,  get_TrxName());
+			BigDecimal target = replenish.getQtyToOrder();
+			for (int j = 0; j < storages.length; j++)
+			{
+				MStorage storage = storages[j];
+				if (storage.getQtyOnHand().signum() <= 0)
+					continue;
+				BigDecimal moveQty = target;
+				if (storage.getQtyOnHand().compareTo(moveQty) < 0)
+					moveQty = storage.getQtyOnHand();
+				//
+				MMovementLine line = new MMovementLine(move);
+				line.setM_Product_ID(replenish.getM_Product_ID());
+				line.setMovementQty(moveQty);
+				if (replenish.getQtyToOrder().compareTo(moveQty) != 0)
+					line.setDescription("Total: " + replenish.getQtyToOrder());
+				line.setM_Locator_ID(storage.getM_Locator_ID());		//	from
+				line.setM_AttributeSetInstance_ID(storage.getM_AttributeSetInstance_ID());
+				line.setM_LocatorTo_ID(M_LocatorTo_ID);					//	to
+				line.setM_AttributeSetInstanceTo_ID(storage.getM_AttributeSetInstance_ID());
+				line.save();
+				//
+				target = target.subtract(moveQty);
+				if (target.signum() == 0)
+					break;
+			}
+		}
+		if (replenishs.length == 0)
+		{
+			m_info = "No Source Warehouse";
+			log.warning(m_info);
+		}
+		else
+		{
+			m_info = "#" + noMoves + info;
+			log.info(m_info);
+		}
+	}	//	Create Inventory Movements
+	
+	/**
+	 * 	Create Distribution Order
+	 */
+	private void createDO() throws Exception
+	{
+		int noMoves = 0;
+		String info = "";
+		//
+		MClient client = null;
+		MDDOrder order = null;
+		int M_Warehouse_ID = 0;
+		int M_WarehouseSource_ID = 0;
+		MWarehouse whSource = null;
+		MWarehouse wh = null;
+		X_T_Replenish[] replenishs = getReplenish("M_WarehouseSource_ID IS NOT NULL");
+		for (X_T_Replenish replenish:replenishs)
+		{
+			if (whSource == null || whSource.getM_WarehouseSource_ID() != replenish.getM_WarehouseSource_ID())
+				whSource = MWarehouse.get(getCtx(), replenish.getM_WarehouseSource_ID());
+			if (wh == null || wh.getM_Warehouse_ID() != replenish.getM_Warehouse_ID())
+				wh = MWarehouse.get(getCtx(), replenish.getM_Warehouse_ID());
+			if (client == null || client.getAD_Client_ID() != whSource.getAD_Client_ID())
+				client = MClient.get(getCtx(), whSource.getAD_Client_ID());
+			//
+			if (order == null
+				|| M_WarehouseSource_ID != replenish.getM_WarehouseSource_ID()
+				|| M_Warehouse_ID != replenish.getM_Warehouse_ID())
+			{
+				M_WarehouseSource_ID = replenish.getM_WarehouseSource_ID();
+				M_Warehouse_ID = replenish.getM_Warehouse_ID();
+				
+				order = new MDDOrder (getCtx(), 0, get_TrxName());
+				order.setC_DocType_ID(p_C_DocType_ID);
+				order.setDescription(Msg.getMsg(getCtx(), "Replenishment")
+					+ ": " + whSource.getName() + "->" + wh.getName());
+				//	Set Org
+				order.setAD_Org_ID(whSource.getAD_Org_ID());
+				// Set Org Trx
+				MOrg orgTrx = MOrg.get(getCtx(), wh.getAD_Org_ID());
+				order.setAD_OrgTrx_ID(orgTrx.getAD_Org_ID());
+				int C_BPartner_ID = orgTrx.getLinkedC_BPartner_ID(get_TrxName()); 
+				if (C_BPartner_ID==0)
+					throw new AdempiereUserError(Msg.translate(getCtx(), "C_BPartner_ID")+ " @FillMandatory@ ");
+				MBPartner bp = new MBPartner(getCtx(),C_BPartner_ID,get_TrxName());
+				// Set BPartner Link to Org
+				order.setBPartner(bp);
+				order.setDateOrdered(new Timestamp(System.currentTimeMillis()));
+				//order.setDatePromised(DatePromised);
+				order.setDeliveryRule(MDDOrder.DELIVERYRULE_Availability);
+				order.setDeliveryViaRule(MDDOrder.DELIVERYVIARULE_Delivery);
+				order.setPriorityRule(MDDOrder.PRIORITYRULE_Medium);
+				order.setIsInDispute(false);
+				order.setIsApproved(false);
+				order.setIsDropShip(false);
+				order.setIsDelivered(false);
+				order.setIsInTransit(false);
+				order.setIsPrinted(false);
+				order.setIsSelected(false);
+				order.setIsSOTrx(false);
+				// Warehouse in Transit
+				MWarehouse[] whsInTransit  = MWarehouse.getForOrg(getCtx(), whSource.getAD_Org_ID());
+				for (MWarehouse whInTransit:whsInTransit)
+				{
+					if(whInTransit.isInTransit())	
+					order.setM_Warehouse_ID(whInTransit.getM_Warehouse_ID());
+				}
+				if (order.getM_Warehouse_ID()==0)
+					throw new AdempiereUserError("Warehouse inTransit is @FillMandatory@ ");
+				
+				if (!order.save())
+					return;
+				log.fine(order.toString());
+				noMoves++;
+				info += " - " + order.getDocumentNo();
+			}
+		
+			//	To
+			int M_LocatorTo_ID = wh.getDefaultLocator().getM_Locator_ID();
+			int M_Locator_ID = whSource.getDefaultLocator().getM_Locator_ID();
+			if(M_LocatorTo_ID == 0 || M_Locator_ID==0)
+			throw new AdempiereUserError(Msg.translate(getCtx(), "M_Locator_ID")+" @FillMandatory@ ");
+			
+			//	From: Look-up Storage
+			/*MProduct product = MProduct.get(getCtx(), replenish.getM_Product_ID());
+			MProductCategory pc = MProductCategory.get(getCtx(), product.getM_Product_Category_ID());
+			String MMPolicy = pc.getMMPolicy();
+			if (MMPolicy == null || MMPolicy.length() == 0)
+				MMPolicy = client.getMMPolicy();
+			//
+			MStorage[] storages = MStorage.getWarehouse(getCtx(), 
+				whSource.getM_Warehouse_ID(), replenish.getM_Product_ID(), 0, 0,
+				true, null, 
+				MClient.MMPOLICY_FiFo.equals(MMPolicy), get_TrxName());
+			
+			
+			BigDecimal target = replenish.getQtyToOrder();
+			for (int j = 0; j < storages.length; j++)
+			{
+				MStorage storage = storages[j];
+				if (storage.getQtyOnHand().signum() <= 0)
+					continue;
+				BigDecimal moveQty = target;
+				if (storage.getQtyOnHand().compareTo(moveQty) < 0)
+					moveQty = storage.getQtyOnHand();
+				//
+				MDDOrderLine line = new MDDOrderLine(order);
+				line.setM_Product_ID(replenish.getM_Product_ID());
+				line.setQtyEntered(moveQty);
+				if (replenish.getQtyToOrder().compareTo(moveQty) != 0)
+					line.setDescription("Total: " + replenish.getQtyToOrder());
+				line.setM_Locator_ID(storage.getM_Locator_ID());		//	from
+				line.setM_AttributeSetInstance_ID(storage.getM_AttributeSetInstance_ID());
+				line.setM_LocatorTo_ID(M_LocatorTo_ID);					//	to
+				line.setM_AttributeSetInstanceTo_ID(storage.getM_AttributeSetInstance_ID());
+				line.setIsInvoiced(false);
+				line.save();
+				//
+				target = target.subtract(moveQty);
+				if (target.signum() == 0)
+					break;
+			}*/
+			
+			MDDOrderLine line = new MDDOrderLine(order);
+			line.setM_Product_ID(replenish.getM_Product_ID());
+			line.setQty(replenish.getQtyToOrder());
+			if (replenish.getQtyToOrder().compareTo(replenish.getQtyToOrder()) != 0)
+				line.setDescription("Total: " + replenish.getQtyToOrder());
+			line.setM_Locator_ID(M_Locator_ID);		//	from
+			line.setM_AttributeSetInstance_ID(0);
+			line.setM_LocatorTo_ID(M_LocatorTo_ID);					//	to
+			line.setM_AttributeSetInstanceTo_ID(0);
+			line.setIsInvoiced(false);
+			line.save();
+			
+		}
+		if (replenishs.length == 0)
+		{
+			m_info = "No Source Warehouse";
+			log.warning(m_info);
+		}
+		else
+		{
+			m_info = "#" + noMoves + info;
+			log.info(m_info);
+		}
+	}	//	create Distribution Order
+	/**
+	 * 	Create Production
+	 */
+	private void createProduction()
+	{
+		int noProds = 0;
+		String info = "";
+		//
+		MProduction production = null;
+		MWarehouse wh = null;
+		X_T_Replenish[] replenishs = getReplenish("M_WarehouseSource_ID IS NULL " +
+				"AND EXISTS (SELECT * FROM M_Product p WHERE p.M_Product_ID=T_Replenish.M_Product_ID " +
+				"AND p.IsBOM='Y' AND p.IsManufactured='Y') ");
+		for (int i = 0; i < replenishs.length; i++)
+		{
+			X_T_Replenish replenish = replenishs[i];
+			if (wh == null || wh.getM_Warehouse_ID() != replenish.getM_Warehouse_ID())
+				wh = MWarehouse.get(getCtx(), replenish.getM_Warehouse_ID());
+			
+			BigDecimal batchQty = null;
+			BigDecimal qtyToProduce = replenish.getQtyToOrder();
+			
+			while ( qtyToProduce.compareTo(Env.ZERO) > 0)
+			{
+				BigDecimal qty = qtyToProduce;
+				if ( batchQty != null && batchQty.compareTo(Env.ZERO) > 0 && qtyToProduce.compareTo(batchQty) > 0)
+				{
+					qty = batchQty;
+					qtyToProduce = qtyToProduce.subtract(batchQty);
+				}
+				else
+				{
+					qtyToProduce = Env.ZERO;
+				}
+				production = new MProduction (getCtx(), 0, get_TrxName());
+				production.setDescription(Msg.getMsg(getCtx(), "Replenishment"));
+				//	Set Org/WH
+				production.setAD_Org_ID(wh.getAD_Org_ID());
+				production.setM_Locator_ID(wh.getDefaultLocator().get_ID());
+				production.setM_Product_ID(replenish.getM_Product_ID());
+				production.setProductionQty(qty);
+				production.setMovementDate(Env.getContextAsDate(getCtx(), "#Date"));
+				production.saveEx();
+				//	Process
+				production.setDocAction(DocAction.ACTION_Complete);
+				production.processIt(DocAction.ACTION_Complete);
+				production.saveEx(get_TrxName());
+				log.fine(production.toString());
+				noProds++;
+				info += " - " + production.getDocumentNo();
+			}
+
+		}
+		m_info = "#" + noProds + info;
+		log.info(m_info);
+	}	//	createRequisition
+
+	/**
+	 * 	Get Replenish Records
+	 *	@return replenish
+	 */
+	private X_T_Replenish[] getReplenish (String where)
+	{
+		String sql = "SELECT * FROM T_Replenish "
+			+ "WHERE AD_PInstance_ID=? ";
+		if (where != null && where.length() > 0)
+			sql += " AND " + where;
+		sql	+= " ORDER BY M_Warehouse_ID, M_WarehouseSource_ID, C_BPartner_ID";
+		ArrayList<X_T_Replenish> list = new ArrayList<X_T_Replenish>();
+		PreparedStatement pstmt = null;
+		try
+		{
+			pstmt = DB.prepareStatement (sql, get_TrxName());
+			pstmt.setInt (1, getAD_PInstance_ID());
+			ResultSet rs = pstmt.executeQuery ();
+			while (rs.next ())
+				list.add (new X_T_Replenish (getCtx(), rs, get_TrxName()));
+			rs.close ();
+			pstmt.close ();
+			pstmt = null;
+		}
+		catch (Exception e)
+		{
+			log.log(Level.SEVERE, sql, e);
+		}
+		try
+		{
+			if (pstmt != null)
+				pstmt.close ();
+			pstmt = null;
+		}
+		catch (Exception e)
+		{
+			pstmt = null;
+		}
+		X_T_Replenish[] retValue = new X_T_Replenish[list.size ()];
+		list.toArray (retValue);
+		return retValue;
+	}	//	getReplenish
+	
+
+}	//	Replenish

--- a/src/patches/org/compiere/project/process/ProjectGenPO.java
+++ b/src/patches/org/compiere/project/process/ProjectGenPO.java
@@ -1,0 +1,300 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 1999-2006 ComPiere, Inc. All Rights Reserved.                *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * ComPiere, Inc., 2620 Augustine Dr. #245, Santa Clara, CA 95054, USA        *
+ * or via info@compiere.org or http://www.compiere.org/license.html           *
+ *****************************************************************************/
+package org.compiere.project.process;
+
+import org.adempiere.core.domains.models.I_C_ProjectPhase;
+import org.adempiere.core.domains.models.I_C_ProjectTask;
+import org.compiere.model.MBPartner;
+import org.compiere.model.MConversionRate;
+import org.compiere.model.MOrder;
+import org.compiere.model.MOrderLine;
+import org.compiere.model.MPriceList;
+import org.compiere.model.MProductPO;
+import org.compiere.model.MProject;
+import org.compiere.model.MProjectLine;
+import org.compiere.model.MProjectPhase;
+import org.compiere.model.MProjectTask;
+import org.compiere.model.PO;
+import org.compiere.model.Query;
+import org.compiere.util.Env;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ *  Generate Purchase Order from Project.
+ *
+ *	@author Jorg Janke
+ *	@version $Id: ProjectGenPO.java,v 1.2 2006/07/30 00:51:01 jjanke Exp $
+ */
+public class ProjectGenPO extends ProjectGenPOAbstract
+{
+	private ArrayList<MOrder>	orders = new ArrayList<MOrder>();
+
+	/**
+	 *  Prepare - e.g., get Parameters.
+	 */
+	protected void prepare()
+	{
+		super.prepare();
+	}	//	prepare
+
+	/**
+	 *  Perform process.
+	 *  @return Message 
+	 *  @throws Exception if not successful
+	 */
+	protected String doIt() throws Exception
+	{
+		log.info("doIt - C_Project_ID=" + getProjectId() + " - C_ProjectLine_ID=" + getProjectLineId() + " - Consolidate=" + isConsolidateDocument());
+		if (getProjectId() != 0)
+		{
+			MProjectLine projectLine = new MProjectLine(getCtx(), getProjectLineId(), get_TrxName());
+			MProject project = new MProject (getCtx(), projectLine.getC_Project_ID(), get_TrxName());
+			createPO (project, projectLine);
+		}
+		else
+		{
+			MProject project = new MProject (getCtx(), getProjectId(), get_TrxName());
+			project.getLines().stream().forEach( projectLine -> createPO (project, projectLine));
+		}
+		return "";
+	}	//	doIt
+
+    /**
+     * Create PO from Planned Amt/Qty
+     *
+     * @param projectLine project line
+     */
+    private void createPO(MProject project, MProjectLine projectLine) {
+        if (projectLine.getM_Product_ID() == 0) {
+            addLog(projectLine.getLine(), null, null, "Line has no Product");
+            return;
+        }
+        if (projectLine.getC_OrderPO_ID() != 0) {
+            addLog(projectLine.getLine(), null, null, "Line was ordered previously");
+            return;
+        }
+
+        //	PO Record
+        List<MProductPO> productPurchaseList = MProductPO.getByPartnerAndOrg(getCtx(), getVendorId(), projectLine.getM_Product_ID(), projectLine.getAD_Org_ID(), get_TrxName());
+        if (getVendorId() <= 0 && (productPurchaseList == null || productPurchaseList.size() == 0)) {
+            addLog(projectLine.getLine(), null, null, "Product has no PO record");
+            return;
+        }
+
+        MProductPO productPurchase = productPurchaseList.stream()
+                .findFirst()
+                .orElseGet(() -> new MProductPO(getCtx(), projectLine.getM_Product_ID(), getVendorId(), project.getC_Currency_ID(), projectLine.getAD_Org_ID(), get_TrxName())
+                );
+
+        MOrder pruchaseOrder = orders.stream()
+                .filter(order -> order.getC_BPartner_ID() == productPurchase.getC_BPartner_ID())
+                .findFirst()
+                .orElseGet(() -> createOrder(project, projectLine, productPurchase.getC_BPartner_ID()));
+        createOrderLine(pruchaseOrder, projectLine, productPurchase);
+    }    //	createPOfromProjectLine
+
+    private MOrder createOrder(MProject project, MProjectLine projectLine, Integer partnerId) {
+        Optional<I_C_ProjectPhase> optionalProjectPhase = Optional.ofNullable(projectLine.getC_ProjectPhase());
+        Optional<I_C_ProjectTask> optionalProjectTask = Optional.ofNullable(projectLine.getC_ProjectTask());
+
+        //	Vendor
+        MBPartner vendor = new MBPartner(getCtx(), partnerId, get_TrxName());
+        //	New Order
+        MOrder order = new MOrder(getCtx(), 0, get_TrxName());
+        order.setClientOrg(projectLine.getAD_Client_ID(), projectLine.getAD_Org_ID());
+        order.setIsSOTrx(false);
+        order.setDescription(project.getName());
+        optionalProjectPhase.ifPresent(projectPhase -> {
+            setDimension(
+                    order,
+                    project.getC_Project_ID(),
+                    projectPhase.getC_ProjectPhase_ID(),
+                    -1,
+                    projectPhase.getResponsible_ID(),
+                    projectPhase.getC_Activity_ID(),
+                    projectPhase.getC_Campaign_ID(),
+                    projectPhase.getAD_OrgTrx_ID(),
+                    projectPhase.getUser1_ID(),
+                    projectPhase.getUser2_ID(),
+                    projectPhase.getUser3_ID(),
+                    projectPhase.getUser4_ID());
+        });
+
+        optionalProjectTask.ifPresent(projectTask -> {
+            setDimension(
+                    order,
+                    project.getC_Project_ID(),
+                    projectTask.getC_ProjectPhase_ID(),
+                    projectTask.getC_ProjectTask_ID(),
+                    projectTask.getResponsible_ID(),
+                    projectTask.getC_Activity_ID(),
+                    projectTask.getC_Campaign_ID(),
+                    projectTask.getAD_OrgTrx_ID(),
+                    projectTask.getUser1_ID(),
+                    projectTask.getUser2_ID(),
+                    projectTask.getUser3_ID(),
+                    projectTask.getUser4_ID());
+        });
+        order.setPriorityRule(projectLine.getPriorityRule());
+        order.setDateOrdered(projectLine.getDateOrdered());
+        order.setDatePromised(projectLine.getDatePromised());
+        //
+        order.setBPartner(vendor);
+        if (order.getM_PriceList_ID() <= 0) {
+            MPriceList priceList = getPriceList(project.getC_Currency_ID());
+            order.setM_PriceList_ID(priceList.getM_PriceList_ID());
+        }
+
+        order.setAD_User_ID(project.getAD_User_ID());
+        order.setM_Warehouse_ID(project.getM_Warehouse_ID());
+        order.setC_DocTypeTarget_ID();
+        int orgId = projectLine.getAD_Org_ID();
+        if (orgId == 0) {
+            log.warning("createPOfromProjectLine - AD_Org_ID=0");
+            orgId = Env.getAD_Org_ID(getCtx());
+            if (orgId != 0)
+                projectLine.setAD_Org_ID(orgId);
+        }
+
+        order.saveEx();
+        //	optionally save for consolidation
+        if (isConsolidateDocument())
+            orders.add(order);
+
+        return order;
+    }
+
+    /**
+     * Set Dimension
+     *
+     * @param instance
+     * @param responsibleId
+     * @param activityId
+     * @param campaignId
+     * @param orgTrxId
+     * @param user1Id
+     * @param user2Id
+     * @param user3Id
+     * @param user4Id
+     */
+    private void setDimension(
+            PO instance,
+            Integer projectId,
+            Integer projectPhaseId,
+            Integer projectTaskId,
+            Integer responsibleId,
+            Integer activityId,
+            Integer campaignId,
+            Integer orgTrxId,
+            Integer user1Id,
+            Integer user2Id,
+            Integer user3Id,
+            Integer user4Id) {
+        if (instance.get_ColumnIndex(MProject.COLUMNNAME_C_Project_ID) > 0 && projectId > 0)
+            instance.set_ValueOfColumn(MProject.COLUMNNAME_C_Project_ID, projectId);
+        if (instance.get_ColumnIndex(MProjectPhase.COLUMNNAME_C_ProjectPhase_ID) > 0 && projectPhaseId > 0)
+            instance.set_ValueOfColumn(MProjectPhase.COLUMNNAME_C_ProjectPhase_ID, projectPhaseId);
+        if (instance.get_ColumnIndex(MProjectTask.COLUMNNAME_C_ProjectTask_ID) > 0 && projectTaskId > 0)
+            instance.set_ValueOfColumn(MProjectTask.COLUMNNAME_C_ProjectTask_ID, projectTaskId);
+        if (instance.get_ColumnIndex(MProject.COLUMNNAME_SalesRep_ID) > 0 && responsibleId > 0)
+            instance.set_ValueOfColumn(MProject.COLUMNNAME_SalesRep_ID, responsibleId);
+        if (instance.get_ColumnIndex(MProject.COLUMNNAME_C_Activity_ID) > 0 && activityId > 0)
+            instance.set_ValueOfColumn(MProject.COLUMNNAME_C_Activity_ID, activityId);
+        if (instance.get_ColumnIndex(MProject.COLUMNNAME_C_Campaign_ID) > 0 && campaignId > 0)
+            instance.set_ValueOfColumn(MProject.COLUMNNAME_C_Campaign_ID, campaignId);
+        if (instance.get_ColumnIndex(MProject.COLUMNNAME_AD_OrgTrx_ID) > 0 && orgTrxId > 0)
+            instance.set_ValueOfColumn(MProject.COLUMNNAME_AD_OrgTrx_ID, orgTrxId);
+        if (instance.get_ColumnIndex(MProject.COLUMNNAME_User1_ID) > 0 && user1Id > 0)
+            instance.set_ValueOfColumn(MProject.COLUMNNAME_User1_ID, user1Id);
+        if (instance.get_ColumnIndex(MProject.COLUMNNAME_User2_ID) > 0 && user2Id > 0)
+            instance.set_ValueOfColumn(MProject.COLUMNNAME_User2_ID, user2Id);
+        if (instance.get_ColumnIndex(MProject.COLUMNNAME_User3_ID) > 0 && user3Id > 0)
+            instance.set_ValueOfColumn(MProject.COLUMNNAME_User3_ID, user3Id);
+        if (instance.get_ColumnIndex(MProject.COLUMNNAME_User4_ID) > 0 && user4Id > 0)
+            instance.set_ValueOfColumn(MProject.COLUMNNAME_User4_ID, user4Id);
+    }
+
+    private MOrderLine createOrderLine(
+            MOrder order,
+            MProjectLine projectLine,
+            MProductPO productPurchase) {
+        MOrderLine orderLine = new MOrderLine(order);
+        orderLine.setM_Product_ID(projectLine.getM_Product_ID(), true);
+        orderLine.setQty(projectLine.getPlannedQty());
+        orderLine.setDescription(projectLine.getDescription());
+
+        //	(Vendor) PriceList Price
+        orderLine.setPrice();
+        if (orderLine.getPriceActual().signum() == 0) {
+            BigDecimal purchasePrice = productPurchase.getPricePO();
+            int currencyId = productPurchase.getC_Currency_ID();
+            //	Try to find purchase price
+            if (purchasePrice == null || purchasePrice.signum() == 0)
+                purchasePrice = productPurchase.getPriceLastPO();
+            if (purchasePrice == null || purchasePrice.signum() == 0)
+                purchasePrice = productPurchase.getPriceList();
+            //	We have a price
+            if (purchasePrice != null && purchasePrice.signum() != 0) {
+                if (order.getC_Currency_ID() != currencyId)
+                    purchasePrice = MConversionRate.convert(getCtx(), purchasePrice,
+                            currencyId, order.getC_Currency_ID(),
+                            order.getDateAcct(), order.getC_ConversionType_ID(),
+                            order.getAD_Client_ID(), order.getAD_Org_ID());
+                orderLine.setPrice(purchasePrice);
+            }
+        }
+        orderLine.setTax();
+        setDimension(
+                orderLine,
+                projectLine.getC_Project_ID(),
+                projectLine.getC_ProjectPhase_ID(),
+                projectLine.getC_ProjectTask_ID(),
+                order.getSalesRep_ID(),
+                order.getC_Activity_ID(),
+                order.getC_Campaign_ID(),
+                order.getAD_OrgTrx_ID(),
+                order.getUser1_ID(),
+                order.getUser2_ID(),
+                order.getUser3_ID(),
+                order.getUser4_ID());
+        orderLine.saveEx();
+        //	update ProjectLine
+        projectLine.setC_OrderPO_ID(order.getC_Order_ID());
+        projectLine.saveEx();
+        addLog(projectLine.getLine(), null, projectLine.getPlannedQty(), order.getDocumentNo());
+        return orderLine;
+    }
+
+    private MPriceList getPriceList(Integer currencyId) {
+        StringBuilder whereClause = new StringBuilder();
+        whereClause
+                .append(MPriceList.COLUMNNAME_C_Currency_ID).append("=? AND ")
+                .append(MPriceList.COLUMNNAME_IsSOPriceList).append("=?");
+        MPriceList priceList = new Query(getCtx(), MPriceList.Table_Name, whereClause.toString(), get_TrxName())
+                .setClient_ID()
+                .setParameters(currencyId, "N")
+                .setOrderBy(MPriceList.COLUMNNAME_IsDefault)
+                .first();
+
+        return priceList;
+
+    }
+}	//	ProjectGenPO

--- a/src/patches/org/eevolution/manufacturing/process/ImportProductPlanning.java
+++ b/src/patches/org/eevolution/manufacturing/process/ImportProductPlanning.java
@@ -1,0 +1,435 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 1999-2006 ComPiere, Inc. All Rights Reserved.                *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * ComPiere, Inc., 2620 Augustine Dr. #245, Santa Clara, CA 95054, USA        *
+ * or via info@compiere.org or http://www.compiere.org/license.html           *
+ * Contributor: victor.perez@e-evolution.com                                  *
+ *****************************************************************************/
+package org.eevolution.manufacturing.process;
+
+import org.adempiere.core.domains.models.I_C_BPartner;
+import org.adempiere.core.domains.models.I_DD_NetworkDistribution;
+import org.adempiere.core.domains.models.I_PP_Product_BOM;
+import org.adempiere.core.domains.models.I_S_Resource;
+import org.adempiere.core.domains.models.X_I_ProductPlanning;
+import org.adempiere.core.domains.models.X_S_Resource;
+import org.compiere.model.MColumn;
+import org.compiere.model.MOrg;
+import org.compiere.model.MProduct;
+import org.compiere.model.MProductPO;
+import org.compiere.model.MTable;
+import org.compiere.model.MWarehouse;
+import org.compiere.model.Query;
+import org.compiere.process.ProcessInfoParameter;
+import org.compiere.process.SvrProcess;
+import org.compiere.util.Env;
+import org.compiere.util.Msg;
+import org.eevolution.manufacturing.model.MPPProductPlanning;
+
+import java.util.List;
+import java.util.logging.Level;
+
+/**
+ * Import Product Planning
+ * 
+ * @author victor.perez@e-evolution.com, www.e-evolution.com
+ * @author alberto.juarez@e-evolution.com, www.e-evolution.com <li>Create new
+ *         importer for Planning Data <li>
+ *         http://sourceforge.net/support/tracker.php?aid=2952245
+ * @version
+ */
+public class ImportProductPlanning extends SvrProcess {
+	/** Is Imported */
+	private boolean isImported = false;
+	/** Delete old Imported */
+	private boolean p_DeleteOldImported = false;
+	/** Import if no Errors */
+	private boolean p_IsImportOnlyNoErrors = true;
+	/** Record Import **/
+	private int imported = 0;
+	/** No import records */
+	private int notimported = 0;
+
+	/**
+	 * Prepare - e.g., get Parameters.
+	 */
+	protected void prepare() {
+		ProcessInfoParameter[] paramaters = getParameter();
+		for (ProcessInfoParameter para : paramaters) {
+			String name = para.getParameterName();
+			if (para.getParameter() == null)
+				;
+			else if (name.equals("IsImportOnlyNoErrors"))
+				p_IsImportOnlyNoErrors = "Y".equals(para.getParameter());
+			else if (name.equals("DeleteOldImported"))
+				p_DeleteOldImported = "Y".equals(para.getParameter());
+			else
+				log.log(Level.SEVERE, "Unknown Parameter: " + name);
+		}
+	} // prepare
+
+	/**
+	 * Perform process.
+	 * 
+	 * @return Message
+	 * @throws Exception
+	 */
+	protected String doIt() throws Exception {
+
+		if (p_DeleteOldImported) {
+			int no = 0;
+			for (X_I_ProductPlanning ipp : getRecords(true, false)) {
+				ipp.deleteEx(true);
+				no++;
+			}
+			log.fine("Delete Old Impored =" + no);
+		}
+
+		// fill IDs using Search Key
+		fillIDValues();
+		// import record
+		importRecords();
+		return "Imported: " + imported + ", Not imported: " + notimported;
+		//
+	} // doIt
+
+	/**
+	 * import record using X_I_ProductPlanning table
+	 */
+	private void importRecords() {
+		for (X_I_ProductPlanning ipp : getRecords(false, p_IsImportOnlyNoErrors)) {
+			isImported = false;
+			MPPProductPlanning pp = importProductPlanning(ipp);
+			if (pp == null)
+				isImported = false;
+
+			if (isImported) {
+				ipp.setPP_Product_Planning_ID(pp.getPP_Product_Planning_ID());
+				ipp.setI_IsImported(true);
+				ipp.setProcessed(true);
+				ipp.setI_ErrorMsg("");
+				ipp.saveEx();
+				imported++;
+			} else {
+				ipp.setI_IsImported(false);
+				ipp.setProcessed(true);
+				ipp.saveEx();
+				notimported++;
+			}
+		}
+	}
+
+	/**
+	 * import record using X_I_ProductPlanning table
+	 * 
+	 * @param ipp
+	 *            X_I_ProductPlanning
+	 */
+	private MPPProductPlanning importProductPlanning(X_I_ProductPlanning ipp) {
+		try {
+
+			MPPProductPlanning pp = null;
+
+			if (ipp.getPP_Product_Planning_ID() > 0)
+				pp = new MPPProductPlanning(getCtx(),
+						ipp.getPP_Product_Planning_ID(), get_TrxName());
+			else {
+				pp = MPPProductPlanning.get(getCtx(), ipp.getAD_Client_ID(),
+						ipp.getAD_Org_ID(), ipp.getM_Warehouse_ID(),
+						ipp.getS_Resource_ID(), ipp.getM_Product_ID(),
+						get_TrxName());
+			}
+
+			if (pp == null || pp.get_ID() <= 0) {
+				pp = new MPPProductPlanning(Env.getCtx(), 0, get_TrxName());
+				pp.setAD_Org_ID(ipp.getAD_Org_ID());
+				pp.setM_Product_ID(ipp.getM_Product_ID());
+				pp.setS_Resource_ID(ipp.getS_Resource_ID());
+				pp.setM_Warehouse_ID(ipp.getM_Warehouse_ID());
+				pp.setIsRequiredDRP(false);
+				pp.setIsRequiredMRP(false);
+			}
+
+			fillValue(pp, ipp);
+
+			if (ipp.getC_BPartner_ID() > 0 && ipp.getVendorProductNo() != null) {
+				importPurchaseProductPlanning(ipp);
+			}
+
+			pp.saveEx();
+			isImported = true;
+			return pp;
+		} catch (Exception e) {
+			ipp.setI_ErrorMsg(e.getMessage());
+			isImported = false;
+			return null;
+		}
+	}
+
+	/**
+	 * Import record using X_I_ProductPlanning table
+	 * 
+	 * @param ipp
+	 *            X_I_ProductPlanning
+	 */
+	private void importPurchaseProductPlanning(X_I_ProductPlanning ipp) {
+		MProduct product = MProduct.get(getCtx(), ipp.getM_Product_ID());
+		if (product.isPurchased()) {
+			final StringBuffer whereClause = new StringBuffer();
+			whereClause.append(MProductPO.COLUMNNAME_M_Product_ID).append(
+					"=? AND ");
+			whereClause.append(MProductPO.COLUMNNAME_C_BPartner_ID)
+					.append("=?");
+			whereClause.append(" AND AD_Org_ID in (0, ?)");
+			MProductPO productPO = new Query(getCtx(), MProductPO.Table_Name,
+					whereClause.toString(), get_TrxName())
+					.setClient_ID()
+					.setParameters(ipp.getM_Product_ID(),
+							ipp.getC_BPartner_ID(), ipp.getAD_Org_ID()).setOrderBy("AD_Org_ID DESC").first();
+
+			if (productPO == null) {
+				productPO = new MProductPO(getCtx(), 0, get_TrxName());
+				productPO.setAD_Org_ID(ipp.getAD_Org_ID());
+				productPO.setM_Product_ID(ipp.getM_Product_ID());
+				productPO.setC_BPartner_ID(ipp.getC_BPartner_ID());
+
+			}
+
+			productPO.setAD_Org_ID(ipp.getAD_Org_ID());
+			productPO.setOrder_Min(ipp.getOrder_Min());
+			productPO.setOrder_Pack(ipp.getOrder_Pack());
+			productPO.setDeliveryTime_Promised(ipp.getDeliveryTime_Promised()
+					.intValue());
+			productPO.setVendorProductNo(ipp.getVendorProductNo());
+			productPO.saveEx();
+		}
+
+	}
+
+	/**
+	 * fill MPPProductPlanning using I_ProductPlanning's values
+	 * 
+	 * @param pp
+	 *            MPPProductPlanning
+	 * @param ipp
+	 *            I_ProductPlanning
+	 */
+	private void fillValue(MPPProductPlanning pp, X_I_ProductPlanning ipp) {
+
+		for (MColumn col : getProductPlanningColumns()) {
+			if (!pp.is_new() && !col.isUpdateable()
+					&& ipp.get_ColumnIndex(col.getColumnName()) > 0)
+				continue;
+			
+			if(MPPProductPlanning.COLUMNNAME_IsRequiredDRP.equals(col.getColumnName()) || 
+			   MPPProductPlanning.COLUMNNAME_IsRequiredMRP.equals(col.getColumnName()) ||
+			   MPPProductPlanning.COLUMNNAME_PP_Product_Planning_ID.equals(col.getColumnName()))
+				continue;
+
+			if (ipp.get_Value(col.getColumnName()) != null
+					&& pp.get_Value(col.getColumnName()) != null
+					&& pp.get_Value(col.getColumnName()).equals(
+							ipp.get_Value(col.getColumnName())))
+				continue;
+
+			pp.set_ValueOfColumn(col.getColumnName(),
+					ipp.get_Value(col.getColumnName()));
+
+		}
+		isImported = true;
+		return;
+	}
+
+	/**
+	 * get Product Planning Columns
+	 * 
+	 * @return array MColumn
+	 */
+	private MColumn[] getProductPlanningColumns() {
+		return MTable.get(getCtx(), MPPProductPlanning.Table_Name).getColumns(
+				false);
+	}
+
+	/**
+	 * fill IDs values based on Search Key
+	 */
+	private void fillIDValues() {
+		for (X_I_ProductPlanning ppi : getRecords(false, p_IsImportOnlyNoErrors)) {
+
+			int AD_Org_ID = 0;
+			if (ppi.getAD_Org_ID() > 0)
+				AD_Org_ID = getID(MOrg.Table_Name, "AD_Org_ID = ?",
+						ppi.getAD_Org_ID());
+
+			if (AD_Org_ID <= 0 && ppi.getOrgValue() != null) {
+				AD_Org_ID = getID(MOrg.Table_Name, "Value = ?",
+						ppi.getOrgValue());
+				ppi.setAD_Org_ID(AD_Org_ID);
+			} else
+				ppi.setAD_Org_ID(AD_Org_ID);
+
+			int C_BPartner_ID = 0;
+			if (ppi.getC_BPartner_ID() == 0)
+				C_BPartner_ID = getID(I_C_BPartner.Table_Name,
+						I_C_BPartner.COLUMNNAME_C_BPartner_ID + "=?",
+						ppi.getC_BPartner_ID());
+
+			if (C_BPartner_ID <= 0 && ppi.getBPartner_Value() != null) {
+				C_BPartner_ID = getID(I_C_BPartner.Table_Name,
+						I_C_BPartner.COLUMNNAME_Value + "=?",
+						ppi.getBPartner_Value());
+				ppi.setC_BPartner_ID(C_BPartner_ID);
+			} else
+				ppi.setC_BPartner_ID(C_BPartner_ID);
+
+			// Product
+			int M_Product_ID = 0;
+			if (ppi.getM_Product_ID() > 0)
+				M_Product_ID = getID(MProduct.Table_Name, "M_Product_ID = ?",
+						ppi.getM_Product_ID());
+
+			if (M_Product_ID <= 0 && ppi.getProductValue() != null) {
+				M_Product_ID = getID(MProduct.Table_Name, "Value = ?",
+						ppi.getProductValue());
+				ppi.setM_Product_ID(M_Product_ID);
+			} else
+				ppi.setM_Product_ID(M_Product_ID);
+
+			// Warehouse
+			int M_Warehouse_ID = 0;
+			if (ppi.getM_Warehouse_ID() > 0)
+				M_Warehouse_ID = getID(MWarehouse.Table_Name,
+						"M_Warehouse_ID = ?", ppi.getM_Warehouse_ID());
+
+			if (M_Warehouse_ID <= 0 && ppi.getWarehouseValue() != null) {
+				M_Warehouse_ID = getID(MWarehouse.Table_Name, "Value = ?",
+						ppi.getWarehouseValue());
+				ppi.setM_Warehouse_ID(M_Warehouse_ID);
+			} else
+				ppi.setM_Warehouse_ID(M_Warehouse_ID);
+
+			int DD_NetworkDistribution_ID = 0;
+			if (ppi.getDD_NetworkDistribution_ID() > 0)
+				DD_NetworkDistribution_ID = getID(
+						I_DD_NetworkDistribution.Table_Name,
+						I_DD_NetworkDistribution.COLUMNNAME_DD_NetworkDistribution_ID
+								+ " = ?", ppi.getDD_NetworkDistribution_ID());
+
+			if (DD_NetworkDistribution_ID <= 0
+					&& ppi.getNetworkDistributionValue() != null) {
+				DD_NetworkDistribution_ID = getID(
+						I_DD_NetworkDistribution.Table_Name,
+						I_DD_NetworkDistribution.COLUMNNAME_Value + "= ?",
+						ppi.getNetworkDistributionValue());
+				ppi.setDD_NetworkDistribution_ID(DD_NetworkDistribution_ID);
+			} else
+				ppi.setDD_NetworkDistribution_ID(DD_NetworkDistribution_ID);
+
+			int PP_Product_BOM_ID = 0;
+			if (ppi.getPP_Product_BOM_ID() > 0)
+				PP_Product_BOM_ID = getID(I_PP_Product_BOM.Table_Name,
+						I_PP_Product_BOM.COLUMNNAME_PP_Product_BOM_ID + "= ?",
+						ppi.getPP_Product_BOM_ID());
+
+			if (PP_Product_BOM_ID <= 0 && ppi.getProduct_BOM_Value() != null) {
+				PP_Product_BOM_ID = getID(I_PP_Product_BOM.Table_Name,
+						I_PP_Product_BOM.COLUMNNAME_Value + "= ?",
+						ppi.getProduct_BOM_Value());
+				ppi.setPP_Product_BOM_ID(PP_Product_BOM_ID);
+			} else
+				ppi.setPP_Product_BOM_ID(PP_Product_BOM_ID);
+
+			int S_Resource_ID = 0;
+			if (ppi.getS_Resource_ID() > 0)
+				S_Resource_ID = getID(I_S_Resource.Table_Name,
+						I_S_Resource.COLUMNNAME_S_Resource_ID + "= ?",
+						ppi.getS_Resource_ID());
+
+			if (S_Resource_ID <= 0 && ppi.getResourceValue() != null) {
+				S_Resource_ID = getID(
+						I_S_Resource.Table_Name,
+						I_S_Resource.COLUMNNAME_Value
+								+ "=? AND "
+								+ I_S_Resource.COLUMNNAME_ManufacturingResourceType
+								+ "=?", ppi.getResourceValue(),
+						X_S_Resource.MANUFACTURINGRESOURCETYPE_Plant);
+				ppi.setS_Resource_ID(S_Resource_ID);
+			} else
+				ppi.setS_Resource_ID(S_Resource_ID);
+
+			ppi.saveEx();
+
+			StringBuffer err = new StringBuffer("");
+			if (ppi.getAD_Org_ID() <= 0)
+				err.append(" @AD_Org_ID@ @NotFound@,");
+
+			if (ppi.getM_Product_ID() <= 0)
+				err.append(" @M_Product_ID@ @NotFound@,");
+
+			// if (ppi.getM_Warehouse_ID() <= 0)
+			// err.append(" @M_Warehouse_ID@ @NotFound@,");
+
+			// if (ppi.getC_BPartner_ID() <= 0)
+			// err.append(" @S_Resource_ID@ @NotFound@,");
+
+			if (err.toString() != null && err.toString().length() > 0) {
+				notimported++;
+				ppi.setI_ErrorMsg(Msg.parseTranslation(getCtx(), err.toString()));
+				ppi.saveEx();
+			}
+
+		}
+	}
+
+	/**
+	 * get a record's ID
+	 * 
+	 * @param tableName
+	 *            String
+	 * @param whereClause
+	 *            String
+	 * @param values
+	 *            Object[]
+	 * @return unique record's ID in the table
+	 */
+	private int getID(String tableName, String whereClause,
+			Object... parameters) {
+		return new Query(getCtx(), tableName, whereClause, get_TrxName())
+				.setParameters(parameters).firstId();
+	}
+
+	/**
+	 * get all records in X_I_ProductPlanning table
+	 * 
+	 * @param imported
+	 *            boolean
+	 * @param isWithError
+	 *            boolean
+	 * @return List of X_I_ProductPlanning records
+	 */
+	private List<X_I_ProductPlanning> getRecords(boolean imported,
+			boolean isWithError) {
+		final StringBuffer whereClause = new StringBuffer(
+				X_I_ProductPlanning.COLUMNNAME_I_IsImported).append("=?");
+
+		if (isWithError) {
+			whereClause.append(" AND ")
+					.append(X_I_ProductPlanning.COLUMNNAME_I_ErrorMsg)
+					.append(" IS NULL");
+		}
+
+		return new Query(getCtx(), X_I_ProductPlanning.Table_Name,
+				whereClause.toString(), get_TrxName()).setClient_ID()
+				.setParameters(imported).list();
+	}
+} // Import Product Planning

--- a/src/patches/org/eevolution/process/ValuationEffectiveDate.java
+++ b/src/patches/org/eevolution/process/ValuationEffectiveDate.java
@@ -1,0 +1,304 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * Copyright (C) 2003-2010 e-Evolution,SC. All Rights Reserved.               *
+ * Contributor(s): victor.perez@e-evolution.com http://www.e-evolution.com    *
+ *****************************************************************************/
+package org.eevolution.process;
+
+import org.adempiere.core.domains.models.I_M_Product;
+import org.compiere.model.MAcctSchema;
+import org.compiere.model.MCostElement;
+import org.compiere.model.MCostType;
+import org.compiere.model.MWarehouse;
+import org.compiere.model.Query;
+import org.compiere.util.DB;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Regenerate Cost Detail
+ * 
+ * @author victor.perez@e-evolution.com, www.e-evolution.com
+ */
+public class ValuationEffectiveDate extends ValuationEffectiveDateAbstract {
+
+	private List<MAcctSchema> acctSchemas = new ArrayList<MAcctSchema>();
+	private List<MCostType> costTypes = new ArrayList<MCostType>();
+	private List<MCostElement> costElements = new ArrayList<MCostElement>();
+	private List<MWarehouse> warehouses = new ArrayList<MWarehouse>();
+	private int[] products = {};
+
+	private StringBuffer whereClause1 = null;
+	private StringBuffer whereClause2 = null;
+	PreparedStatement pstmt = null;
+	private int batchSize = 1000;
+	private int count = 0;
+
+	/**
+	 * Prepare - e.g., get Parameters.
+	 */
+	protected void prepare() {
+		super.prepare();
+	} // prepare
+
+	/**
+	 * execute the Valuation Effective Date
+	 */
+	protected String doIt() throws Exception {
+		setup();
+		for (MAcctSchema acctSchema : acctSchemas)
+			for (MWarehouse warehouse : warehouses)
+				for (MCostType costType : costTypes)
+					for (MCostElement costElement : costElements)
+						for (int productId : products)
+							generateInventoryValue(
+									productId ,
+									acctSchema.getC_AcctSchema_ID(),
+									acctSchema.getC_Currency_ID(),
+									costType.getM_CostType_ID(),
+									costElement.getM_CostElement_ID(),
+									warehouse.getM_Warehouse_ID()
+							);
+
+		pstmt.executeBatch();
+		commitEx();
+		DB.close(pstmt);
+		updatePricePO();
+		for (MAcctSchema acctSchema: acctSchemas) {
+			int no = 0;
+			String whereSeq = " (SELECT MAX(SeqNo) FROM M_CostDetail " + 
+					" WHERE IsReversal='N' AND M_Product_ID=iv.M_Product_ID AND iv.M_CostType_ID=cd.M_CostType_ID AND iv.C_AcctSchema_ID=cd.C_AcctSchema_ID AND iv.M_CostElement_ID=cd.M_Costelement_ID AND DateAcct <=?))";
+			if (acctSchema.getCostingLevel().equals(MAcctSchema.COSTINGLEVEL_Client)) {
+				ArrayList<Object> params = new ArrayList<>();
+				params.add(getDateValue());
+				params.add(getDateValue());
+				params.add(getDateValue());
+				params.add(getAD_PInstance_ID());
+				StringBuffer update1 = new StringBuffer( "UPDATE T_InventoryValue iv ")
+						.append(" set costamt = (SELECT COALESCE(CurrentCostPrice,0) FROM RV_M_Transaction_Costing cd WHERE iv.M_Product_ID=cd.M_Product_ID AND cd.SeqNo= ")
+						.append(whereSeq);
+				update1.append(", costamtll = (SELECT COALESCE(CurrentCostPriceLL) FROM RV_M_Transaction_Costing cd WHERE iv.M_Product_ID=cd.M_Product_ID AND cd.SeqNo= ")
+				.append(whereSeq);
+				//update1.append(" ,cumulatedamt = (select endingqtybalance from rv_m_transaction_costing cd where iv.m_Product_ID=cd.m_Product_ID and cd.seqno= ")
+				//.append(whereSeq);
+				update1.append(", DateValue = ? WHERE iv.AD_PInstance_ID=?");
+				no = DB.executeUpdateEx(update1.toString(), params.toArray(), get_TrxName());		
+				int i = no;
+				commitEx();
+				String update2 = "UPDATE T_InventoryValue set CumulatedAmt = (CostAmt +CostAmtLL)*QtyonHand WHERE AD_PInstance_ID=?";
+				DB.executeUpdate(update2, getAD_PInstance_ID(), get_TrxName());
+			}
+			if (acctSchema.getCostingLevel().equals(MAcctSchema.COSTINGLEVEL_Warehouse)) {
+				no = DB.executeUpdate("UPDATE T_InventoryValue SET Cost = CASE WHEN QtyOnHand <> 0 THEN (CostAmt + CostAmtLL) / QtyOnHand ELSE  0 END  ,  CumulatedAmt = CASE WHEN QtyOnHand <> 0  THEN  CostAmt + CostAmtLL ELSE 0 END ,  DateValue = "
+						+ DB.TO_DATE(getDateValue()) + " WHERE AD_PInstance_ID=?",
+				getAD_PInstance_ID(), get_TrxName());
+				int i=no;
+			}
+			
+		}
+
+		return "@Ok@ " + count;
+
+	}
+
+	/**
+	 * Update Price PO
+	 */
+	private void updatePricePO() {
+		//  Update Prices
+		StringBuffer update = new StringBuffer("UPDATE T_InventoryValue iv "
+			+ "SET PricePO = "
+				+ "(SELECT currencyConvert (po.PricePO,po.C_Currency_ID,iv.C_Currency_ID,iv.DateValue,null, po.AD_Client_ID,po.AD_Org_ID)"
+				+ " FROM M_Product_PO po WHERE po.M_Product_ID=iv.M_Product_ID"
+				+ " AND po.IsCurrentVendor='Y' and po.AD_Org_ID IN (0, iv.AD_Org_ID) ORDER BY po.AD_Org_ID DESC LIMIT 1) ");
+			if(getPriceListVersionId() != 0) {
+				update.append(", PriceList = "
+				+ "(SELECT currencyConvert(pp.PriceList,pl.C_Currency_ID,iv.C_Currency_ID,iv.DateValue,null, pl.AD_Client_ID,pl.AD_Org_ID)"
+				+ " FROM M_PriceList pl, M_PriceList_Version plv, M_ProductPrice pp"
+				+ " WHERE pp.M_Product_ID=iv.M_Product_ID AND pp.M_PriceList_Version_ID=iv.M_PriceList_Version_ID"
+				+ " AND pp.M_PriceList_Version_ID=plv.M_PriceList_Version_ID"
+				+ " AND plv.M_PriceList_ID=pl.M_PriceList_ID), "
+			+ "PriceStd = "
+				+ "(SELECT currencyConvert(pp.PriceStd,pl.C_Currency_ID,iv.C_Currency_ID,iv.DateValue,null, pl.AD_Client_ID,pl.AD_Org_ID)"
+				+ " FROM M_PriceList pl, M_PriceList_Version plv, M_ProductPrice pp"
+				+ " WHERE pp.M_Product_ID=iv.M_Product_ID AND pp.M_PriceList_Version_ID=iv.M_PriceList_Version_ID"
+				+ " AND pp.M_PriceList_Version_ID=plv.M_PriceList_Version_ID"
+				+ " AND plv.M_PriceList_ID=pl.M_PriceList_ID), "
+			+ "PriceLimit = "
+				+ "(SELECT currencyConvert(pp.PriceLimit,pl.C_Currency_ID,iv.C_Currency_ID,iv.DateValue,null, pl.AD_Client_ID,pl.AD_Org_ID)"
+				+ " FROM M_PriceList pl, M_PriceList_Version plv, M_ProductPrice pp"
+				+ " WHERE pp.M_Product_ID=iv.M_Product_ID AND pp.M_PriceList_Version_ID=iv.M_PriceList_Version_ID"
+				+ " AND pp.M_PriceList_Version_ID=plv.M_PriceList_Version_ID"
+				+ " AND plv.M_PriceList_ID=pl.M_PriceList_ID)");
+			}
+			//	Add general where clause
+			update.append(" WHERE iv.AD_PInstance_ID=").append(getAD_PInstance_ID());
+		//	Update
+		DB.executeUpdateEx (update.toString(), get_TrxName());
+	}
+	
+	/**
+	 * Setup the collections
+	 */
+	private void setup() {
+
+		if (getAcctSchemaId() > 0)
+			acctSchemas.add(MAcctSchema.get(getCtx(), getAcctSchemaId(), get_TrxName()));
+		else
+			acctSchemas = Arrays.asList(MAcctSchema.getClientAcctSchema(getCtx() , getAD_Client_ID()));
+		
+		if (getCostTypeId() > 0)
+			costTypes.add(new MCostType(getCtx(), getCostTypeId(), get_TrxName()));
+		else
+			costTypes = MCostType.get(getCtx(), get_TrxName());
+
+		if (getCostElementId() > 0)
+			costElements.add(MCostElement.get(getCtx(), getCostElementId()));
+		else
+			costElements = MCostElement.getCostElement(getCtx(), get_TrxName());
+
+		if (getWarehouseId() > 0)
+			warehouses.add(MWarehouse.get(getCtx(), getWarehouseId(), get_TrxName()));
+		else {
+			warehouses = new Query(getCtx(), MWarehouse.Table_Name, "", get_TrxName()).setClient_ID().list();
+		}
+		
+		if(getProductId() == 0)
+			products = new Query (getCtx() , I_M_Product.Table_Name , "" , get_TrxName()).setClient_ID().getIDs();
+		else
+			products = new int[] {getProductId()};
+		
+		setWhere();
+		
+		StringBuffer insert = new StringBuffer();
+		insert.append("INSERT INTO T_InventoryValue ")
+				.append("(AD_PInstance_ID,DateValue,AD_Client_ID,AD_Org_ID,C_AcctSchema_ID,M_CostElement_ID,M_CostType_ID,M_Warehouse_ID,")
+				.append("M_Product_ID,M_Product_Category_ID,M_AttributeSetInstance_ID,Group1,Group2,QtyOnHand,CostAmt,CostAmtLL, M_PriceList_Version_ID, C_Currency_ID) ")
+				.append("SELECT ")
+				.append(getAD_PInstance_ID())
+				.append(",")
+				.append("tc.DateAcct")
+				.append(",")
+				.append("p.AD_Client_ID,p.AD_Org_ID, tc.C_AcctSchema_ID ,tc.M_CostElement_ID,tc.M_CostType_ID, tc.M_Warehouse_ID,p.M_Product_ID,")
+				.append("p.M_Product_Category_ID,tc.M_AttributeSetInstance_ID,p.Group1,p.Group2,SUM(t.MovementQty) AS QtyOnHand,")
+				.append(" CASE WHEN tc.Qty < 0 OR (tc.qty = 0 AND tc.cumulatedqty < 0) THEN ((tc.costAmt + tc.costadjustment) * -1) + tc.CumulatedAmt ELSE ((tc.costAmt + tc.costadjustment) * 1) + tc.CumulatedAmt END  AS CostAmt,")
+				.append(" CASE WHEN tc.Qty < 0 OR (tc.qty = 0 AND tc.cumulatedqty < 0) THEN ((tc.costAmtLL + tc.costadjustmentLL) * -1)  + tc.CumulatedAmtLL ELSE ((tc.costAmtLL + tc.costadjustmentLL) * 1) + tc.CumulatedAmtLL END AS CostAmtLL, ")
+				.append(getPriceListVersionId() != 0? getPriceListVersionId(): "null").append(", ? ")
+				.append(" FROM M_Product p ")
+				.append(" INNER JOIN M_Transaction t ON (p.M_Product_ID = t.M_Product_ID) ")
+				.append(" INNER JOIN M_Locator l ON (l.M_Locator_ID = t.M_Locator_ID) ")
+				.append(" INNER JOIN M_CostDetail tc ON (p.M_Product_ID=tc.M_Product_ID) ");
+		insert.append(whereClause1).append(whereClause2);
+		
+		String groubByClause = "GROUP BY "
+								+ "tc.M_Warehouse_ID, "
+								+ "tc.DateAcct, "
+								+ "p.AD_Client_ID, "
+								+ "p.AD_Org_ID,  "
+								+ "tc.C_AcctSchema_ID , "
+								+ "tc.M_CostElement_ID, "
+								+ "tc.M_CostType_ID,  "
+								+ "tc.M_Warehouse_ID, "
+								+ "p.M_Product_ID, "
+								+ "p.M_Product_Category_ID, "
+								+ "tc.M_AttributeSetInstance_ID, "
+								+ "p.Group1, "
+								+ "p.Group2, "
+								+ "tc.Qty, "
+								+ "tc.cumulatedqty, "
+								+ "tc.costAmt, "
+								+ "tc.costadjustment, "
+								+ "tc.CumulatedAmt, "
+								+ "tc.costAmt, "
+								+ "tc.costadjustment, "
+								+ "tc.CumulatedAmt, "
+								+ "tc.costAmtLL, "
+								+ "tc.costadjustmentLL, "
+								+ "tc.CumulatedAmtLL ";
+		insert.append(groubByClause);
+		pstmt = DB.prepareStatement(insert.toString(),
+				ResultSet.TYPE_SCROLL_INSENSITIVE,
+				ResultSet.CONCUR_UPDATABLE, get_TrxName());
+	}
+
+	public void setWhere() {
+
+		whereClause1 = new StringBuffer("WHERE tc.IsReversal='N' ");
+		whereClause2 = new StringBuffer(
+				" AND tc.SeqNo = (SELECT MAX(SeqNo) FROM M_CostDetail tc1")
+				.append(" WHERE tc1.IsReversal='N' AND tc1.M_Product_ID=tc.M_Product_ID AND tc1.M_Warehouse_ID = tc.M_Warehouse_ID ");
+
+		whereClause1.append("AND tc.DateAcct<= ").append(DB.TO_DATE(getDateValue()));
+		whereClause2.append("AND tc1.DateAcct<= ").append(DB.TO_DATE(getDateValue()));
+		
+		whereClause1.append(" AND t.MovementDate<= ").append(DB.TO_DATE(getDateValue()));
+		whereClause1.append(" AND tc.M_Warehouse_ID = l.M_Warehouse_ID");
+		
+
+		whereClause1.append(" AND p.M_Product_ID=? ");
+
+		whereClause1.append(" AND tc.C_AcctSchema_ID=? ");
+		whereClause2.append(" AND tc1.C_AcctSchema_ID = tc.C_AcctSchema_ID");
+
+		whereClause1.append(" AND tc.M_CostType_ID =?  ");
+		whereClause2.append(" AND tc1.M_CostType_ID=tc.M_CostType_ID ");
+
+		whereClause1.append(" AND tc.M_CostElement_ID=? ");
+		whereClause2.append(" AND tc1.M_CostElement_ID = tc.M_CostElement_ID");
+		
+		whereClause1.append(" AND tc.M_Warehouse_ID=? ");
+		whereClause2.append(")");
+		//	
+		if (getProductCategoryId() > 0) {
+			whereClause1.append(" AND p.M_Product_Category_ID =? ");
+		}
+
+	}
+	
+	/**
+	 * Generate the Inventory Valuation
+	 * 
+	 * @throws SQLException
+	 */
+	private void generateInventoryValue(
+			int productId ,
+			int accountSchemaId,
+			int currencyId, 
+			int costTypeId,
+			int costElementId,
+			int warehouseId) throws SQLException {
+			
+			int index = 1;
+			pstmt.setInt(index++, currencyId);
+			pstmt.setInt(index++, productId);
+			pstmt.setInt(index++, accountSchemaId);
+			pstmt.setInt(index++, costTypeId);
+			pstmt.setInt(index++, costElementId);
+			pstmt.setInt(index++, warehouseId);
+			
+			if(getProductCategoryId() > 0)
+				pstmt.setInt(index++, getProductCategoryId());
+			
+			pstmt.addBatch();
+			
+			if(++count % batchSize == 0) {
+				pstmt.executeBatch();
+				commitEx();
+		    }
+	}
+}

--- a/src/patches/org/eevolution/wms/process/ReleaseInOutBound.java
+++ b/src/patches/org/eevolution/wms/process/ReleaseInOutBound.java
@@ -1,0 +1,410 @@
+/**********************************************************************
+ * This file is part of Adempiere ERP Bazaar                          * 
+ * http://www.adempiere.org                                           * 
+ *                                                                    * 
+ * Copyright (C) Victor Perez	                                      * 
+ * Copyright (C) Contributors                                         * 
+ *                                                                    * 
+ * This program is free software; you can redistribute it and/or      * 
+ * modify it under the terms of the GNU General Public License        * 
+ * as published by the Free Software Foundation; either version 2     * 
+ * of the License, or (at your option) any later version.             * 
+ *                                                                    * 
+ * This program is distributed in the hope that it will be useful,    * 
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of     * 
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the       * 
+ * GNU General Public License for more details.                       * 
+ *                                                                    * 
+ * You should have received a copy of the GNU General Public License  * 
+ * along with this program; if not, write to the Free Software        * 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,         * 
+ * MA 02110-1301, USA.                                                * 
+ *                                                                    * 
+ * Contributors:                                                      * 
+ *  - Victor Perez (victor.perez@e-evolution.com	 )                *
+ *                                                                    *
+ * Sponsors:                                                          *
+ *  - e-Evolution (http://www.e-evolution.com/)                       *
+ **********************************************************************/
+
+package org.eevolution.wms.process;
+
+import org.adempiere.core.domains.models.X_C_BP_Group;
+import org.adempiere.core.domains.models.X_C_DocType;
+import org.adempiere.core.domains.models.X_DD_Order;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.exceptions.NoVendorForProductException;
+import org.compiere.model.MBPartner;
+import org.compiere.model.MDocType;
+import org.compiere.model.MLocator;
+import org.compiere.model.MOrderLine;
+import org.compiere.model.MOrg;
+import org.compiere.model.MProduct;
+import org.compiere.model.MProductPO;
+import org.compiere.model.MRequisition;
+import org.compiere.model.MRequisitionLine;
+import org.compiere.model.MStorage;
+import org.compiere.model.MTable;
+import org.compiere.model.MUser;
+import org.compiere.model.MWarehouse;
+import org.compiere.print.MPrintFormat;
+import org.compiere.process.DocAction;
+import org.compiere.util.DB;
+import org.compiere.util.Env;
+import org.compiere.util.Msg;
+import org.compiere.wf.MWorkflow;
+import org.eevolution.distribution.model.MDDOrder;
+import org.eevolution.distribution.model.MDDOrderLine;
+import org.eevolution.manufacturing.exceptions.NoBPartnerLinkedforOrgException;
+import org.eevolution.manufacturing.exceptions.NoPlantForWarehouseException;
+import org.eevolution.manufacturing.model.MPPMRP;
+import org.eevolution.manufacturing.model.MPPOrder;
+import org.eevolution.manufacturing.model.MPPProductBOM;
+import org.eevolution.manufacturing.model.MPPProductPlanning;
+import org.eevolution.wms.engine.WMRuleEngine;
+import org.eevolution.wms.model.MWMInOutBound;
+import org.eevolution.wms.model.MWMInOutBoundLine;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * @author victor.perez@e-evolution.com, www.e-evolution.com
+ * @version $Id: $
+ */
+public class ReleaseInOutBound extends ReleaseInOutBoundAbstract {
+    private Timestamp today = new Timestamp(System.currentTimeMillis());
+    private MDDOrder orderDistribution;
+
+    /**
+     * Get Parameters
+     */
+    @Override
+    protected void prepare() {
+        super.prepare();
+    }
+
+    /**
+     * Process - Generate Export Format
+     *
+     * @return info
+     */
+    @Override
+    protected String doIt() throws Exception {
+        MLocator outBoundLocator = Optional.ofNullable(new MLocator(getCtx(), getLocatorId(), get_TrxName())).orElseThrow(() -> new AdempiereException("@M_Locator_ID@ @NotFound@"));
+        List<MWMInOutBoundLine> outBoundLines = (List<MWMInOutBoundLine>) getInstancesForSelection(get_TrxName());
+        Hashtable<Integer, MWMInOutBound> outboundOrders = new Hashtable<>();
+        //Complete Outbound Order
+        outBoundLines.forEach(outboundLine -> {
+            outboundLine.setM_LocatorTo_ID(outBoundLocator.getM_Locator_ID());
+            outboundLine.saveEx();
+            MWMInOutBound outboundOrder = outboundLine.getParent();
+            if (!outboundOrders.contains(outboundOrder.get_ID()))
+                outboundOrders.put(outboundOrder.get_ID(), outboundOrder);
+        });
+        // Complete selected order
+        outboundOrders.forEach((key, outboundOrder) -> {
+            if (DocAction.STATUS_Drafted.equals(outboundOrder.getDocStatus()) || DocAction.STATUS_InProgress.equals(outboundOrder.getDocStatus())) {
+                outboundOrder.setDocAction(DocAction.ACTION_Complete);
+                outboundOrder.processIt(DocAction.ACTION_Complete);
+                outboundOrder.saveEx();
+            }
+        });
+
+        outBoundLines.forEach(outboundLine -> {
+            // if the locator is same to pick then the storage are in outbound locator not is necessary create other Distribution Order
+            if (outboundLine.getDD_OrderLine_ID() > 0) {
+                MDDOrderLine orderDistributionLine = new MDDOrderLine(getCtx(), outboundLine.getDD_OrderLine_ID(), get_TrxName());
+                if (orderDistributionLine.getWM_InOutBoundLine_ID() <= 0) {
+                    orderDistributionLine.setWM_InOutBoundLine_ID(orderDistributionLine.getWM_InOutBoundLine_ID());
+                    orderDistributionLine.saveEx();
+                }
+                if (orderDistributionLine.getM_LocatorTo_ID() == outboundLine.getM_LocatorTo_ID())
+                    return;
+            }
+            BigDecimal qtySupply = createDistributionOrder(outboundLine);
+            if (isCreateSupply() && qtySupply.signum() > 0) {
+                Env.setContext(outboundLine.getCtx(), "IsCreateSupply", "Y");
+                createSupply(outboundLine, qtySupply);
+            }
+        });
+
+        Optional.ofNullable(getDocAction()).flatMap(docAction -> Optional.ofNullable(orderDistribution)).ifPresent(order -> {
+            order.setDocAction(getDocAction());
+            order.processIt(DocAction.ACTION_Complete);
+            order.saveEx();
+        });
+        Optional.ofNullable(orderDistribution).ifPresent(order -> {
+            if (isPrintPickList()) {
+            	printDocument(orderDistribution, getPrintFormatId("DistributionOrder_Header  ** TEMPLATE **", "DD_Order_Header_v"), false);
+            }
+        });
+        Optional<String> createdDescription =  Optional.ofNullable(orderDistribution).map(order -> "@Created@ " + order.getDocumentInfo());
+        return createdDescription.orElse("");
+    }
+    
+    private int getPrintFormatId(String formatName, String tableName) {
+		return MPrintFormat.getPrintFormat_ID(formatName, MTable.getTable_ID(tableName), getAD_Client_ID());
+	}
+
+    /**
+     * create Distribution Order to performance a Pick List
+     *
+     * @param outboundLine Outbound Line
+     * @return Quantity that was not covert for inventory
+     */
+    private BigDecimal createDistributionOrder(MWMInOutBoundLine outboundLine) {
+        int shipperId = 0;
+        WMRuleEngine engineRule = WMRuleEngine.get();
+        List<MStorage> storageList = engineRule.getStorage(outboundLine, getAreaTypeId(), getSectionTypeId());
+        AtomicReference<BigDecimal> qtySupply = new AtomicReference<>(BigDecimal.ZERO);
+        if (storageList.size() > 0) {
+            //get the warehouse in transit
+            MLocator outboundLocator = MLocator.get(outboundLine.getCtx(), outboundLine.getM_LocatorTo_ID());
+            List<MWarehouse> transitWarehouse = Arrays.asList(MWarehouse.getInTransitForOrg(getCtx(), outboundLocator.getAD_Org_ID()));
+            if (transitWarehouse.isEmpty())
+                throw new AdempiereException("@M_Warehouse_ID@ @IsInTransit@ @NotFound@");
+
+            //Org Must be linked to BPartner
+            MOrg org = MOrg.get(getCtx(), outboundLocator.getAD_Org_ID());
+            int partnerId = org.getLinkedC_BPartner_ID(get_TrxName());
+            if (partnerId <= 0)
+                throw new NoBPartnerLinkedforOrgException(org);
+
+            MBPartner partner = MBPartner.get(getCtx(), partnerId);
+            if (orderDistribution == null) {
+                orderDistribution = new MDDOrder(getCtx(), 0, get_TrxName());
+            orderDistribution.setAD_Org_ID(outboundLocator.getAD_Org_ID());
+            orderDistribution.setC_BPartner_ID(partnerId);
+            orderDistribution.setDescription(Msg.parseTranslation(getCtx(), "@Generate@ @From@ " +outboundLine.getParent().getDocumentInfo()));
+            if (getDocTypeId() > 0)
+                orderDistribution.setC_DocType_ID(getDocTypeId());
+            else
+                orderDistribution.setC_DocType_ID(MDocType.getDocType(X_C_DocType.DOCBASETYPE_DistributionOrder));
+
+            orderDistribution.setM_Warehouse_ID(transitWarehouse.stream().findFirst().get().get_ID());
+            orderDistribution.setDocAction(Optional.ofNullable(getDocAction()).orElseGet(() -> X_DD_Order.DOCACTION_Prepare));
+            List<MUser> users = Arrays.asList(MUser.getOfBPartner(getCtx(), partner.getC_BPartner_ID(), get_TrxName()));
+            if (users.isEmpty())
+                throw new AdempiereException("@AD_User_ID@ @NotFound@ @Value@ - @C_BPartner_ID@ : " + partner.getValue() + " - " + partner.getName());
+
+            orderDistribution.setAD_User_ID(users.stream().findFirst().get().getAD_User_ID());
+            orderDistribution.setDateOrdered(getToday());
+            orderDistribution.setDatePromised(getToday());
+            orderDistribution.setM_Shipper_ID(shipperId);
+            orderDistribution.setM_FreightCategory_ID(outboundLine.getParent().getM_FreightCategory_ID());
+            orderDistribution.setFreightCostRule(outboundLine.getParent().getFreightCostRule());
+            orderDistribution.setFreightAmt(outboundLine.getParent().getFreightAmt());
+            orderDistribution.setIsInDispute(false);
+            orderDistribution.setIsInTransit(false);
+            orderDistribution.setSalesRep_ID(getAD_User_ID());
+            orderDistribution.setDocStatus(MDDOrder.DOCSTATUS_Drafted);
+            orderDistribution.saveEx();
+        }
+
+            storageList.stream()
+                    .filter(storage -> storage.getQtyOnHand().signum() > 0)
+                    .forEach(storage -> {
+                            BigDecimal balanceQtyToPick = outboundLine.getQtyToPick().subtract(qtySupply.get());
+                            if (balanceQtyToPick.signum() > 0) {
+                                MDDOrderLine orderLine = new MDDOrderLine(orderDistribution);
+                                orderLine.setM_Locator_ID(storage.getM_Locator_ID());
+                                orderLine.setM_LocatorTo_ID(outboundLine.getM_LocatorTo_ID());
+                                orderLine.setC_UOM_ID(outboundLine.getC_UOM_ID());
+                                orderLine.setM_Product_ID(outboundLine.getM_Product_ID());
+                                orderLine.setDateOrdered(getToday());
+                                orderLine.setDatePromised(outboundLine.getPickDate());
+                                orderLine.setWM_InOutBoundLine_ID(outboundLine.getWM_InOutBoundLine_ID());
+                                orderLine.setIsInvoiced(false);
+
+                                if (balanceQtyToPick.compareTo(storage.getQtyOnHand()) < 0) {
+                                    orderLine.setConfirmedQty(outboundLine.getQtyToPick());
+                                    orderLine.setQtyEntered(outboundLine.getQtyToPick());
+                                    orderLine.setQtyOrdered(outboundLine.getQtyToPick());
+                                    orderLine.setTargetQty(outboundLine.getQtyToPick());
+                                    orderLine.setM_AttributeSetInstance_ID(storage.getM_AttributeSetInstance_ID());
+                                    orderLine.setM_AttributeSetInstanceTo_ID(storage.getM_AttributeSetInstance_ID());
+                                    qtySupply.updateAndGet(supply -> supply.add(balanceQtyToPick));
+                                } else {
+                                    orderLine.setConfirmedQty(storage.getQtyOnHand());
+                                    orderLine.setQtyEntered(storage.getQtyOnHand());
+                                    orderLine.setQtyOrdered(storage.getQtyOnHand());
+                                    orderLine.setTargetQty(storage.getQtyOnHand());
+                                    orderLine.setM_AttributeSetInstance_ID(storage.getM_AttributeSetInstance_ID());
+                                    orderLine.setM_AttributeSetInstanceTo_ID(storage.getM_AttributeSetInstance_ID());
+                                    qtySupply.updateAndGet(supply -> supply.add(storage.getQtyOnHand()));
+                                }
+                                if (qtySupply.get().signum() > 0) {
+                                    //Save the last location from a storage found
+                                    outboundLine.setM_Locator_ID(storage.getM_Locator_ID());
+                                    outboundLine.saveEx();
+                                }
+                                orderLine.setFreightAmt(outboundLine.getFreightAmt());
+                                orderLine.setM_FreightCategory_ID(outboundLine.getM_FreightCategory_ID());
+                                orderLine.setM_Shipper_ID(outboundLine.getM_Shipper_ID());
+                                orderLine.saveEx();
+                            }
+                    });
+        }
+        return outboundLine.getQtyToPick().subtract(qtySupply.get());
+    }
+
+    /**
+     * Create supply based in Out bound Line
+     *
+     * @param outBoundOrderLine Out bound Line
+     * @param qtySupply         Quantity Supply
+     */
+    private void createSupply(MWMInOutBoundLine outBoundOrderLine, BigDecimal qtySupply) {
+        Optional<MProduct> maybeProduct = Optional.ofNullable(MProduct.get(outBoundOrderLine.getCtx(), outBoundOrderLine.getM_Product_ID()));
+        maybeProduct.ifPresent(product -> {
+            if (product.isBOM())
+                createManufacturingOrder(outBoundOrderLine, product, qtySupply);
+            else if (product.isPurchased())
+                createRequisition(outBoundOrderLine, product, qtySupply);
+        });
+    }
+
+    /**
+     * Create Requisition when the Is create supply is define as yes
+     *
+     * @param outboundLine OutboundLine
+     * @param product      Product
+     * @param QtyPlanned   Qty Planned
+     */
+    private MRequisition createRequisition(MWMInOutBoundLine outboundLine, MProduct product, BigDecimal QtyPlanned) {
+        List<MProductPO> productPOs = Arrays.asList(MProductPO.getOfProductAndOrg(getCtx(), product.getM_Product_ID(), outboundLine.getAD_Org_ID(), get_TrxName()));
+        Optional<MProductPO> maybeProductPO = productPOs.stream().filter(productPO -> productPO.isCurrentVendor() && productPO.getC_BPartner_ID() > 0).findFirst();
+        return maybeProductPO.map(productPO -> {
+            final String sql = "SELECT COALESCE(bp." + MBPartner.COLUMNNAME_PO_PriceList_ID
+                    + ",bpg." + X_C_BP_Group.COLUMNNAME_PO_PriceList_ID + ")"
+                    + " FROM C_BPartner bp"
+                    + " INNER JOIN C_BP_Group bpg ON (bpg.C_BP_Group_ID=bp.C_BP_Group_ID)"
+                    + " WHERE bp.C_BPartner_ID=?";
+            int priceListId = DB.getSQLValueEx(get_TrxName(), sql, productPO.getC_BPartner_ID());
+            MLocator outboundLocator = MLocator.get(outboundLine.getCtx(), outboundLine.getM_LocatorTo_ID());
+            MRequisition requisition = new MRequisition(getCtx(), 0, get_TrxName());
+            requisition.setAD_Org_ID(outboundLocator.getAD_Org_ID());
+            requisition.setAD_User_ID(getAD_User_ID());
+            requisition.setDateRequired(outboundLine.getPickDate());
+            requisition.setDescription(Msg.parseTranslation(getCtx(), "@Generated@ @From@ @WM_InOutBound_ID@"+outboundLine.getParent().getDocumentInfo()));
+            requisition.setM_Warehouse_ID(outboundLocator.getM_Warehouse_ID());
+            requisition.setC_DocType_ID(MDocType.getDocType(MDocType.DOCBASETYPE_PurchaseRequisition));
+            if (priceListId > 0)
+                requisition.setM_PriceList_ID(priceListId);
+            requisition.saveEx();
+
+            MRequisitionLine requisitionLine = new MRequisitionLine(requisition);
+            requisitionLine.setLine(10);
+            requisitionLine.setAD_Org_ID(outboundLocator.getAD_Org_ID());
+            requisitionLine.setC_BPartner_ID(productPO.getC_BPartner_ID());
+            requisitionLine.setM_Product_ID(product.getM_Product_ID());
+            requisitionLine.setPrice();
+            requisitionLine.setPriceActual(Env.ZERO);
+            requisitionLine.setQty(QtyPlanned);
+            requisitionLine.saveEx();
+
+
+            Optional<MOrderLine> maybeOrderLine = Optional.ofNullable(new MOrderLine(getCtx(), outboundLine.getC_OrderLine_ID(), get_TrxName()));
+            maybeOrderLine.ifPresent(orderLine -> {
+                StringBuilder descriptionLine = new StringBuilder(Optional.ofNullable(orderLine.getDescription()).orElse(""));
+                descriptionLine.append(" ").append(Msg.translate(getCtx(), MRequisition.COLUMNNAME_M_Requisition_ID)).append(" : ").append(requisition.getDocumentNo());
+                orderLine.setDescription(descriptionLine.toString());
+                orderLine.saveEx();
+                StringBuilder descriptionOutboundLine = new StringBuilder(Optional.ofNullable(outboundLine.getDescription()).orElse(""));
+                descriptionOutboundLine.append(" ").append(Msg.translate(outboundLine.getCtx(), MRequisition.COLUMNNAME_M_Requisition_ID)).append(" : ").append(requisition.getDocumentNo());
+                outboundLine.setDescription(descriptionOutboundLine.toString());
+                outboundLine.saveEx();
+            });
+            return requisition;
+        }).orElseThrow(() -> new NoVendorForProductException(""));
+    }
+
+    /**
+     * Create Manufacturing Order when the Is create supply is define as yes
+     *
+     * @param outBoundOrderLine Bound Line
+     * @param product           Product
+     * @param qtySupply         Quantity to Supply
+     * @return
+     */
+    private MPPOrder createManufacturingOrder(MWMInOutBoundLine outBoundOrderLine, MProduct product, BigDecimal qtySupply) {
+        Optional<MPPOrder> maybeOrder = Optional.ofNullable(
+                MPPOrder.forC_OrderLine_ID(outBoundOrderLine.getCtx(), outBoundOrderLine.getC_OrderLine_ID(),
+                        product.get_ID(),
+                        outBoundOrderLine.get_TrxName()));
+        return maybeOrder.map(order -> {
+            order.setM_Shipper_ID(outBoundOrderLine.getParent().getM_Shipper_ID());
+            order.setM_FreightCategory_ID(outBoundOrderLine.getParent().getM_FreightCategory_ID());
+            order.setFreightCostRule(outBoundOrderLine.getParent().getFreightCostRule());
+            return order;
+        }).orElseGet(() -> {
+            Optional<MPPProductPlanning> maybeProductPlanning = Optional.ofNullable(
+                    MPPProductPlanning.find(getCtx(), outBoundOrderLine.getAD_Org_ID(), outBoundOrderLine.getM_Warehouse_ID(), 0, product.getM_Product_ID(), get_TrxName())
+            );
+            // get Product BOM
+            MPPProductBOM bom = maybeProductPlanning.map(MPPProductPlanning::getPP_Product_BOM).orElseGet(() -> {
+                Optional<MPPProductBOM> maybeDefaultBOM = Optional.ofNullable(MPPProductBOM.getDefault(product, get_TrxName()));
+                return maybeDefaultBOM.orElseThrow(() -> new AdempiereException("@PP_Product_BOM_ID@ @NotFound@"));
+            });
+            // get Manufacturing Workflow
+            MWorkflow workflow = maybeProductPlanning.map(MPPProductPlanning::getAD_Workflow).orElseGet(() -> {
+                int workflowId =  MWorkflow.getWorkflowSearchKey(product);
+                Optional<MWorkflow> maybeWorkflow = Optional.ofNullable(workflowId > 0 ? MWorkflow.get(getCtx(), MWorkflow.getWorkflowSearchKey(product)) : null);
+                return maybeWorkflow.orElseThrow(() -> new AdempiereException("@AD_Workflow_ID@ @NotFound@ @To@ @M_Product_ID@  @Value@ : " + product.getValue() + " @Name@: " + product.getName()));
+            });
+
+            int plantId = MPPProductPlanning.getPlantForWarehouse(outBoundOrderLine.getM_Warehouse_ID());
+            if (plantId <= 0)
+                throw new NoPlantForWarehouseException(outBoundOrderLine.getM_Warehouse_ID());
+
+            StringBuilder description = new StringBuilder(Msg.parseTranslation(getCtx(), "@Generated@ @From@ @WM_InOutBound_ID@"));
+            description.append("  ").append(outBoundOrderLine.getParent().getDocumentInfo());
+            //Create temporary Product Planning to Create Manufacturing Order
+            MPPProductPlanning productPlanning = new MPPProductPlanning(getCtx(), 0, get_TrxName());
+            productPlanning.setAD_Org_ID(outBoundOrderLine.getAD_Org_ID());
+            productPlanning.setM_Product_ID(product.getM_Product_ID());
+            productPlanning.setPlanner_ID(outBoundOrderLine.getParent().getSalesRep_ID());
+            productPlanning.setPP_Product_BOM_ID(bom.getPP_Product_BOM_ID());
+            productPlanning.setAD_Workflow_ID(workflow.getAD_Workflow_ID());
+            productPlanning.setM_Warehouse_ID(outBoundOrderLine.getM_Warehouse_ID());
+            productPlanning.setS_Resource_ID(plantId);
+            MPPOrder order = MPPMRP.createMO(
+                    productPlanning,
+                    outBoundOrderLine.getC_OrderLine_ID(),
+                    outBoundOrderLine.getM_AttributeSetInstance_ID(),
+                    qtySupply,
+                    outBoundOrderLine.getPickDate(),
+                    outBoundOrderLine.getShipDate(),
+                    description.toString()
+            );
+            Optional<MOrderLine> maybeOrderLine = Optional.ofNullable(new MOrderLine(getCtx(), outBoundOrderLine.getC_OrderLine_ID(), get_TrxName()));
+            maybeOrderLine.ifPresent(orderLine -> {
+                Optional.ofNullable(orderLine.getDescription()).ifPresent(descriptionLine -> description.append(descriptionLine));
+                StringBuilder descriptionOrderLine = new StringBuilder(Msg.translate(orderLine.getCtx(), MPPOrder.COLUMNNAME_PP_Order_ID));
+                descriptionOrderLine.append(" : ").append(Optional.ofNullable(order.getDocumentNo()).orElse(""));
+                orderLine.setDescription(descriptionOrderLine.toString());
+                orderLine.saveEx();
+            });
+            StringBuilder boundDescription = new StringBuilder(Optional.ofNullable(outBoundOrderLine.getDescription()).orElse(""));
+            boundDescription.append(Msg.translate(getCtx(), MPPOrder.COLUMNNAME_PP_Order_ID)).append(" : ").append(Optional.ofNullable(order.getDocumentNo()).orElse(""));
+            outBoundOrderLine.setDescription(boundDescription.toString());
+            outBoundOrderLine.saveEx();
+            return order;
+        });
+    }
+
+    /**
+     * get Today
+     *
+     * @return Today
+     */
+    protected Timestamp getToday() {
+        return this.today;
+    }
+}

--- a/src/patches/org/solop/process/ProductReplenishmentSearch.java
+++ b/src/patches/org/solop/process/ProductReplenishmentSearch.java
@@ -1,0 +1,403 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2017 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * or (at your option) any later version.                                     *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net                                                  *
+ * or https://github.com/adempiere/adempiere/blob/develop/license.html        *
+ *****************************************************************************/
+
+package org.solop.process;
+
+import org.adempiere.core.domains.models.X_T_Replenish;
+import org.compiere.model.MWarehouse;
+import org.compiere.model.Query;
+import org.compiere.util.DB;
+import org.compiere.util.Env;
+import org.compiere.util.ReplenishInterface;
+import org.compiere.util.ReplenishInterface_V2;
+import org.compiere.util.Trx;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+
+/**
+ * 	Generated Process for (Product Replenishment Search)
+ *  @author Yamel Senih, yamel.senih@solopsoftware.com, Solop <a href="http://www.solopsoftware.com">solopsoftware.com</a>
+ *  @version Release 5.1.2
+ */
+public class ProductReplenishmentSearch extends ProductReplenishmentSearchAbstract {
+
+	private final Map<String, ReplenishInterface> replenishmentResolver = new HashMap<>();
+
+	@Override
+	protected void prepare() {
+		super.prepare();
+	}
+
+	@Override
+	protected String doIt() throws Exception {
+		Trx.run(this::prepareTable);
+		AtomicReference<String> result = new AtomicReference<>();
+		Trx.run(transactionName -> {
+			result.set(insertReplenish(transactionName));
+		});
+		Trx.run(this::runRules);
+		return result.get();
+	}
+
+	private ReplenishInterface getResolver(String className) {
+		ReplenishInterface resolver = null;
+		if(className == null) {
+			return null;
+		}
+		if(replenishmentResolver.containsKey(className)) {
+			return replenishmentResolver.get(className);
+		} else {
+			try {
+				Class<?> clazz = Class.forName(className);
+				resolver = (ReplenishInterface) clazz.getDeclaredConstructor().newInstance();
+				replenishmentResolver.put(className, resolver);
+			} catch (Exception e) {
+				log.log(Level.SEVERE, "Replenishment Class Not Found"
+						+ className, e);
+			}
+		}
+		return resolver;
+	}
+
+	private void runRules(String transactionName) {
+		//	Custom Replenishment
+		getCustomReplenish()
+				.parallelStream()
+				.forEach(replenish -> {
+			if(replenish.get_ValueAsString("ReplenishmentClass") != null) {
+				ReplenishInterface custom = getResolver(replenish.get_ValueAsString("ReplenishmentClass"));
+				if(custom != null) {
+					BigDecimal qto = null;
+					try {
+						MWarehouse warehouse = MWarehouse.get(getCtx(), replenish.getM_Warehouse_ID());
+						if (ReplenishInterface_V2.class.isAssignableFrom(custom.getClass())){
+							qto = ((ReplenishInterface_V2)custom).getQtyToOrder(warehouse, replenish, this);
+						} else {
+							qto = custom.getQtyToOrder(warehouse, replenish);
+						}
+					} catch (Exception e) {
+						log.log(Level.SEVERE, custom.toString(), e);
+					}
+					if (qto == null) {
+						qto = Env.ZERO;
+					}
+					replenish.setQtyToOrder(qto);
+					replenish.saveEx();
+				}
+			}
+		});
+		//	Delete rows where nothing to order
+		String sql = "DELETE FROM T_Replenish "
+				+ "WHERE QtyToOrder < 1"
+				+ " AND AD_PInstance_ID=" + getAD_PInstance_ID();
+		int no = DB.executeUpdateEx(sql, transactionName);
+		if (no != 0) {
+			log.fine("Delete No QtyToOrder=" + no);
+		}
+	}
+
+	private String insertReplenish(String transactionName) {
+		List<Object> parameters = new ArrayList<>();
+		StringBuilder insertSql = new StringBuilder("INSERT INTO T_Replenish (AD_PInstance_ID, " +
+				"AD_Client_ID, " +
+				"AD_Org_ID, " +
+				"M_Product_ID, " +
+				"ReplenishType, " +
+				"Level_Min, " +
+				"Level_Max, " +
+				"QtyAvailable, " +
+				"QtyOnHand, " +
+				"QtyReserved, " +
+				"QtyOrdered, " +
+				"QtyToOrder, " +
+				"M_Warehouse_ID, " +
+				"M_WarehouseSource_ID, " +
+				"C_BPartner_ID, " +
+				"Order_Min, " +
+				"Order_Pack, " +
+				"ReplenishmentClass," +
+				"DateTrx) ");
+
+		insertSql.append("SELECT " + getAD_PInstance_ID() + ", r.AD_Client_ID," +
+				"    r.AD_Org_ID," +
+				"    r.M_Product_ID," +
+				"    r.ReplenishType," +
+				"    r.Level_Min," +
+				"    r.Level_Max," +
+				"    r.QtyAvailable," +
+				"    r.QtyOnHand," +
+				"    r.QtyReserved," +
+				"    r.QtyOrdered," +
+				"    CASE" +
+				"     WHEN r.Order_Pack > 0 AND MOD(CASE" +
+				"        WHEN r.QtyToOrder < r.Order_Min AND r.QtyToOrder > 0" +
+				"        THEN r.Order_Min" +
+				"        ELSE r.QtyToOrder" +
+				"       END, CASE WHEN COALESCE(r.Order_Pack, 0) > 0 THEN r.Order_Pack ELSE 1 END) <> 0 AND r.QtyToOrder > 0" +
+				"     THEN CASE" +
+				"       WHEN r.QtyToOrder < r.Order_Min AND r.QtyToOrder > 0" +
+				"       THEN r.Order_Min" +
+				"       ELSE r.QtyToOrder" +
+				"      END - MOD(CASE" +
+				"         WHEN r.QtyToOrder < r.Order_Min AND r.QtyToOrder > 0" +
+				"         THEN r.Order_Min" +
+				"         ELSE r.QtyToOrder" +
+				"        END, CASE WHEN COALESCE(r.Order_Pack, 0) > 0 THEN r.Order_Pack ELSE 1 END) + r.Order_Pack" +
+				"     ELSE r.QtyToOrder" +
+				"    END AS QtyToOrder," +
+				"    r.M_Warehouse_ID," +
+				"    r.M_WarehouseSource_ID," +
+				"    r.C_BPartner_ID," +
+				"    r.Order_Min," +
+				"    r.Order_Pack, " +
+				"    r.ReplenishmentClass, " +
+				"    ?" +
+				" FROM (SELECT r.AD_Client_ID," +
+				"        r.AD_Org_ID," +
+				"        r.M_Product_ID," +
+				"        r.ReplenishType," +
+				"        COALESCE(r.Level_Min, 0) AS Level_Min," +
+				"     COALESCE(r.Level_Max, 0) AS Level_Max," +
+				"     COALESCE(s.QtyAvailable, 0) AS QtyAvailable," +
+				"     COALESCE(s.QtyOnHand, 0) AS QtyOnHand," +
+				"     COALESCE(s.QtyReserved, 0) AS QtyReserved," +
+				"     COALESCE(s.QtyOrdered, 0) AS QtyOrdered," +
+				"        COALESCE(CASE" +
+				"            WHEN r.ReplenishType = '1' THEN" +
+				"                CASE" +
+				"                    WHEN COALESCE(s.QtyOnHand, 0) - COALESCE(s.QtyReserved, 0) + COALESCE(s.QtyOrdered, 0) <= r.Level_Min" +
+				"                    THEN r.Level_Max - COALESCE(s.QtyOnHand, 0) + COALESCE(s.QtyReserved, 0) - COALESCE(s.QtyOrdered, 0)" +
+				"                    ELSE 0" +
+				"                END" +
+				"            WHEN r.ReplenishType = '2' THEN r.Level_Max - COALESCE(s.QtyOnHand, 0) + COALESCE(s.QtyReserved, 0) - COALESCE(s.QtyOrdered, 0)" +
+				"            ELSE 0" +
+				"        END, 0) AS QtyToOrder," +
+				"        r.M_Warehouse_ID," +
+				"        COALESCE(r.M_WarehouseSource_ID, w.M_WarehouseSource_ID) AS M_WarehouseSource_ID," +
+				"        po.C_BPartner_ID," +
+				"        COALESCE(po.Order_Min, 0) AS Order_Min," +
+				"        COALESCE(po.Order_Pack, 0) AS Order_Pack, " +
+				"        COALESCE(r.ReplenishmentClass, w.ReplenishmentClass) AS ReplenishmentClass" +
+				"    FROM M_Replenish r" +
+				"    INNER JOIN M_Warehouse w ON(w.M_Warehouse_ID = r.M_Warehouse_ID)" +
+				"    LEFT JOIN LATERAL (SELECT po.C_BPartner_ID, po.Order_Min, po.Order_Pack FROM M_Product_PO po WHERE po.M_Product_ID = r.M_Product_ID AND po.IsActive = 'Y' AND po.IsCurrentVendor = 'Y' AND po.AD_Org_ID IN (0,w.AD_Org_ID) ORDER BY po.AD_Org_ID DESC LIMIT 1) po ON true " +
+				"    LEFT JOIN (SELECT s.M_Product_ID, s.M_Warehouse_ID," +
+				"                SUM(s.QtyOnHand) AS QtyOnHand," +
+				"                SUM(s.QtyOrdered) AS QtyOrdered," +
+				"                SUM(s.QtyReserved) AS QtyReserved," +
+				"                SUM(s.QtyAvailable) AS QtyAvailable" +
+				"            FROM RV_Storage s" +
+				"            GROUP BY s.M_Product_ID, s.M_Warehouse_ID) s ON(s.M_Product_ID = r.M_Product_ID AND s.M_Warehouse_ID = r.M_Warehouse_ID)" +
+				"    WHERE r.IsActive = 'Y') r " +
+				"INNER JOIN M_Product p ON(p.M_Product_ID = r.M_Product_ID)");
+		//	Add Where Clause
+		insertSql.append(" WHERE r.M_Warehouse_ID = ?");
+
+		parameters.add(getDateTrx());
+		parameters.add(getWarehouseId());
+		//	Organization
+		if(getOrgId() > 0) {
+			insertSql.append(" AND r.AD_Org_ID = ?");
+			parameters.add(getOrgId());
+		}
+		//	Source Warehouse
+		if(getWarehouseSourceId() > 0) {
+			insertSql.append(" AND r.M_WarehouseSource_ID = ?");
+			parameters.add(getWarehouseSourceId());
+		}
+		//	Product
+		if(getProductId() > 0) {
+			insertSql.append(" AND r.M_Product_ID = ?");
+			parameters.add(getProductId());
+		}
+		//	Product Brand
+		if(getBrandId() > 0) {
+			insertSql.append(" AND p.M_Brand_ID = ?");
+			parameters.add(getBrandId());
+		}
+		//	Product Industry Sector
+		if(getIndustrySectorId() > 0) {
+			insertSql.append(" AND p.M_Industry_Sector_ID = ?");
+			parameters.add(getIndustrySectorId());
+		}
+		//	Product Material Type
+		if(getMaterialGroupId() > 0) {
+			insertSql.append(" AND p.M_Material_Group_ID = ?");
+			parameters.add(getMaterialGroupId());
+		}
+		//	Product Material Type
+		if(getMaterialTypeId() > 0) {
+			insertSql.append(" AND p.M_Material_Type_ID = ?");
+			parameters.add(getMaterialTypeId());
+		}
+		//	Product Part Type
+		if(getPartTypeId() > 0) {
+			insertSql.append(" AND p.M_PartType_ID = ?");
+			parameters.add(getPartTypeId());
+		}
+		//	Product Category
+		if(getProductCategoryId() > 0) {
+			insertSql.append(" AND p.M_Product_Category_ID = ?");
+			parameters.add(getProductCategoryId());
+		}
+		//	Product Class
+		if(getProductClassId() > 0) {
+			insertSql.append(" AND p.M_Product_Class_ID = ?");
+			parameters.add(getProductClassId());
+		}
+		//	Product Classification
+		if(getProductClassificationId() > 0) {
+			insertSql.append(" AND p.M_Product_Classification_ID = ?");
+			parameters.add(getProductClassificationId());
+		}
+		//	Product Group
+		if(getProductGroupId() > 0) {
+			insertSql.append(" AND p.M_Product_Group_ID = ?");
+			parameters.add(getProductGroupId());
+		}
+		//	Product Purchase Group
+		if(getPurchaseGroupId() > 0) {
+			insertSql.append(" AND p.M_Purchase_Group_ID = ?");
+			parameters.add(getPurchaseGroupId());
+		}
+		//	Product Sales Group
+		if(getSalesGroupId() > 0) {
+			insertSql.append(" AND p.M_Sales_Group_ID = ?");
+			parameters.add(getSalesGroupId());
+		}
+		//	Vendor
+		if(getBPartnerId() > 0) {
+			insertSql.append(" AND r.C_BPartner_ID = ?");
+			parameters.add(getBPartnerId());
+		}
+		//	Vendor
+		if(getReplenishType() != null) {
+			insertSql.append(" AND r.ReplenishType = ?");
+			parameters.add(getReplenishType());
+		}
+		int inserted = DB.executeUpdateEx(insertSql.toString(), parameters.toArray(), transactionName);
+		if (inserted != 0) {
+			log.fine("Filled Replenishments = " + inserted);
+		}
+		//	Delete inactive products and replenishments
+		String sql = "DELETE T_Replenish r "
+				+ "WHERE (EXISTS (SELECT * FROM M_Product p "
+				+ "WHERE p.M_Product_ID=r.M_Product_ID AND p.IsActive='N')"
+				+ " OR EXISTS (SELECT * FROM M_Replenish rr "
+				+ " WHERE rr.M_Product_ID=r.M_Product_ID AND rr.IsActive='N'"
+				+ " AND rr.M_Warehouse_ID=" + getWarehouseId() + " ))"
+				+ " AND AD_PInstance_ID=" + getAD_PInstance_ID();
+		int no = DB.executeUpdateEx(sql, transactionName);
+		if (no != 0) {
+			log.fine("Delete Inactive=" + no);
+		}
+
+		//	Ensure Data consistency
+		sql = "UPDATE T_Replenish SET QtyOnHand = 0 WHERE QtyOnHand IS NULL";
+		no = DB.executeUpdateEx(sql, transactionName);
+		sql = "UPDATE T_Replenish SET QtyReserved = 0 WHERE QtyReserved IS NULL";
+		no = DB.executeUpdateEx(sql, transactionName);
+		sql = "UPDATE T_Replenish SET QtyOrdered = 0 WHERE QtyOrdered IS NULL";
+		no = DB.executeUpdateEx(sql, transactionName);
+
+		//	Set Minimum / Maximum Maintain Level
+		//	X_M_Replenish.REPLENISHTYPE_ReorderBelowMinimumLevel
+		sql = "UPDATE T_Replenish"
+				+ " SET QtyToOrder = CASE WHEN QtyOnHand - QtyReserved + QtyOrdered <= Level_Min "
+				+ " THEN Level_Max - QtyOnHand + QtyReserved - QtyOrdered "
+				+ " ELSE 0 END "
+				+ "WHERE ReplenishType='1'"
+				+ " AND AD_PInstance_ID=" + getAD_PInstance_ID();
+		no = DB.executeUpdateEx(sql, transactionName);
+		if (no != 0) {
+			log.fine("Update Type-1=" + no);
+		}
+		//
+		//	X_M_Replenish.REPLENISHTYPE_MaintainMaximumLevel
+		sql = "UPDATE T_Replenish"
+				+ " SET QtyToOrder = Level_Max - QtyOnHand + QtyReserved - QtyOrdered "
+				+ "WHERE ReplenishType='2'"
+				+ " AND AD_PInstance_ID=" + getAD_PInstance_ID();
+		no = DB.executeUpdateEx(sql, transactionName);
+		if (no != 0) {
+			log.fine("Update Type-2=" + no);
+		}
+		//	Minimum Order Quantity
+		sql = "UPDATE T_Replenish"
+				+ " SET QtyToOrder = Order_Min "
+				+ "WHERE QtyToOrder < Order_Min"
+				+ " AND QtyToOrder > 0"
+				+ " AND AD_PInstance_ID=" + getAD_PInstance_ID();
+		no = DB.executeUpdateEx(sql, transactionName);
+		if (no != 0) {
+			log.fine("Set MinOrderQty=" + no);
+		}
+		//	Even dividable by Pack
+		sql = "UPDATE T_Replenish"
+				+ " SET QtyToOrder = QtyToOrder - MOD(QtyToOrder, CASE WHEN COALESCE(Order_Pack, 0) > 0 THEN Order_Pack ELSE 1 END) + Order_Pack "
+				+ "WHERE MOD(QtyToOrder, CASE WHEN COALESCE(Order_Pack, 0) > 0 THEN Order_Pack ELSE 1 END) <> 0"
+				+ " AND QtyToOrder > 0"
+				+ " AND AD_PInstance_ID=" + getAD_PInstance_ID();
+		no = DB.executeUpdateEx(sql, transactionName);
+		if (no != 0) {
+			log.fine("Set OrderPackQty=" + no);
+		}
+		//	Check Source Warehouse
+		sql = "UPDATE T_Replenish"
+				+ " SET M_WarehouseSource_ID = NULL "
+				+ "WHERE M_Warehouse_ID=M_WarehouseSource_ID"
+				+ " AND AD_PInstance_ID=" + getAD_PInstance_ID();
+		no = DB.executeUpdateEx(sql, transactionName);
+		if (no != 0) {
+			log.fine("Set same Source Warehouse=" + no);
+		}
+		return "@Created@ " + inserted;
+	}
+
+	/**
+	 * 	Prepare/Check Replenishment Table
+	 */
+	private void prepareTable(String transactionName) {
+		//	Level_Max must be >= Level_Max
+		String sql = "UPDATE M_Replenish"
+				+ " SET Level_Max = Level_Min "
+				+ "WHERE Level_Max < Level_Min";
+		int no = DB.executeUpdateEx(sql, transactionName);
+		if (no != 0) {
+			log.fine("Corrected Max_Level=" + no);
+		}
+	}	//	prepareTable
+
+	/**
+	 * 	Get Replenish Records
+	 *	@return replenish
+	 */
+	private List<X_T_Replenish> getCustomReplenish() {
+		return new Query(getCtx(), X_T_Replenish.Table_Name,
+				"AD_PInstance_ID = ?" + " AND " + "ReplenishType='9'", null)
+                .setParameters(getAD_PInstance_ID())
+                .setOrderBy("M_Warehouse_ID, M_WarehouseSource_ID, C_BPartner_ID")
+                .list();
+	}	//	getReplenish
+}

--- a/src/patches/org/solop/sp016/model/validator/ConsignedMaterial.java
+++ b/src/patches/org/solop/sp016/model/validator/ConsignedMaterial.java
@@ -1,0 +1,283 @@
+/************************************************************************************
+ * Copyright (C) 2012-2018 E.R.P. Consultores y Asociados, C.A.                     *
+ * Contributor(s): Yamel Senih ysenih@erpya.com                                     *
+ * This program is free software: you can redistribute it and/or modify             *
+ * it under the terms of the GNU General Public License as published by             *
+ * the Free Software Foundation, either version 2 of the License, or                *
+ * (at your option) any later version.                                              *
+ * This program is distributed in the hope that it will be useful,                  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+ * GNU General Public License for more details.                                     *
+ * You should have received a copy of the GNU General Public License                *
+ * along with this program.	If not, see <https://www.gnu.org/licenses/>.            *
+ ************************************************************************************/
+package org.solop.sp016.model.validator;
+
+import org.adempiere.core.domains.models.I_C_Invoice;
+import org.adempiere.core.domains.models.I_C_InvoiceLine;
+import org.adempiere.core.domains.models.I_C_Order;
+import org.adempiere.core.domains.models.I_M_InOut;
+import org.adempiere.core.domains.models.I_M_Inventory;
+import org.adempiere.core.domains.models.I_M_Product_PO;
+import org.compiere.acct.Fact;
+import org.compiere.model.FactsValidator;
+import org.compiere.model.MAcctSchema;
+import org.compiere.model.MClient;
+import org.compiere.model.MDocType;
+import org.compiere.model.MInOut;
+import org.compiere.model.MInventory;
+import org.compiere.model.MInvoice;
+import org.compiere.model.MInvoiceLine;
+import org.compiere.model.MMatchInv;
+import org.compiere.model.MOrder;
+import org.compiere.model.MOrderLine;
+import org.compiere.model.MProduct;
+import org.compiere.model.MProductPO;
+import org.compiere.model.ModelValidationEngine;
+import org.compiere.model.ModelValidator;
+import org.compiere.model.PO;
+import org.compiere.util.CLogger;
+import org.compiere.util.Env;
+import org.solop.sp016.util.ConsignedMaterialUtil;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Useful method for Consignment Material
+ * @author Yamel Senih ysenih@erpya.com
+ *
+ */
+public class ConsignedMaterial implements ModelValidator, FactsValidator {
+
+	/** Logger */
+	private static CLogger log = CLogger.getCLogger(ConsignedMaterial.class);
+	/** Client */
+	private int clientId = -1;
+	
+	@Override
+	public void initialize(ModelValidationEngine engine, MClient client) {
+		// client = null for global validator
+		if (client != null) {
+			clientId = client.getAD_Client_ID();
+			log.info(client.toString());
+		} else {
+			log.info("Initializing global validator: " + this.toString());
+		}
+		//	Add Persistence for IsDefault values
+		engine.addDocValidate(I_C_Order.Table_Name, this);
+		engine.addDocValidate(I_C_Invoice.Table_Name, this);
+		engine.addModelChange(I_C_Invoice.Table_Name, this);
+		engine.addModelChange(I_C_InvoiceLine.Table_Name, this);
+		engine.addModelChange(I_C_Order.Table_Name, this);
+		engine.addModelChange(I_M_Inventory.Table_Name, this);
+		engine.addModelChange(I_M_Product_PO.Table_Name, this);
+//		engine.addModelChange(I_M_InOut.Table_Name, this);
+		
+
+		//Support Currency Convert on Fact
+		engine.addFactsValidate(MInOut.Table_Name, this);
+		engine.addFactsValidate(MMatchInv.Table_Name, this);
+	}
+	
+	@Override
+	public int getAD_Client_ID() {
+		return clientId;
+	}
+
+	@Override
+	public String login(int AD_Org_ID, int AD_Role_ID, int AD_User_ID) {
+		log.info("AD_User_ID=" + AD_User_ID);
+		return null;
+	}
+
+	@Override
+	public String modelChange(PO entity, int type) throws Exception {
+		if(type == TYPE_BEFORE_DELETE) {
+			if(entity.get_TableName().equals(I_C_InvoiceLine.Table_Name)) {
+				MInvoiceLine invoiceLine = (MInvoiceLine) entity;
+				MInvoice invoice = invoiceLine.getParent();
+				if(!invoice.isSOTrx()) {
+					//	For Sales Order Lines
+					ConsignedMaterialUtil.getLinkedSalesOrderLinesFromInvoiceLine(invoiceLine.getCtx(), invoiceLine.getC_InvoiceLine_ID(), invoiceLine.get_TrxName()).forEach(orderLine -> {
+						orderLine.setLink_OrderLine_ID(-1);
+						orderLine.saveEx(invoiceLine.get_TrxName());
+					});
+					//	For Inventory Line
+					ConsignedMaterialUtil.getLinkedInventoryLinesFromInvoiceLine(invoiceLine.getCtx(), invoiceLine.getC_InvoiceLine_ID(), invoiceLine.get_TrxName()).forEach(inventoryLine -> {
+						inventoryLine.set_ValueOfColumn(MOrderLine.COLUMNNAME_Link_OrderLine_ID, null);
+						inventoryLine.saveEx(invoiceLine.get_TrxName());
+					});
+				}
+			}
+		} else if(type == TYPE_BEFORE_NEW
+				|| type == TYPE_BEFORE_CHANGE) {
+			if(entity.get_TableName().equals(I_C_InvoiceLine.Table_Name)) {
+				//	For AP Invoice
+				if(entity.is_new()
+						|| entity.is_ValueChanged(I_C_InvoiceLine.COLUMNNAME_C_OrderLine_ID)) {
+					MInvoiceLine invoiceLine = (MInvoiceLine) entity;
+					if(!invoiceLine.getParent().isSOTrx()) {
+						ConsignedMaterialUtil.recalculateInvoiceLineRate(invoiceLine);
+					}
+				}
+			} else if(entity.get_TableName().equals(I_C_Order.Table_Name)) {
+				//	For Purchase Order set default value when is drop ship based on document type
+				MOrder purchaseOrder = (MOrder) entity;
+				if(!purchaseOrder.isSOTrx()
+						&& purchaseOrder.getC_DocTypeTarget_ID() > 0
+						&& (purchaseOrder.is_new()
+						|| purchaseOrder.is_ValueChanged(I_C_Order.COLUMNNAME_C_DocTypeTarget_ID))) {
+					MDocType documentType = MDocType.get(purchaseOrder.getCtx(), purchaseOrder.getC_DocTypeTarget_ID());
+					purchaseOrder.setIsDropShip(documentType.get_ValueAsBoolean(MProduct.COLUMNNAME_IsDropShip));
+				}
+			} else if(entity.get_TableName().equals(I_M_Inventory.Table_Name)) {
+				//	For Inventory Internal use set default value when is drop ship based on document type
+				MInventory inventory = (MInventory) entity;
+				if(inventory.getC_DocType_ID() > 0
+						&& (inventory.is_new()
+						|| inventory.is_ValueChanged(I_C_Order.COLUMNNAME_C_DocType_ID))) {
+					MDocType documentType = MDocType.get(inventory.getCtx(), inventory.getC_DocType_ID());
+					inventory.set_ValueOfColumn(MOrder.COLUMNNAME_IsDropShip, documentType.get_ValueAsBoolean(MProduct.COLUMNNAME_IsDropShip));
+				}
+			} else if(entity.get_TableName().equals(I_M_Product_PO.Table_Name)) {
+				//	For AP Invoice
+				if(entity.is_new()
+						|| entity.is_ValueChanged(ConsignedMaterialUtil.COLUMNNAME_PriceLastLanded)) {
+					MProductPO purchaseProduct = (MProductPO) entity;
+					BigDecimal purchasePrice = Optional.ofNullable(purchaseProduct.getPricePO()).orElse(Env.ZERO);
+					BigDecimal landedCostPrice = Optional.ofNullable((BigDecimal) purchaseProduct.get_Value(ConsignedMaterialUtil.COLUMNNAME_PriceLastLanded)).orElse(Env.ZERO);
+					purchaseProduct.setPricePO(purchasePrice.add(landedCostPrice));
+				}
+			} else if(entity.get_TableName().equals(I_M_InOut.Table_Name)
+					&& type == TYPE_BEFORE_CHANGE) {
+//				MInOut inOut = (MInOut) entity;
+//				if(inOut.getC_Order_ID() > 0
+//						&& inOut.is_ValueChanged(I_M_InOut.COLUMNNAME_M_Warehouse_ID)
+//						&& !inOut.isSOTrx()) {
+//					MOrder order = (MOrder) inOut.getC_Order();
+//					if(order.getM_Warehouse_ID() == inOut.getM_Warehouse_ID()
+//							&& order.getAD_Org_ID() != inOut.get_ValueOldAsInt(I_M_InOut.COLUMNNAME_AD_Org_ID)) {
+//						inOut.setM_Warehouse_ID(inOut.get_ValueOldAsInt(I_M_InOut.COLUMNNAME_M_Warehouse_ID));
+//						inOut.setAD_Org_ID(inOut.get_ValueOldAsInt(I_M_InOut.COLUMNNAME_AD_Org_ID));
+//					}
+//				}
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public String docValidate(PO entity, int timing) {
+		if(timing == TIMING_BEFORE_COMPLETE) {
+			if(entity.get_TableName().equals(I_C_Order.Table_Name)) {
+				MOrder order = (MOrder) entity;
+				if(!order.isSOTrx()) {
+					//	Only Drop Ship
+					Arrays.asList(order.getLines())
+					.stream()
+					.filter(orderLine -> orderLine.getM_Product_ID() > 0)
+					.forEach(orderLine -> {
+						List<MProductPO> purchaseProductList = MProductPO.getByPartnerAndOrg(orderLine.getCtx(), order.getC_BPartner_ID(), orderLine.getM_Product_ID(), order.getAD_Org_ID(), order.get_TrxName());
+						Optional<MProductPO> maybePurchaseProduct = purchaseProductList.stream().filter(puchaseProduct -> puchaseProduct.getC_Currency_ID() == order.getC_Currency_ID()).findFirst();
+						if(maybePurchaseProduct.isPresent()) {	//	Update Price
+							MProductPO purchaseProductToUpdate = maybePurchaseProduct.get();
+							purchaseProductToUpdate.setPriceList(orderLine.getPriceActual());
+							purchaseProductToUpdate.setPricePO(orderLine.getPriceActual());
+							purchaseProductToUpdate.setPriceLastPO(orderLine.getPriceActual());
+							purchaseProductToUpdate.setIsActive(true);
+							purchaseProductToUpdate.setIsCurrentVendor(true);
+							purchaseProductToUpdate.saveEx();
+						} else {	//	Create New
+							MProduct product = MProduct.get(order.getCtx(), orderLine.getM_Product_ID());
+							MProductPO purchaseProductToCreate = new MProductPO(order.getCtx(), orderLine.getM_Product_ID(), order.getC_BPartner_ID(), order.getC_Currency_ID(), order.getAD_Org_ID(), order.get_TrxName());
+							purchaseProductToCreate.setVendorProductNo(product.getValue());
+							purchaseProductToCreate.setC_UOM_ID(product.getC_UOM_ID());
+							purchaseProductToCreate.setUPC(product.getUPC());
+							purchaseProductToCreate.setPriceList(orderLine.getPriceList());
+							purchaseProductToCreate.setPricePO(orderLine.getPriceActual());
+							purchaseProductToCreate.setPriceLastPO(orderLine.getPriceActual());
+							purchaseProductToCreate.setIsCurrentVendor(true);
+							purchaseProductToCreate.saveEx();
+						}
+					});
+				}
+			} else if(entity.get_TableName().equals(I_C_Invoice.Table_Name)) {
+				//	For Sales Invoice
+				MInvoice invoice = (MInvoice) entity;
+				if(invoice.isSOTrx()) {
+					Arrays.asList(invoice.getLines(true))
+						.stream()
+						.filter(invoiceLine -> invoiceLine.getM_Product_ID() > 0 && Optional.ofNullable(invoiceLine.getPriceLimit()).orElse(Env.ZERO).compareTo(Env.ZERO) == 0)
+						.forEach(invoiceLine -> {
+							ConsignedMaterialUtil.setPriceLimitFromLastPurchase(invoiceLine);
+							invoiceLine.saveEx();
+						});
+				}
+			}
+		} else if(timing == TIMING_AFTER_REVERSECORRECT
+				|| timing == TIMING_AFTER_REVERSEACCRUAL
+				|| timing == TIMING_AFTER_VOID) {
+			if(entity.get_TableName().equals(I_C_Invoice.Table_Name)) {
+				MInvoice invoice = (MInvoice) entity;
+				if(!invoice.isSOTrx()) {
+					//	For Sales Order Lines
+					ConsignedMaterialUtil.getLinkedSalesOrderLinesFromInvoice(invoice.getCtx(), invoice.getC_Invoice_ID(), invoice.get_TrxName()).forEach(orderLine -> {
+						orderLine.setLink_OrderLine_ID(-1);
+						orderLine.saveEx(invoice.get_TrxName());
+					});
+					//	For Inventory Line
+					ConsignedMaterialUtil.getLinkedInventoryLinesFromInvoiceLine(invoice.getCtx(), invoice.getC_Invoice_ID(), invoice.get_TrxName()).forEach(inventoryLine -> {
+						inventoryLine.set_ValueOfColumn(MOrderLine.COLUMNNAME_Link_OrderLine_ID, null);
+						inventoryLine.saveEx(invoice.get_TrxName());
+					});
+				}
+			} else if(entity.get_TableName().equals(I_C_Order.Table_Name)) {
+				MOrder purchaseOrder = (MOrder) entity;
+				//	Remove Linked Order Lines
+				if(!purchaseOrder.isSOTrx()) {
+					//	For Sales Order Lines
+					ConsignedMaterialUtil.getLinkedSalesOrderLinesFromPurchaseOrder(purchaseOrder.getCtx(), purchaseOrder.getC_Order_ID(), purchaseOrder.get_TrxName()).forEach(orderLine -> {
+						orderLine.setLink_OrderLine_ID(-1);
+						orderLine.saveEx(purchaseOrder.get_TrxName());
+					});
+					//	For Inventory Lines
+					ConsignedMaterialUtil.getLinkedInventoryLinesFromPurchaseOrder(purchaseOrder.getCtx(), purchaseOrder.getC_Order_ID(), purchaseOrder.get_TrxName()).forEach(inventoryLine -> {
+						inventoryLine.set_ValueOfColumn(MOrderLine.COLUMNNAME_Link_OrderLine_ID, null);
+						inventoryLine.saveEx(purchaseOrder.get_TrxName());
+					});
+				}
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public String factsValidate(MAcctSchema schema, List<Fact> facts, PO po) {
+		Optional.ofNullable(po).ifPresent(entity ->{
+			if (entity.get_TableName().equals(MInOut.Table_Name)
+					|| entity.get_TableName().equals(MMatchInv.Table_Name)) {
+				facts.forEach(fact->{
+					Arrays.asList(fact.getLines()).stream().forEach(fLine->{
+						if (fLine.getM_Product_ID()!=0) {
+							Optional.ofNullable(MProduct.get(entity.getCtx(), fLine.getM_Product_ID()))
+									.ifPresent(product ->{
+										if (product.isDropShip()) {
+											fLine.setAmtSourceCr(Env.ZERO);
+											fLine.setAmtSourceDr(Env.ZERO);
+											fLine.setAmtAcctCr(Env.ZERO);
+											fLine.setAmtAcctDr(Env.ZERO);
+										}
+							});
+						}
+					});
+				});
+			}
+		});
+		
+		return null;
+	}
+}

--- a/src/patches/org/solop/sp016/util/ConsignedMaterialUtil.java
+++ b/src/patches/org/solop/sp016/util/ConsignedMaterialUtil.java
@@ -1,0 +1,201 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 or later of the                                  *
+ * GNU General Public License as published                                    *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * Copyright (C) 2003-2019 E.R.P. Consultores y Asociados, C.A.               *
+ * All Rights Reserved.                                                       *
+ * Contributor(s): Yamel Senih www.erpya.com                                  *
+ *****************************************************************************/
+package org.solop.sp016.util;
+
+import org.adempiere.core.domains.models.I_C_OrderLine;
+import org.adempiere.core.domains.models.I_M_InventoryLine;
+import org.compiere.model.MConversionRate;
+import org.compiere.model.MCurrency;
+import org.compiere.model.MInventoryLine;
+import org.compiere.model.MInvoice;
+import org.compiere.model.MInvoiceLine;
+import org.compiere.model.MOrder;
+import org.compiere.model.MOrderLine;
+import org.compiere.model.MProductPO;
+import org.compiere.model.Query;
+import org.compiere.util.Env;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+
+/**
+ * Added for handle custom values for ADempiere core
+ * @author Yamel Senih, ysenih@erpya.com, ERPCyA http://www.erpya.com
+ */
+public class ConsignedMaterialUtil {
+	
+	/**	Column Used for Landed Cost	*/
+	public static final String COLUMNNAME_PriceLastLanded = "PriceLastLanded";
+	
+	/**
+	 * Get Linked Order Lines from Invoice
+	 * @param context
+	 * @param invoiceId
+	 * @param transactionName
+	 * @return
+	 */
+	public static final List<MOrderLine>getLinkedSalesOrderLinesFromInvoice(Properties context, int invoiceId, String transactionName) {
+		return new Query(context, I_C_OrderLine.Table_Name, "EXISTS(SELECT 1 FROM C_InvoiceLine il "
+				+ "WHERE il.C_Invoice_ID = ? "
+				+ "AND il.C_OrderLine_ID = C_OrderLine.Link_OrderLine_ID)", transactionName)
+				.setParameters(invoiceId)
+				.list();
+	}
+	
+	/**
+	 * Get Linked Inventory Lines from Invoice
+	 * @param context
+	 * @param invoiceId
+	 * @param transactionName
+	 * @return
+	 */
+	public static final List<MInventoryLine>getLinkedInventoryLineFromInvoice(Properties context, int invoiceId, String transactionName) {
+		return new Query(context, I_M_InventoryLine.Table_Name, "EXISTS(SELECT 1 FROM C_InvoiceLine il "
+				+ "WHERE il.C_Invoice_ID = ? "
+				+ "AND il.C_OrderLine_ID = M_InventoryLine.Link_OrderLine_ID)", transactionName)
+				.setParameters(invoiceId)
+				.list();
+	}
+	
+	/**
+	 * Get Linked Order Line from Purchase Order
+	 * @param context
+	 * @param purchaseOrderId
+	 * @param transactionName
+	 * @return
+	 */
+	public static final List<MOrderLine>getLinkedSalesOrderLinesFromPurchaseOrder(Properties context, int purchaseOrderId, String transactionName) {
+		return new Query(context, I_C_OrderLine.Table_Name, "EXISTS(SELECT 1 FROM C_Order lo "
+				+ "INNER JOIN C_OrderLine lol ON(lol.C_Order_ID = lo.C_Order_ID) "
+				+ "WHERE lo.C_Order_ID = ? "
+				+ "AND lol.C_OrderLine_ID = C_OrderLine.Link_OrderLine_ID)", transactionName)
+				.setParameters(purchaseOrderId)
+				.list();
+	}
+	
+	/**
+	 * Get Linked Inventory Line from Purchase Order
+	 * @param context
+	 * @param purchaseOrderId
+	 * @param transactionName
+	 * @return
+	 */
+	public static final List<MInventoryLine>getLinkedInventoryLinesFromPurchaseOrder(Properties context, int purchaseOrderId, String transactionName) {
+		return new Query(context, I_M_InventoryLine.Table_Name, "EXISTS(SELECT 1 FROM C_Order lo "
+				+ "INNER JOIN C_OrderLine lol ON(lol.C_Order_ID = lo.C_Order_ID) "
+				+ "WHERE lo.C_Order_ID = ? "
+				+ "AND lol.C_OrderLine_ID = M_InventoryLine.Link_OrderLine_ID)", transactionName)
+				.setParameters(purchaseOrderId)
+				.list();
+	}
+	
+	/**
+	 * Get Linked Order Lines from Invoice Line
+	 * @param context
+	 * @param invoiceLineId
+	 * @param transactionName
+	 * @return
+	 */
+	public static final List<MOrderLine>getLinkedSalesOrderLinesFromInvoiceLine(Properties context, int invoiceLineId, String transactionName) {
+		return new Query(context, I_C_OrderLine.Table_Name, "EXISTS(SELECT 1 FROM C_InvoiceLine il "
+				+ "WHERE il.C_InvoiceLine_ID = ? "
+				+ "AND il.C_OrderLine_ID = C_OrderLine.Link_OrderLine_ID)", transactionName)
+				.setParameters(invoiceLineId)
+				.list();
+	}
+	
+	/**
+	 * Get Linked Inventory Lines from Invoice Line
+	 * @param context
+	 * @param invoiceLineId
+	 * @param transactionName
+	 * @return
+	 */
+	public static final List<MInventoryLine>getLinkedInventoryLinesFromInvoiceLine(Properties context, int invoiceLineId, String transactionName) {
+		return new Query(context, I_M_InventoryLine.Table_Name, "EXISTS(SELECT 1 FROM C_InvoiceLine il "
+				+ "WHERE il.C_InvoiceLine_ID = ? "
+				+ "AND il.C_OrderLine_ID = M_InventoryLine.Link_OrderLine_ID)", transactionName)
+				.setParameters(invoiceLineId)
+				.list();
+	}
+	
+	/**
+	 * Recaulculate Invoice Line from Order
+	 * @param invoiceLine
+	 * @return
+	 */
+	public static final void recalculateInvoiceLineRate(MInvoiceLine invoiceLine) {
+		if(invoiceLine.getC_OrderLine_ID() > 0) {
+			if(!invoiceLine.isProcessed()) {
+				MOrderLine orderLine = (MOrderLine) invoiceLine.getC_OrderLine();
+				MOrder order = orderLine.getParent();
+				MInvoice invoice = invoiceLine.getParent();
+				if(invoice.getC_Currency_ID() != order.getC_Currency_ID()
+						&& !invoice.isReversal()) {
+					int conversionTypeId = invoice.getC_ConversionType_ID();
+					if(conversionTypeId <= 0) {
+						conversionTypeId = order.getC_ConversionType_ID();
+					}
+					BigDecimal orderPriceList = Optional.ofNullable(orderLine.getPriceList()).orElse(Env.ZERO);
+					BigDecimal orderPriceActual = Optional.ofNullable(orderLine.getPriceActual()).orElse(Env.ZERO);
+					BigDecimal orderPriceEntered = Optional.ofNullable(orderLine.getPriceEntered()).orElse(Env.ZERO);
+					BigDecimal conversionRate = Optional.ofNullable(MConversionRate.getRate (order.getC_Currency_ID(),
+		                    invoice.getC_Currency_ID(), invoice.getDateAcct(), conversionTypeId, invoice.getAD_Client_ID(),
+		                    invoice.getAD_Org_ID()))
+		            		.orElse(Env.ZERO);
+					MCurrency currencyTo = MCurrency.get (invoice.getCtx(), invoice.getC_Currency_ID());
+					BigDecimal invoicePriceList = orderPriceList.multiply(conversionRate).setScale(currencyTo.getStdPrecision(), RoundingMode.HALF_UP);
+					BigDecimal invoicePriceActual = orderPriceActual.multiply(conversionRate).setScale(currencyTo.getStdPrecision(), RoundingMode.HALF_UP);
+					BigDecimal invoicePriceEntered = orderPriceEntered.multiply(conversionRate).setScale(currencyTo.getStdPrecision(), RoundingMode.HALF_UP);
+					//	Set Price
+					invoiceLine.setPriceList(invoicePriceList);
+					invoiceLine.setPriceActual(invoicePriceActual);
+					invoiceLine.setPriceEntered(invoicePriceEntered);
+					invoiceLine.setLineNetAmt();
+					invoiceLine.setTaxAmt();
+				}
+			}
+		}
+	}
+	
+	/**
+	 * Set Price Limit for sales from purchases
+	 * @param invoiceLine
+	 * @return
+	 */
+	public static final void setPriceLimitFromLastPurchase(MInvoiceLine invoiceLine) {
+		if(!invoiceLine.isProcessed()
+				&& invoiceLine.getM_Product_ID() > 0) {
+			MInvoice invoice = invoiceLine.getParent();
+			Optional<MProductPO> purchasedProduct = Arrays.asList(MProductPO.getOfProductAndOrg(invoiceLine.getCtx(), invoiceLine.getM_Product_ID(), invoiceLine.getAD_Org_ID(), invoiceLine.get_TrxName()))
+				.stream()
+				.filter(purchase -> !purchase.isDiscontinued())
+				.sorted(Comparator.comparing(MProductPO::getUpdated).reversed())
+				.findFirst();
+			purchasedProduct.ifPresent(purchase -> {
+				BigDecimal convertedPrice = MConversionRate.convert(invoice.getCtx(), purchase.getPricePO(), purchase.getC_Currency_ID(), invoice.getC_Currency_ID(), invoice.getDateInvoiced(), invoice.getC_ConversionType_ID(), invoice.getAD_Client_ID(), invoice.getAD_Org_ID());
+				Optional.ofNullable(convertedPrice).ifPresent(convertedPriceToSet -> invoiceLine.setPriceLimit(convertedPriceToSet));
+			});
+		}
+	}
+}


### PR DESCRIPTION
Adds support for having a current vendor per organization on M_Product_PO, so each org can define its own current vendor for the same product (shared records with AD_Org_ID = 0 remain valid fallbacks).                         
   
  Changes                                                                                                                                                                                                                           
                                                         
  - MProductPO: new constructor accepting orgId, new getByProductWithCurrentVendorAndOrg / getByPartnerAndOrg lookup methods, and updated beforeSave() to scope the "only one current vendor" rule per organization.                
  - Processes and models consuming M_Product_PO updated to pass organization context when selecting the current vendor (requisitions, replenishment, costing, imports, project PO generation, RMA flows, consignment, outbound,
  inventory valuation, etc.).                                                                                                                                                                                                       
  - Database views refactored to join M_Product_PO with AD_Org_ID IN (0, <ctx>.AD_Org_ID) using a LATERAL pattern, covering invoice/inout/RMA create-from views, replenishment, slow-moving inventory, consignment detail, storage
  per vendor and customer/vendor reporting views.

### Additional Context
fixes: https://github.com/solop-develop/adempiere-solop/issues/2228