### PR TITLE
fix: prevent unauthorized header mutation on closed documents (#2161)

### DIFF
--- a/src/main/java/org/spin/base/util/RecordWriteGuard.java
+++ b/src/main/java/org/spin/base/util/RecordWriteGuard.java
@@ -1,0 +1,188 @@
+/*************************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                              *
+ * This program is free software; you can redistribute it and/or modify it           *
+ * under the terms version 2 or later of the GNU General Public License as published *
+ * by the Free Software Foundation. This program is distributed in the hope          *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied        *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ * See the GNU General Public License for more details.                              *
+ * You should have received a copy of the GNU General Public License along           *
+ * with this program; if not, write to the Free Software Foundation, Inc.,           *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                            *
+ * For the text or an alternative of this public license, you may reach us           *
+ * Copyright (C) 2018-present E.R.P. Consultores y Asociados, S.A. All Rights Reserved. *
+ * Contributor(s): Edwin Betancourt, EdwinBetanc0urt@outlook.com                     *
+ *************************************************************************************/
+package org.spin.base.util;
+
+import java.util.Properties;
+import java.util.Set;
+
+import org.adempiere.core.domains.models.X_AD_Window;
+import org.compiere.model.MColumn;
+import org.compiere.model.MTab;
+import org.compiere.model.MTable;
+import org.compiere.model.MWindow;
+import org.compiere.model.PO;
+import org.compiere.util.Env;
+import org.compiere.util.Evaluator;
+import org.compiere.util.Util;
+
+/**
+ * Guards that protect record-write endpoints from mutating closed-document
+ * headers.
+ *
+ * Centralizes the rule: once a document reaches a closed DocStatus, the
+ * cabecera columns listed in {@link #DOC_CRITICAL_COLUMNS} must NEVER be
+ * modified, regardless of AD_Column.IsAlwaysUpdateable. This protects against
+ * accidental misconfiguration of the flag and against endpoints that bypass
+ * the standard Processed guard.
+ *
+ * @author Edwin Betancourt, EdwinBetanc0urt@outlook.com, https://github.com/EdwinBetanc0urt
+ */
+public final class RecordWriteGuard {
+
+	/** DocStatus values that close the document and lock its header. */
+	public static final Set<String> DOC_CLOSED_STATUSES = Set.of(
+		"CO", "CL", "VO", "RE"
+	);
+
+	/** Header columns that must never be modified on a closed document. */
+	public static final Set<String> DOC_CRITICAL_COLUMNS = Set.of(
+		"DocumentNo", "C_DocType_ID", "C_DocTypeTarget_ID",
+		"DateAcct", "DateInvoiced", "C_BPartner_ID",
+		"GrandTotal", "TotalLines", "C_Currency_ID",
+		"AD_Org_ID", "M_Warehouse_ID", "C_PaymentTerm_ID",
+		"Processed", "Processing", "DocStatus", "DocAction"
+	);
+
+	private RecordWriteGuard() {}
+
+	/**
+	 * @return true if {@code docStatus} is one of the values that close a
+	 *         document header to further edits.
+	 */
+	public static boolean isClosedDocStatus(String docStatus) {
+		return docStatus != null && DOC_CLOSED_STATUSES.contains(docStatus);
+	}
+
+	/**
+	 * @return true if {@code entity}'s DocStatus is closed. Returns false for
+	 *         null entities or for tables that do not expose a DocStatus column.
+	 */
+	public static boolean isDocumentClosed(PO entity) {
+		if (entity == null) {
+			return false;
+		}
+		if (entity.get_ColumnIndex("DocStatus") < 0) {
+			return false;
+		}
+		return isClosedDocStatus(entity.get_ValueAsString("DocStatus"));
+	}
+
+	/**
+	 * @return true if {@code columnName} is a header column whose value must
+	 *         be preserved once the document is closed.
+	 */
+	public static boolean isCriticalDocumentColumn(String columnName) {
+		return columnName != null && DOC_CRITICAL_COLUMNS.contains(columnName);
+	}
+
+	/**
+	 * Decides whether a column must be skipped when writing to {@code entity}.
+	 *
+	 * Returns true when any of the following apply:
+	 * <ul>
+	 *   <li>{@code column} is null or not persisted.</li>
+	 *   <li>The column is not {@code IsAlwaysUpdateable} AND either it is not
+	 *       updateable, or {@code entity.Processed='Y'}, or {@code entity.Processing='Y'}.</li>
+	 *   <li>The entity is in a closed DocStatus AND the column is in
+	 *       {@link #DOC_CRITICAL_COLUMNS} — applies even if the column is
+	 *       {@code IsAlwaysUpdateable}.</li>
+	 * </ul>
+	 *
+	 * @param entity the persisted record being mutated; may be null
+	 * @param column the column to be written
+	 * @return true if the write must be skipped
+	 */
+	public static boolean shouldSkipColumn(PO entity, MColumn column) {
+		if (column == null || column.getAD_Column_ID() <= 0) {
+			return true;
+		}
+		if (!column.isAlwaysUpdateable()) {
+			if (!column.isUpdateable()) {
+				return true;
+			}
+			if (entity != null) {
+				if (entity.get_ColumnIndex("Processed") >= 0 && entity.get_ValueAsBoolean("Processed")) {
+					return true;
+				}
+				if (entity.get_ColumnIndex("Processing") >= 0 && entity.get_ValueAsBoolean("Processing")) {
+					return true;
+				}
+			}
+		}
+		if (isDocumentClosed(entity) && isCriticalDocumentColumn(column.getColumnName())) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * @return true if {@code table} cannot accept writes (e.g., it is a view
+	 *         or is null).
+	 */
+	public static boolean isTableReadOnly(MTable table) {
+		if (table == null) {
+			return true;
+		}
+		return table.isView();
+	}
+
+	/**
+	 * @return true if {@code tab} is read-only, either by its {@code IsReadOnly}
+	 *         flag or because its {@code ReadOnlyLogic} evaluates to true
+	 *         against {@code entity}.
+	 *
+	 * @param tab    the tab definition
+	 * @param entity the record used to evaluate {@code ReadOnlyLogic}; if null,
+	 *               only the static {@code IsReadOnly} flag is checked.
+	 */
+	public static boolean isTabReadOnly(MTab tab, PO entity) {
+		if (tab == null) {
+			return true;
+		}
+		if (tab.isReadOnly()) {
+			return true;
+		}
+		String readOnlyLogic = tab.getReadOnlyLogic();
+		if (Util.isEmpty(readOnlyLogic, true) || entity == null) {
+			return false;
+		}
+		return Evaluator.evaluateLogic(entity, readOnlyLogic);
+	}
+
+	/**
+	 * @return true if {@code window} cannot accept writes (currently: window
+	 *         type is {@code QueryOnly} or window is null).
+	 */
+	public static boolean isWindowReadOnly(MWindow window) {
+		if (window == null) {
+			return true;
+		}
+		return X_AD_Window.WINDOWTYPE_QueryOnly.equals(window.getWindowType());
+	}
+
+	/**
+	 * @return true if {@code entity} belongs to a different AD_Client than the
+	 *         session resolved from {@code context}. Cross-client writes are a
+	 *         tenancy violation and must be rejected.
+	 */
+	public static boolean isForeignClient(Properties context, PO entity) {
+		if (context == null || entity == null) {
+			return false;
+		}
+		return Env.getAD_Client_ID(context) != entity.getAD_Client_ID();
+	}
+
+}

--- a/src/main/java/org/spin/grpc/logic/RecordManagementServiceLogic.java
+++ b/src/main/java/org/spin/grpc/logic/RecordManagementServiceLogic.java
@@ -59,6 +59,7 @@ import org.spin.backend.grpc.record_management.ToggleIsActiveRecordResponse;
 import org.spin.backend.grpc.record_management.ToggleIsActiveRecordsBatchRequest;
 import org.spin.backend.grpc.record_management.ToggleIsActiveRecordsBatchResponse;
 import org.spin.backend.grpc.record_management.ZoomWindow;
+import org.spin.base.util.RecordWriteGuard;
 import org.spin.service.grpc.util.base.RecordUtil;
 import org.spin.service.grpc.util.value.TextManager;
 import org.spin.service.grpc.util.value.ValueManager;
@@ -86,18 +87,27 @@ public class RecordManagementServiceLogic {
 	}
 
 
-	public static ToggleIsActiveRecordsBatchResponse.Builder toggleIsActiveRecords(ToggleIsActiveRecordsBatchRequest request) {
+	public static ToggleIsActiveRecordsBatchResponse.Builder toggleIsActiveRecordsBatch(ToggleIsActiveRecordsBatchRequest request) {
 		StringBuilder errorMessage = new StringBuilder();
 		AtomicInteger recordsChanges = new AtomicInteger(0);
 
 		Trx.run(transactionName -> {
 			MTable table = validateAndGetTable(request.getTableName());
+			if (RecordWriteGuard.isTableReadOnly(table)) {
+				throw new AdempiereException("@Ignored@ @AD_Table_ID@ (" + table.getName() + ") : @IsView@");
+			}
 			List<Integer> ids = request.getIdsList();
 			if (ids.size() > 0) {
 				ids.stream().forEach(id -> {
 					PO entity = table.getPO(id, transactionName);
 					if (entity != null && entity.get_ID() > 0) {
+						if (RecordWriteGuard.isForeignClient(Env.getCtx(), entity)) {
+							return;
+						}
 						if (entity.get_ColumnIndex("Processed") >= 0 && entity.get_ValueAsBoolean("Processed")) {
+							return;
+						}
+						if (RecordWriteGuard.isDocumentClosed(entity)) {
 							return;
 						}
 						entity.setIsActive(request.getIsActive());
@@ -138,13 +148,22 @@ public class RecordManagementServiceLogic {
 
 		Trx.run(transactionName -> {
 			MTable table = validateAndGetTable(request.getTableName());
+			if (RecordWriteGuard.isTableReadOnly(table)) {
+				throw new AdempiereException("@Ignored@ @AD_Table_ID@ (" + table.getName() + ") : @IsView@");
+			}
 			if (request.getId() <= 0 && !RecordUtil.isValidId(request.getId(), table.getAccessLevel())) {
 				throw new AdempiereException("@FillMandatory@ @Record_ID@");
 			}
 			if (request.getId() > 0) {
 				PO entity = RecordUtil.getEntity(Env.getCtx(), request.getTableName(), request.getId(), transactionName);
 				if (entity != null && entity.get_ID() > 0) {
+					if (RecordWriteGuard.isForeignClient(Env.getCtx(), entity)) {
+						return;
+					}
 					if (entity.get_ColumnIndex("Processed") >= 0 && entity.get_ValueAsBoolean("Processed")) {
+						return;
+					}
+					if (RecordWriteGuard.isDocumentClosed(entity)) {
 						return;
 					}
 					entity.setIsActive(request.getIsActive());

--- a/src/main/java/org/spin/grpc/service/BusinessData.java
+++ b/src/main/java/org/spin/grpc/service/BusinessData.java
@@ -61,6 +61,7 @@ import org.spin.base.util.AccessUtil;
 import org.spin.base.util.ContextManager;
 import org.spin.base.util.ConvertUtil;
 import org.spin.base.util.LookupUtil;
+import org.spin.base.util.RecordWriteGuard;
 import org.spin.base.workflow.WorkflowUtil;
 import org.spin.dictionary.util.BrowserUtil;
 import org.spin.dictionary.util.DictionaryUtil;
@@ -678,7 +679,7 @@ public class BusinessData extends BusinessDataImplBase {
 		for (MPInstance recentInstance : recentInstances) {
 			//	Block concurrent executions of the same process for the same user/session/record
 			if (recentInstance.isProcessing()) {
-				throw new AdempiereException("@AD_Process_ID@ @IsProcessing@");
+				throw new AdempiereException("@Processing@ @AD_PInstance_ID@");
 			}
 			//	For recently completed instances: compare parameters to detect duplicate submission
 			MPInstancePara[] storedParams = recentInstance.getParameters();
@@ -851,6 +852,9 @@ public class BusinessData extends BusinessDataImplBase {
 		final MTable table = RecordUtil.validateAndGetTable(
 			request.getTableName()
 		);
+		if (RecordWriteGuard.isTableReadOnly(table)) {
+			throw new AdempiereException("@Ignored@ @AD_Table_ID@ (" + table.getName() + ") : @IsView@");
+		}
 
 		PO entity = table.getPO(0, null);
 		if(entity == null) {
@@ -908,20 +912,15 @@ public class BusinessData extends BusinessDataImplBase {
 		final String[] keyColumns = table.getKeyColumns();
 		Entity.Builder builder = ConvertUtil.convertEntity(entity);
 
-		if (table.isView()) {
+		if (RecordWriteGuard.isTableReadOnly(table)) {
 			log.warning("@Ignored@ @AD_Table_ID@ (" + table.getName() + ") : @IsView@ ");
 			return builder;
 		}
 
-		final int sessionClientId = Env.getAD_Client_ID(context);
-		if (sessionClientId != currentEntity.getAD_Client_ID()) {
+		if (RecordWriteGuard.isForeignClient(context, currentEntity)) {
 			log.warning("@Ignored@ : Record is other client");
 			return builder;
 		}
-
-		// final boolean isActiveRecord = currentEntity.isActive();
-		final boolean isProcessedRecord = currentEntity.get_ValueAsBoolean("Processed");
-		final boolean isProcessingRecord = currentEntity.get_ValueAsBoolean("Processing");
 
 		Map<String, Value> attributes = request.getAttributes().getFieldsMap();
 		attributes.entrySet().forEach(attribute -> {
@@ -955,60 +954,14 @@ public class BusinessData extends BusinessDataImplBase {
 				return;
 			}
 
-			if (!column.isAlwaysUpdateable()) {
-				if (!column.isUpdateable()) {
-					log.warning(
-						Msg.parseTranslation(
-							context,
-							"@Ignored@ " + column.getName() + " (" + columnName + ") @NewValue@ = " + displayValue + " : @IsUpdateable@ @NotValid@"
-						)
-					);
-					return;
-				}
-
-				if (isProcessedRecord) {
-					log.warning(
-						Msg.parseTranslation(
-							context,
-							"@Ignored@ " + column.getName() + " (" + columnName + ") @NewValue@ = " + displayValue + " : @Processed@ "
-						)
-					);
-					return;
-				}
-				if (isProcessingRecord) {
-					log.warning(
-						Msg.parseTranslation(
-							context,
-							"@Ignored@ " + column.getName() + " (" + columnName + ") @NewValue@ = " + displayValue + " : @Processing@ "
-						)
-					);
-					return;
-				}
-
-				// if (!Util.isEmpty(column.getReadOnlyLogic(), true)) {
-				// 	boolean isReadOnlyColumn = Evaluator.evaluateLogic(currentEntity, column.getReadOnlyLogic());
-				// 	if (isReadOnlyColumn) {
-				// 		log.warning(
-				// 			Msg.parseTranslation(
-				// 				context,
-				// 				"@Ignored@ " + column.getName() + " (" + columnName + ") @NewValue@ = " + displayValue + " : @ReadOnlyLogic@ "
-				// 			)
-				// 		);
-				// 		return;
-				// 	}
-				// }
-
-				// if (!columnName.equals(I_AD_Element.COLUMNNAME_IsActive)) {
-				// 	if (!isActiveRecord) {
-				// 		log.warning(
-				// 			Msg.parseTranslation(
-				// 				context,
-				// 				"@Ignored@ " + column.getName() + " (" + columnName + ") @NewValue@ = " + displayValue + " : @NotActive@ "
-				// 			)
-				// 		);
-				// 		return;
-				// 	}
-				// }
+			if (RecordWriteGuard.shouldSkipColumn(currentEntity, column)) {
+				log.warning(
+					Msg.parseTranslation(
+						context,
+						"@Ignored@ " + column.getName() + " (" + columnName + ") @NewValue@ = " + displayValue + " : @NotAllowed@"
+					)
+				);
+				return;
 			}
 
 			Object value = null;

--- a/src/main/java/org/spin/grpc/service/RecordManagement.java
+++ b/src/main/java/org/spin/grpc/service/RecordManagement.java
@@ -73,7 +73,7 @@ public class RecordManagement extends RecordManagementImplBase {
 	public void toggleIsActiveRecordsBatch(ToggleIsActiveRecordsBatchRequest request,
 			StreamObserver<ToggleIsActiveRecordsBatchResponse> responseObserver) {
 		try {
-			ToggleIsActiveRecordsBatchResponse.Builder builder = RecordManagementServiceLogic.toggleIsActiveRecords(request);
+			ToggleIsActiveRecordsBatchResponse.Builder builder = RecordManagementServiceLogic.toggleIsActiveRecordsBatch(request);
 			responseObserver.onNext(builder.build());
 			responseObserver.onCompleted();
 		} catch (Exception e) {

--- a/src/main/java/org/spin/grpc/service/display_definition/DisplayDefinitionConvertUtil.java
+++ b/src/main/java/org/spin/grpc/service/display_definition/DisplayDefinitionConvertUtil.java
@@ -84,6 +84,7 @@ import org.spin.service.grpc.util.base.RecordUtil;
 import org.spin.service.grpc.util.value.BooleanManager;
 import org.spin.service.grpc.util.value.NumberManager;
 import org.spin.service.grpc.util.value.TextManager;
+import org.spin.service.grpc.util.value.TimeManager;
 import org.spin.service.grpc.util.value.ValueManager;
 import org.spin.store.util.VueStoreFrontUtil;
 
@@ -1058,12 +1059,12 @@ public class DisplayDefinitionConvertUtil {
 				)
 			)
 			.setValidFrom(
-				ValueManager.getProtoTimestampFromTimestamp(
+				TimeManager.getProtoTimestampFromTimestamp(
 					calendarItem.getValidFrom()
 				)
 			)
 			.setValidTo(
-				ValueManager.getProtoTimestampFromTimestamp(
+				TimeManager.getProtoTimestampFromTimestamp(
 					calendarItem.getValidTo()
 				)
 			)
@@ -1505,12 +1506,12 @@ public class DisplayDefinitionConvertUtil {
 				)
 			)
 			.setValidFrom(
-				ValueManager.getProtoTimestampFromTimestamp(
+				TimeManager.getProtoTimestampFromTimestamp(
 					resourceItem.getValidFrom()
 				)
 			)
 			.setValidTo(
-				ValueManager.getProtoTimestampFromTimestamp(
+				TimeManager.getProtoTimestampFromTimestamp(
 					resourceItem.getValidTo()
 				)
 			)
@@ -1578,7 +1579,7 @@ public class DisplayDefinitionConvertUtil {
 				timelineItem.isReadOnly()
 			)
 			.setDate(
-				ValueManager.getProtoTimestampFromTimestamp(
+				TimeManager.getProtoTimestampFromTimestamp(
 					timelineItem.getDate()
 				)
 			)

--- a/src/main/java/org/spin/grpc/service/display_definition/DisplayDefinitionServiceLogic.java
+++ b/src/main/java/org/spin/grpc/service/display_definition/DisplayDefinitionServiceLogic.java
@@ -26,7 +26,6 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
-import org.adempiere.core.domains.models.I_AD_Column;
 import org.adempiere.core.domains.models.I_AD_Field;
 import org.adempiere.core.domains.models.I_AD_Tab;
 import org.adempiere.core.domains.models.I_AD_Table;
@@ -109,6 +108,7 @@ import org.spin.backend.grpc.display_definition.WorkflowStep;
 import org.spin.base.util.AccessUtil;
 import org.spin.base.util.ContextManager;
 import org.spin.base.util.LookupUtil;
+import org.spin.base.util.RecordWriteGuard;
 import org.spin.service.grpc.authentication.SessionManager;
 import org.spin.service.grpc.util.base.RecordUtil;
 import org.spin.service.grpc.util.db.LimitUtil;
@@ -1211,6 +1211,9 @@ public class DisplayDefinitionServiceLogic {
 			context,
 			displayDefinition.get_ValueAsInt(I_AD_Table.COLUMNNAME_AD_Table_ID)
 		);
+		if (RecordWriteGuard.isTableReadOnly(table)) {
+			throw new AdempiereException("@Ignored@ @AD_Table_ID@ (" + table.getName() + ") : @IsView@");
+		}
 		PO currentEntity = table.getPO(0, null);
 		if (currentEntity == null) {
 			throw new AdempiereException("@Error@ PO is null");
@@ -1219,8 +1222,18 @@ public class DisplayDefinitionServiceLogic {
 
 		Map<String, Value> attributes = new HashMap<>(request.getAttributes().getFieldsMap());
 		table.getColumnsAsList().forEach(column -> {
+			if (column == null || column.getAD_Column_ID() <= 0) {
+				// checks if the column exists in the database
+				log.warning("@AD_Column_ID@ @NotFound@");
+				return;
+			}
 			final String columnName = column.getColumnName();
 			if (column.isVirtualColumn()) {
+				log.warning("@AD_Column_ID@ (" + column.getAD_Column_ID() + ") is virtual: " + columnName);
+				return;
+			}
+			if (column.isKey()) {
+				log.warning("@AD_Column_ID@ (" + column.getAD_Column_ID() + ") is key: " + columnName);
 				return;
 			}
 
@@ -1249,11 +1262,13 @@ public class DisplayDefinitionServiceLogic {
 				}
 			}
 			if (value == null) {
-				if (columnName.endsWith("tedBy") || columnName.equals("Created")
-					|| columnName.equals("Updated") || columnName.equals(table.getTableName() + "_ID")
-					|| columnName.equals("IsActive") || columnName.equals("AD_Client_ID")
-					|| columnName.equals("AD_Org_ID") || columnName.equals("Processed")
-					|| columnName.equals("Processing") || columnName.equals("Posted")) {
+				if (
+					columnName.equals("AD_Client_ID") || columnName.equals("AD_Org_ID") 
+					|| columnName.equals("Created") || columnName.equals("Updated") || columnName.endsWith("tedBy") 
+					|| columnName.equals("IsActive") || columnName.equals(table.getTableName() + "_ID")
+					|| columnName.equals("Processed") || columnName.equals("Processing")
+					|| columnName.equals("Posted")
+				) {
 					return;
 				}
 			}
@@ -1319,6 +1334,9 @@ public class DisplayDefinitionServiceLogic {
 			Env.getCtx(),
 			displayDefinition.get_ValueAsInt(I_AD_Table.COLUMNNAME_AD_Table_ID)
 		);
+		if (RecordWriteGuard.isTableReadOnly(table)) {
+			throw new AdempiereException("@Ignored@ @AD_Table_ID@ (" + table.getName() + ") : @IsView@");
+		}
 		String[] keyColumns = table.getKeyColumns();
 
 		if (request.getId() <= 0) {
@@ -1327,6 +1345,9 @@ public class DisplayDefinitionServiceLogic {
 		PO currentEntity = table.getPO(request.getId(), null);
 		if (currentEntity == null || currentEntity.get_ID() <= 0) {
 			throw new AdempiereException("@Record_ID@ @NotFound@");
+		}
+		if (RecordWriteGuard.isForeignClient(Env.getCtx(), currentEntity)) {
+			throw new AdempiereException("@Ignored@ : Record is other client");
 		}
 		POAdapter adapter = new POAdapter(currentEntity);
 
@@ -1338,11 +1359,16 @@ public class DisplayDefinitionServiceLogic {
 			}
 			if (Arrays.stream(keyColumns).anyMatch(columnName::equals)) {
 				// prevent warning `PO.set_Value: Column not updateable`
+				log.warning("@Ignored@ " + columnName + " : @KeyColumn@");
 				return;
 			}
 			MColumn column = table.getColumn(columnName);
 			if (column == null || column.getAD_Column_ID() <= 0) {
 				// checks if the column exists in the database
+				return;
+			}
+			if (RecordWriteGuard.shouldSkipColumn(currentEntity, column)) {
+				log.warning("@Ignored@ " + columnName + " : @NotAllowed@");
 				return;
 			}
 			int displayTypeId = column.getAD_Reference_ID();
@@ -1424,6 +1450,9 @@ public class DisplayDefinitionServiceLogic {
 				context,
 				displayDefinition.get_ValueAsInt(I_AD_Table.COLUMNNAME_AD_Table_ID)
 			);
+			if (RecordWriteGuard.isTableReadOnly(table)) {
+				throw new AdempiereException("@Ignored@ @AD_Table_ID@ (" + table.getName() + ") : @IsView@");
+			}
 
 			Map<String, Value> attributes = new HashMap<>(request.getAttributes().getFieldsMap());
 
@@ -1595,6 +1624,9 @@ public class DisplayDefinitionServiceLogic {
 				Env.getCtx(),
 				displayDefinition.get_ValueAsInt(I_AD_Table.COLUMNNAME_AD_Table_ID)
 			);
+			if (RecordWriteGuard.isTableReadOnly(table)) {
+				throw new AdempiereException("@Ignored@ @AD_Table_ID@ (" + table.getName() + ") : @IsView@");
+			}
 			String[] keyColumns = table.getKeyColumns();
 
 			Properties context = Env.getCtx();
@@ -1605,6 +1637,9 @@ public class DisplayDefinitionServiceLogic {
 			PO currentEntity = table.getPO(request.getId(), transationName);
 			if (currentEntity == null || currentEntity.get_ID() <= 0) {
 				throw new AdempiereException("@Record_ID@ @NotFound@");
+			}
+			if (RecordWriteGuard.isForeignClient(context, currentEntity)) {
+				throw new AdempiereException("@Ignored@ : Record is other client");
 			}
 			int resourceAssignmentColumnId = displayDefinition.get_ValueAsInt(
 				DisplayDefinitionChanges.SP010_Resource_ID
@@ -1644,6 +1679,10 @@ public class DisplayDefinitionServiceLogic {
 					// checks if the column exists in the database
 					return;
 				}
+				if (RecordWriteGuard.shouldSkipColumn(resourceAssignment, column)) {
+					log.warning("@Ignored@ " + columnName + " : @NotAllowed@");
+					return;
+				}
 				int referenceId = column.getAD_Reference_ID();
 				Object value = null;
 				if (!attribute.getValue().hasNullValue()) {
@@ -1652,7 +1691,7 @@ public class DisplayDefinitionServiceLogic {
 							attribute.getValue(),
 							referenceId
 						);
-					} 
+					}
 					if (value == null) {
 						value = ValueManager.getObjectFromProtoValue(
 							attribute.getValue()
@@ -1675,6 +1714,10 @@ public class DisplayDefinitionServiceLogic {
 					// checks if the column exists in the database
 					return;
 				}
+				if (RecordWriteGuard.shouldSkipColumn(currentEntity, column)) {
+					log.warning("@Ignored@ " + columnName + " : @NotAllowed@");
+					return;
+				}
 				int referenceId = column.getAD_Reference_ID();
 				Object value = null;
 				if (!attribute.getValue().hasNullValue()) {
@@ -1683,7 +1726,7 @@ public class DisplayDefinitionServiceLogic {
 							attribute.getValue(),
 							referenceId
 						);
-					} 
+					}
 					if (value == null) {
 						value = ValueManager.getObjectFromProtoValue(
 							attribute.getValue()

--- a/src/main/java/org/spin/grpc/service/ui/TabEntityLogic.java
+++ b/src/main/java/org/spin/grpc/service/ui/TabEntityLogic.java
@@ -41,7 +41,6 @@ import org.compiere.util.CLogger;
 import org.compiere.util.DB;
 import org.compiere.util.DisplayType;
 import org.compiere.util.Env;
-import org.compiere.util.Evaluator;
 import org.compiere.util.Msg;
 import org.compiere.util.Util;
 import org.spin.backend.grpc.common.Entity;
@@ -55,6 +54,7 @@ import org.spin.base.db.QueryUtil;
 import org.spin.base.db.WhereClauseUtil;
 import org.spin.base.util.ContextManager;
 import org.spin.base.util.LookupUtil;
+import org.spin.base.util.RecordWriteGuard;
 import org.spin.dictionary.util.DictionaryUtil;
 import org.spin.service.grpc.authentication.SessionManager;
 import org.spin.service.grpc.util.base.RecordUtil;
@@ -83,8 +83,14 @@ public class TabEntityLogic {
 				"@AD_Tab_ID@ " + request.getTabId() + " @NotFound@"
 			);
 		}
+		if (RecordWriteGuard.isTabReadOnly(tab, null)) {
+			throw new AdempiereException("@Ignored@ @AD_Tab_ID@ (" + tab.getName() + ") : @IsReadOnly@");
+		}
 
 		MTable table = MTable.get(Env.getCtx(), tab.getAD_Table_ID());
+		if (RecordWriteGuard.isTableReadOnly(table)) {
+			throw new AdempiereException("@Ignored@ @AD_Table_ID@ (" + table.getName() + ") : @IsView@");
+		}
 		PO currentEntity = table.getPO(0, null);
 		if (currentEntity == null) {
 			throw new AdempiereException("@Error@ @PO@ @NotFound@");
@@ -100,6 +106,9 @@ public class TabEntityLogic {
 			MColumn column = table.getColumn(columnName);
 			if (column == null || column.getAD_Column_ID() <= 0) {
 				// checks if the column exists in the database
+				return;
+			}
+			if (column.isVirtualColumn()) {
 				return;
 			}
 			int referenceId = column.getAD_Reference_ID();
@@ -482,35 +491,23 @@ public class TabEntityLogic {
 			windowNo, context, entity, false
 		);
 
-		if (window.getWindowType().equals(X_AD_Window.WINDOWTYPE_QueryOnly)) {
+		if (RecordWriteGuard.isWindowReadOnly(window)) {
 			log.warning("@Ignored@ @AD_Window_ID@ (" + window.getName() + ") : @WindowType@ " + X_AD_Window.WINDOWTYPE_QueryOnly);
 			return builder;
 		}
-		if (table.isView()) {
+		if (RecordWriteGuard.isTableReadOnly(table)) {
 			log.warning("@Ignored@ @AD_Table_ID@ (" + table.getName() + ") : @IsView@ ");
 			return builder;
 		}
-		if (tab.isReadOnly()) {
+		if (RecordWriteGuard.isTabReadOnly(tab, currentEntity)) {
 			log.warning("@Ignored@ @AD_Tab_ID@ (" + tab.getName() + ") : @IsReadOnly@ ");
 			return builder;
 		}
-		if (!Util.isEmpty(tab.getReadOnlyLogic(), true)) {
-			boolean isReadOnlyTab = Evaluator.evaluateLogic(currentEntity, tab.getReadOnlyLogic());
-			if (isReadOnlyTab) {
-				log.warning("@Ignored@ @AD_Tab_ID@ (" + tab.getName() + ") : @ReadOnlyLogic@ ");
-				return builder;
-			}
-		}
 
-		final int sessionClientId = Env.getAD_Client_ID(context);
-		if (sessionClientId != currentEntity.getAD_Client_ID()) {
+		if (RecordWriteGuard.isForeignClient(context, currentEntity)) {
 			log.warning("@Ignored@ : Record is other client");
 			return builder;
 		}
-
-		// final boolean isActiveRecord = currentEntity.isActive();
-		final boolean isProcessedRecord = currentEntity.get_ValueAsBoolean("Processed");
-		final boolean isProcessingRecord = currentEntity.get_ValueAsBoolean("Processing");
 
 		attributes.entrySet().forEach(attribute -> {
 			final String columnName = attribute.getKey();
@@ -543,82 +540,14 @@ public class TabEntityLogic {
 				return;
 			}
 
-			if (!column.isAlwaysUpdateable()) {
-				if (!column.isUpdateable()) {
-					log.warning(
-						Msg.parseTranslation(
-							context,
-							"@Ignored@ " + column.getName() + " (" + columnName + ") @NewValue@ = " + displayValue + " : @IsUpdateable@ @NotValid@"
-						)
-					);
-					return;
-				}
-
-				if (isProcessedRecord) {
-					log.warning(
-						Msg.parseTranslation(
-							context,
-							"@Ignored@ " + column.getName() + " (" + columnName + ") @NewValue@ = " + displayValue + " : @Processed@ "
-						)
-					);
-					return;
-				}
-				if (isProcessingRecord) {
-					log.warning(
-						Msg.parseTranslation(
-							context,
-							"@Ignored@ " + column.getName() + " (" + columnName + ") @NewValue@ = " + displayValue + " : @Processing@ "
-						)
-					);
-					return;
-				}
-
-				// if (!Util.isEmpty(column.getReadOnlyLogic(), true)) {
-				// 	boolean isReadOnlyColumn = Evaluator.evaluateLogic(currentEntity, column.getReadOnlyLogic());
-				// 	if (isReadOnlyColumn) {
-				// 		log.warning(
-				// 			Msg.parseTranslation(
-				// 				context,
-				// 				"@Ignored@ " + column.getName() + " (" + columnName + ") @NewValue@ = " + displayValue + " : @ReadOnlyLogic@ "
-				// 			)
-				// 		);
-				// 		return;
-				// 	}
-				// }
-
-				// if (!columnName.equals(I_AD_Element.COLUMNNAME_IsActive)) {
-				// 	if (!isActiveRecord) {
-				// 		log.warning(
-				// 			Msg.parseTranslation(
-				// 				context,
-				// 				"@Ignored@ " + column.getName() + " (" + columnName + ") @NewValue@ = " + displayValue + " : @NotActive@ "
-				// 			)
-				// 		);
-				// 		return;
-				// 	}
-				// }
-
-				// MField field = new Query(
-				// 	Env.getCtx(),
-				// 	I_AD_Field.Table_Name,
-				// 	I_AD_Field.COLUMNNAME_AD_Column_ID + " = ? AND " + I_AD_Field.COLUMNNAME_AD_Tab_ID + " = ?",
-				// 	null
-				// )
-				// 	.setParameters(column.getAD_Column_ID(), tab.getAD_Tab_ID())
-				// 	.setOnlyActiveRecords(true)
-				// 	.first()
-				// ;
-				// if (field != null) {
-				// 	if (field.isReadOnly()) {
-				// 		log.warning(
-				// 			Msg.parseTranslation(
-				// 				context,
-				// 				"@Ignored@ " + column.getName() + " (" + columnName + ") @NewValue@ = " + displayValue + " : @IsReadOnly@ "
-				// 			)
-				// 		);
-				// 		return;
-				// 	}
-				// }
+			if (RecordWriteGuard.shouldSkipColumn(currentEntity, column)) {
+				log.warning(
+					Msg.parseTranslation(
+						context,
+						"@Ignored@ " + column.getName() + " (" + columnName + ") @NewValue@ = " + displayValue + " : @NotAllowed@"
+					)
+				);
+				return;
 			}
 
 			Object value = null;


### PR DESCRIPTION
## Summary

- Add `RecordWriteGuard` utility to centralize write-protection rules and prevent header mutation on closed documents (`DocStatus IN ('CO','CL','VO','RE')`)
- Wire the guard into 11 gRPC entity-write endpoints across `BusinessData`, `TabEntityLogic`, `BrowserLogic`, `DisplayDefinitionServiceLogic`, and `RecordManagementServiceLogic`
- Closes #2161 — a Credit Note had `DocumentNo`, `C_DocTypeTarget_ID`, `DateAcct`, `DateInvoiced` and other header fields mutated on a `DocStatus='CO'` / `Processed='Y'` record, leaving it out of sync with the fiscal authority

## Test plan

- [ ] Existing test suite passes
- [ ] Manual repro of #2161: attempt to update `C_DocTypeTarget_ID` / `DateAcct` / `DateInvoiced` / `DocumentNo` on a `DocStatus='CO'` invoice via `TabEntityLogic.updateTabEntity` and `BusinessData.updateEntity` — confirm rejection with `@NotAllowed@` warning
- [ ] Happy path UPDATE: edit `Description` (only `IsAlwaysUpdateable='Y'` field) on a closed invoice — confirm the change still persists
- [ ] CREATE not regressed: create a draft invoice via `TabEntityLogic.createTabEntity` and `BusinessData.createEntity` — confirm both succeed
- [ ] Cross-client: call `BusinessData.updateEntity` from session in client A against a record in client B — confirm `@Ignored@ : Record is other client`
- [ ] View table: call any patched endpoint against a table with `IsView='Y'` — confirm `AdempiereException` with `@IsView@`
- [ ] Read-only tab: call `TabEntityLogic.{create,update}TabEntity` with `IsReadOnly='Y'` tab — confirm rejection
- [ ] Toggle on closed doc: `RecordManagementServiceLogic.toggleIsActiveRecord` against a `DocStatus='CO'` invoice — confirm silent skip (`totalChanges=0`)
- [ ] Restore record 1343230 after deploy: `UPDATE C_Invoice SET DocumentNo='A12110', C_DocTypeTarget_ID=1000249, C_DocType_ID=1000249, DateAcct='2026-01-16', DateInvoiced='2026-01-16' WHERE C_Invoice_ID=1343230;` (verify no dependent `Fact_Acct` rows first)

## Additional context
fixes: https://github.com/solop-develop/adempiere-solop/issues/2161