### PR TITLE
Better counter document handling

### DIFF
--- a/src/patches/org/compiere/model/MInOut.java
+++ b/src/patches/org/compiere/model/MInOut.java
@@ -714,6 +714,7 @@ public class MInOut extends X_M_InOut implements DocAction , DocumentReversalEna
 			line.setM_AttributeSetInstance_ID(fromLine.getM_AttributeSetInstance_ID());
 		//	line.setS_ResourceAssignment_ID(0);
 			line.setRef_InOutLine_ID(0);
+			line.setWM_InOutBoundLine_ID(0);
 			line.setIsInvoiced(false);
 			//
 			line.setConfirmedQty(Env.ZERO);

--- a/src/patches/org/compiere/model/MInvoice.java
+++ b/src/patches/org/compiere/model/MInvoice.java
@@ -2422,6 +2422,11 @@ public class MInvoice extends X_C_Invoice implements DocAction , DocumentReversa
 			C_DocTypeTarget_ID, !isSOTrx(), true, false, get_TrxName(), true);
 		//
 		counter.setAD_Org_ID(counterAD_Org_ID);
+		if (!counter.isSOTrx()){
+			load(get_TrxName());
+			counter.setDocumentNo(getDocumentNo());
+		}
+
 	//	counter.setM_Warehouse_ID(counterOrgInfo.getM_Warehouse_ID());
 		//
 		counter.setBPartner(counterBP);


### PR DESCRIPTION
Sales invoices created  from counter document have the same document Number as the original invoice (loaded to be sure it uses the last updated document number) InOut does not copy outbound line reference in inOut lines

### Additional context
fixes https://github.com/solop-develop/adempiere-solop/issues/2614