### PR TITLE
fix: Recreate `Print Format` when not items.

### DIFF
--- a/src/main/java/org/spin/grpc/service/PaymentPrintExport.java
+++ b/src/main/java/org/spin/grpc/service/PaymentPrintExport.java
@@ -500,7 +500,6 @@ public class PaymentPrintExport extends PaymentPrintExportImplBase {
 
 		builder.setDocumentNo(documentNo)
 			.setVendorId(vendor.getC_BPartner_ID())
-			// .setVendorTaxId(ValueUtil.validateNull(vendor.getUUID()))
 			.setVendorTaxId(
 				TextManager.getValidString(
 					vendor.getTaxID()

--- a/src/main/java/org/spin/grpc/service/ReportManagement.java
+++ b/src/main/java/org/spin/grpc/service/ReportManagement.java
@@ -672,7 +672,8 @@ public class ReportManagement extends ReportManagementImplBase {
 				null
 			)
 				.setParameters(request.getPrintFormatId())
-				.first();
+				.first()
+			;
 		}
 		//	Get Default
 		if(printFormat == null || printFormat.getAD_PrintFormat_ID() <= 0) {
@@ -682,7 +683,31 @@ public class ReportManagement extends ReportManagementImplBase {
 		}
 		//	Validate print format
 		if(printFormat == null || printFormat.getAD_PrintFont_ID() <= 0) {
-			throw new AdempiereException("@AD_PrintFormat_ID@ @NotFound@");
+			throw new AdempiereException("@AD_PrintFormat_ID@ (" + request.getPrintFormatId() + ") @NotFound@");
+		}
+
+		//	As ReportEngine.get() logic: if the print format has no items,
+		//	delete it and recreate from the report view (preferred) or from the table.
+		if(printFormat.getItemCount() == 0) {
+			log.warning("No Items - recreating: " + printFormat);
+			int reportViewId = printFormat.getAD_ReportView_ID();
+			int tableId = printFormat.getAD_Table_ID();
+			String printFormatName = printFormat.getName();
+			printFormat.delete(true); // Delete old print format
+			MPrintFormat recreatedPrintFormat = null;
+			if(reportViewId > 0) {
+				recreatedPrintFormat = MPrintFormat.createFromReportView(
+					Env.getCtx(),
+					reportViewId,
+					printFormatName
+				);
+			} else if(tableId > 0) {
+				recreatedPrintFormat = MPrintFormat.createFromTable(Env.getCtx(), tableId);
+			}
+			if (recreatedPrintFormat == null || recreatedPrintFormat.getAD_PrintFormat_ID() <= 0) {
+				throw new AdempiereException("@AD_PrintFormat_ID@ @NotFound@");
+			}
+			printFormat = recreatedPrintFormat;
 		}
 
 		if (table == null || table.getAD_Table_ID() != printFormat.getAD_Table_ID()) {
@@ -728,6 +753,9 @@ public class ReportManagement extends ReportManagementImplBase {
 			.setReportType(reportType)
 			.setIsDirectPrint(
 				process.isDirectPrint()
+			)
+			.setPrintFormatId(
+				printFormat.getAD_PrintFormat_ID()
 			)
 		;
 		//	


### PR DESCRIPTION
<img width="1922" height="1002" alt="2026-05-04_18-24" src="https://github.com/user-attachments/assets/ff965e22-7e62-4eef-a844-60bf56a3d732" />

<img width="1919" height="969" alt="imagen" src="https://github.com/user-attachments/assets/3b7e038b-d82f-4eb1-97bc-39879a9485c1" />


### Additional context
fixes https://github.com/solop-develop/adempiere-solop/issues/2544