### PR TITLE
# fix: List print formats for financial reports by matching AD_Table_ID

### DIFF
--- a/src/main/java/org/spin/grpc/service/ReportManagement.java
+++ b/src/main/java/org/spin/grpc/service/ReportManagement.java
@@ -959,10 +959,7 @@ public class ReportManagement extends ReportManagementImplBase {
 		List<Object> parameters = new ArrayList<>();
 		//	For Table Name
 		if(!Util.isEmpty(request.getTableName(), true)) {
-			MTable table = MTable.get(Env.getCtx(), request.getTableName());
-			if (table == null || table.getAD_Table_ID() <= 0) {
-				throw new AdempiereException("@TableName@ @NotFound@");
-			}
+			MTable table = RecordUtil.validateAndGetTable(request.getTableName());
 			whereClause = "AD_Table_ID = ? "
 				+ "OR EXISTS ("
 					+ "SELECT 1 FROM AD_PrintFormat AS pf "
@@ -978,9 +975,19 @@ public class ReportManagement extends ReportManagementImplBase {
 			whereClause = "EXISTS("
 					+ "SELECT 1 FROM AD_Process AS p "
 					+ "WHERE p.AD_Process_ID = ? "
-					+ "AND (p.AD_PrintFormat_ID = AD_PrintFormat.AD_PrintFormat_ID "
-					+ "OR p.AD_ReportView_ID = AD_PrintFormat.AD_ReportView_ID) "
 					+ "AND p.IsActive = 'Y' "
+					+ "AND ("
+						+ "p.AD_PrintFormat_ID = AD_PrintFormat.AD_PrintFormat_ID "
+						+ "OR p.AD_ReportView_ID = AD_PrintFormat.AD_ReportView_ID "
+						+ "OR AD_PrintFormat.AD_Table_ID = ("
+							+ "SELECT AD_Table_ID FROM AD_PrintFormat "
+							+ "WHERE AD_PrintFormat_ID = p.AD_PrintFormat_ID"
+						+ ") "
+						+ "OR AD_PrintFormat.AD_Table_ID = ("
+							+ "SELECT AD_Table_ID FROM AD_ReportView "
+							+ "WHERE AD_ReportView_ID = p.AD_ReportView_ID"
+						+ ")"
+					+ ")"
 				+ ")"
 			;
 			parameters.add(request.getReportId());


### PR DESCRIPTION

## Summary

Financial reports (e.g. *Balance General*) were not listing available print formats in the report viewer, because `listPrintFormats` only matched formats whose `AD_PrintFormat_ID` or `AD_ReportView_ID` referenced the process directly. Financial reports use a generic process while their custom print formats share the same `AD_Table_ID`, so they were excluded.

## Changes

- `listPrintFormats` ([ReportManagement.java:975-992](src/main/java/org/spin/grpc/service/ReportManagement.java#L975-L992)): extend the `EXISTS` clause to also match by `AD_Table_ID`, resolved from both the process's `AD_PrintFormat` and `AD_ReportView`.
- Replace manual `MTable` validation with the existing `RecordUtil.validateAndGetTable(...)` helper.

## Test plan

- [ ] Open a Financial Report and verify the "Print Format" selector lists the formats for its table.
- [ ] Verify reports that worked before still list their formats with no duplicates.
- [ ] Confirm `TableName` and `ReportViewId` filtering paths are unaffected.

## Additional context
fixes https://github.com/solop-develop/adempiere-solop/issues/2783

