### PR TITLE
fix(sp034): GetAttributes — resilient import, category allocation, an…

### DIFF
--- a/src/patches/java/com/solop/sp034/process/GetAttributes.java
+++ b/src/patches/java/com/solop/sp034/process/GetAttributes.java
@@ -1,0 +1,448 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2017 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * or (at your option) any later version.                                     *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net                                                  *
+ * or https://github.com/adempiere/adempiere/blob/develop/license.html        *
+ *****************************************************************************/
+
+package com.solop.sp034.process;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solop.sp034.util.Changes;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.adempiere.core.domains.models.I_M_Product;
+import org.adempiere.core.domains.models.I_W_Store;
+import org.adempiere.exceptions.AdempiereException;
+import org.compiere.model.MStore;
+import org.compiere.model.MTable;
+import org.compiere.model.PO;
+import org.compiere.model.Query;
+import org.compiere.util.CLogger;
+import org.compiere.util.Trx;
+import org.compiere.util.Util;
+
+import java.math.BigDecimal;
+import java.sql.SQLException;
+import java.sql.Savepoint;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/** Generated Process for (Get Attributes)
+ *  @author Yamel Senih, yamel.senih@solopsoftware.com, Solop <a href="http://www.solopsoftware.com">solopsoftware.com</a>
+ */
+public class GetAttributes extends GetAttributesAbstract {
+
+	private static final CLogger log = CLogger.getCLogger(GetAttributes.class);
+	private final AtomicInteger created = new AtomicInteger();
+	private final AtomicInteger errors = new AtomicInteger();
+
+	@Override
+	protected String doIt() throws Exception {
+		if(getSelectionKeys() != null) {
+			if (getSelectionKeys().size() > 1) {
+				throw new AdempiereException("@SP034_SelectOnlyOneRecord@ (" + getSelectionKeys().size() + ")");
+			}
+			Optional<Integer> maybeCategoryId = getSelectionKeys().stream().findFirst();
+			if(maybeCategoryId.isPresent()) {
+				int categoryId = maybeCategoryId.get();
+				MTable temporaryCategoryTable = MTable.get(getCtx(), Changes.Table_T_SP034_Category);
+				PO temporaryCategory = temporaryCategoryTable.getPO(categoryId, get_TrxName());
+				String value = temporaryCategory.get_ValueAsString("Value");
+				String name = temporaryCategory.get_ValueAsString("Name");
+				MStore store = MStore.get(getCtx(), temporaryCategory.get_ValueAsInt(I_W_Store.COLUMNNAME_W_Store_ID));
+				String attributesUrl = store.get_ValueAsString(Changes.SP034_AttributesUrl);
+				if(Util.isEmpty(attributesUrl, true)) {
+					throw new AdempiereException("@W_Store_ID@ [@SP034_AttributesUrl@] @NotFound@");
+				}
+				HttpUrl httpUrl = Objects.requireNonNull(HttpUrl.parse(attributesUrl))
+					.newBuilder()
+					.addQueryParameter("category_id", value)
+					.build()
+				;
+				Request request = new Request.Builder().url(httpUrl).get().build();
+				final OkHttpClient client = new OkHttpClient();
+				try (Response response = client.newCall(request).execute()) {
+					if (response.isSuccessful()) {
+						ObjectMapper objectMapper = new ObjectMapper();
+						if(response.body() != null) {
+							List<AttributeResponse> attributes = objectMapper.readValue(response.body().string(), new TypeReference<List<AttributeResponse>>() {});
+							createAttributes(temporaryCategory, attributes);
+						}
+					} else {
+						throw new AdempiereException("Error sending " + value + " - " + name + ". Response Code: " + response.code() + ", Body: " + response.body().string());
+					}
+				} catch (Exception e) {
+					throw new AdempiereException(e);
+				}
+			}
+		}
+		return "@Created@: " + created + " @Errors@: " + errors;
+	}
+
+	private void deleteOldAllocations(int productId) {
+		MTable allocationTable = MTable.get(getCtx(), Changes.Table_SP034_ProductCategory);
+		new Query(
+			getCtx(),
+			Changes.Table_SP034_ProductCategory,
+			"M_Product_ID = ?",
+			null
+		)
+			.setParameters(productId)
+			.setOnlyActiveRecords(true)
+			.getIDsAsList()
+			.forEach(allocationId -> {
+				PO allocation = allocationTable.getPO(allocationId, get_TrxName());
+				allocation.deleteEx(true);
+			})
+		;
+	}
+
+	private void createAllocation(int productId, int categoryId) {
+		MTable allocationTable = MTable.get(getCtx(), Changes.Table_SP034_ProductCategory);
+		PO allocation = allocationTable.getPO(0, get_TrxName());
+		allocation.set_ValueOfColumn(I_M_Product.COLUMNNAME_M_Product_ID, productId);
+		allocation.set_ValueOfColumn("SP034_Category_ID", categoryId);
+		allocation.saveEx();
+	}
+
+	private boolean isAllocatedToCategory(int productId, int categoryId) {
+		return new Query(
+				getCtx(),
+				Changes.Table_SP034_ProductCategory,
+				"M_Product_ID = ? AND SP034_Category_ID = ?",
+				null
+			)
+			.setParameters(productId, categoryId)
+			.setOnlyActiveRecords(true)
+			.match()
+		;
+	}
+
+	private PO getCategory(String value) {
+		return new Query(
+				getCtx(),
+				Changes.Table_SP034_Category,
+				"Value = ?",
+				null
+			)
+			.setParameters(value)
+			.setOnlyActiveRecords(true)
+			.first()
+		;
+	}
+
+	private PO getAttributeCategory(String value, int categoryId) {
+		return new Query(
+				getCtx(),
+				Changes.Table_SP034_Attribute,
+				"Value = ? AND SP034_Category_ID = ?",
+				null
+			)
+			.setParameters(value, categoryId)
+			.setOnlyActiveRecords(true)
+			.first()
+		;
+	}
+
+	private void deleteOldAttributeAllocations(int productId) {
+		MTable allocationTable = MTable.get(getCtx(), Changes.Table_SP034_Allocation);
+		new Query(
+				getCtx(),
+				Changes.Table_SP034_Allocation,
+				"M_Product_ID = ?",
+				null
+			)
+			.setParameters(productId)
+			.getIDsAsList()
+			.forEach(id -> {
+				PO allocationEntity = allocationTable.getPO(id, get_TrxName());
+				allocationEntity.deleteEx(true);
+			})
+		;
+	}
+
+	private void deleteAttributeListValues(int attributeId) {
+		MTable listTable = MTable.get(getCtx(), Changes.Table_SP034_AttributeList);
+		new Query(
+				getCtx(),
+				Changes.Table_SP034_AttributeList,
+				"SP034_Attribute_ID = ?",
+				null
+			)
+			.setParameters(attributeId)
+			.getIDsAsList()
+			.forEach(id -> {
+				PO attributeEntity = listTable.getPO(id, get_TrxName());
+				attributeEntity.deleteEx(true);
+			})
+		;
+	}
+
+	private void createAttributes(PO temporaryCategory, List<AttributeResponse> attributes) {
+		String value = temporaryCategory.get_ValueAsString("Value");
+		String name = temporaryCategory.get_ValueAsString("Name");
+		String description = temporaryCategory.get_ValueAsString("Description");
+		int storeId = temporaryCategory.get_ValueAsInt(I_W_Store.COLUMNNAME_W_Store_ID);
+		int productId = temporaryCategory.get_ValueAsInt(I_M_Product.COLUMNNAME_M_Product_ID);
+		PO category = getCategory(value);
+		if(category == null) {
+			MTable categoryTable = MTable.get(getCtx(), Changes.Table_SP034_Category);
+			category = categoryTable.getPO(0, get_TrxName());
+			category.setAD_Org_ID(0);
+			category.set_ValueOfColumn("Value", value);
+			category.set_ValueOfColumn("Name", name);
+			category.set_ValueOfColumn("Description", description);
+			category.set_ValueOfColumn("W_Store_ID", storeId);
+			category.saveEx();
+		}
+
+		int categoryId = category.get_ID();
+		// Link this product to the selected category. Previously this only ran when the
+		// category was created for the first time globally, so a product that selected an
+		// already-imported category was never allocated -> no attributes to set in the UI.
+		// When the product changes category we must clear its old values, but we first
+		// snapshot them by attribute code so equivalent attributes in the new category keep
+		// the user's value (issue #2845 follow-up: avoid re-typing values on category change).
+		Map<String, List<AllocationSnapshot>> preservedValues = new HashMap<>();
+		boolean categoryChanged = !isAllocatedToCategory(productId, categoryId);
+		if(categoryChanged) {
+			preservedValues = captureAllocationValues(productId);
+			deleteOldAllocations(productId);
+			deleteOldAttributeAllocations(productId);
+			createAllocation(productId, categoryId);
+		}
+		MTable attributeTable = MTable.get(getCtx(), Changes.Table_SP034_Attribute);
+		Trx trx = get_TrxName() != null ? Trx.get(get_TrxName(), false) : null;
+		log.info("Importing " + attributes.size() + " attributes for category '" + value + "' (id=" + categoryId + ")");
+		for(int index = 0; index < attributes.size(); index++) {
+			AttributeResponse attribute = attributes.get(index);
+			// Skip malformed entries: without a code there is no Value to persist
+			if(Util.isEmpty(attribute.code, true)) {
+				errors.incrementAndGet();
+				log.warning("Skipping attribute without code at position " + index + ": " + attribute);
+				continue;
+			}
+			log.info("Processing attribute [" + index + "] '" + attribute.code + "' (value_type=" + attribute.value_type + ", values=" + (attribute.values != null ? attribute.values.size() : 0) + ")");
+			// Isolate each attribute in its own savepoint so a single failure does not
+			// poison the shared transaction (PostgreSQL aborts the whole transaction on
+			// the first failed statement, which would otherwise drop every later attribute)
+			Savepoint savepoint = null;
+			try {
+				if(trx != null) {
+					savepoint = trx.setSavepoint(null);
+				}
+				boolean isNew;
+				PO attributeEntity = getAttributeCategory(attribute.code, categoryId);
+				if(attributeEntity == null) {
+					isNew = true;
+					attributeEntity = attributeTable.getPO(0, get_TrxName());
+					attributeEntity.setAD_Org_ID(0);
+					attributeEntity.set_ValueOfColumn("SP034_Category_ID", categoryId);
+				} else {
+					isNew = false;
+				}
+				// Always update definition fields (create or refresh)
+				attributeEntity.set_ValueOfColumn("Value", attribute.code);
+				attributeEntity.set_ValueOfColumn("Name", attribute.name);
+				attributeEntity.set_ValueOfColumn("Description", attribute.description);
+				attributeEntity.set_ValueOfColumn("IsMandatory", Boolean.TRUE.equals(attribute.mandatory));
+				//	Value Type
+				if(attribute.values != null && !attribute.values.isEmpty()) {
+					attributeEntity.set_ValueOfColumn(Changes.SP034_ValueType, Changes.SP034_ValueType_List);
+				} else {
+					// value_type can be null when MercadoLibre/n8n omits it; default to String
+					String valueType = attribute.value_type != null ? attribute.value_type : "";
+					switch (valueType) {
+						case "number":
+						case "number_unit":
+							attributeEntity.set_ValueOfColumn(Changes.SP034_ValueType, Changes.SP034_ValueType_Number);
+							break;
+						case "boolean":
+							attributeEntity.set_ValueOfColumn(Changes.SP034_ValueType, Changes.SP034_ValueType_Boolean);
+							break;
+						default:
+							attributeEntity.set_ValueOfColumn(Changes.SP034_ValueType, Changes.SP034_ValueType_String);
+							break;
+					}
+				}
+				attributeEntity.saveEx();
+				int attributeEntityId = attributeEntity.get_ID();
+				// On update, refresh list values; on create they are simply added
+				if(!isNew) {
+					deleteAttributeListValues(attributeEntityId);
+				}
+				if(attribute.values != null && !attribute.values.isEmpty()) {
+					MTable attributeValueTable = MTable.get(getCtx(), Changes.Table_SP034_AttributeList);
+					attribute.values.forEach(attributeValue -> {
+						PO attributeValueEntity = attributeValueTable.getPO(0, get_TrxName());
+						attributeValueEntity.setAD_Org_ID(0);
+						attributeValueEntity.set_ValueOfColumn("SP034_Attribute_ID", attributeEntityId);
+						attributeValueEntity.set_ValueOfColumn("Value", attributeValue.code);
+						attributeValueEntity.set_ValueOfColumn("Name", attributeValue.name);
+						attributeValueEntity.saveEx();
+					});
+				}
+				created.incrementAndGet();
+			} catch (Exception e) {
+				errors.incrementAndGet();
+				log.warning("Error importing attribute '" + attribute.code + "': " + e.getLocalizedMessage());
+				if(trx != null && savepoint != null) {
+					try {
+						trx.rollback(savepoint);
+					} catch (SQLException rollbackError) {
+						log.severe("Could not rollback savepoint for attribute '" + attribute.code + "': " + rollbackError.getLocalizedMessage());
+					}
+				}
+			}
+		}
+		// Re-apply the user's previously loaded values to the new category's attributes,
+		// matching by attribute code. List values are only restored if they still exist in
+		// the new attribute's value list.
+		if(!preservedValues.isEmpty()) {
+			restoreAllocationValues(productId, categoryId, preservedValues);
+		}
+		log.info("Finished importing attributes for category '" + value + "': created=" + created.get() + ", errors=" + errors.get());
+	}
+
+	/** Snapshot of a user-filled allocation value, kept category-independent (keyed later by attribute code). */
+	private static class AllocationSnapshot {
+		String stringValue;
+		BigDecimal numberValue;
+		String booleanValue;
+		String longStringValue;
+		String listValueCode;
+	}
+
+	/** Capture the product's loaded attribute values (template rows, no publishing) indexed by attribute code. */
+	private Map<String, List<AllocationSnapshot>> captureAllocationValues(int productId) {
+		Map<String, List<AllocationSnapshot>> snapshots = new HashMap<>();
+		MTable allocationTable = MTable.get(getCtx(), Changes.Table_SP034_Allocation);
+		MTable attributeTable = MTable.get(getCtx(), Changes.Table_SP034_Attribute);
+		MTable listTable = MTable.get(getCtx(), Changes.Table_SP034_AttributeList);
+		new Query(
+				getCtx(),
+				Changes.Table_SP034_Allocation,
+				"M_Product_ID = ? AND SP034_Publishing_ID IS NULL",
+				get_TrxName()
+			)
+			.setParameters(productId)
+			.setOnlyActiveRecords(true)
+			.getIDsAsList()
+			.forEach(id -> {
+				PO allocation = allocationTable.getPO(id, get_TrxName());
+				PO attribute = attributeTable.getPO(allocation.get_ValueAsInt("SP034_Attribute_ID"), get_TrxName());
+				if(attribute == null) {
+					return;
+				}
+				String code = attribute.get_ValueAsString("Value");
+				if(Util.isEmpty(code, true)) {
+					return;
+				}
+				AllocationSnapshot snapshot = new AllocationSnapshot();
+				snapshot.stringValue = allocation.get_ValueAsString("SP034_String");
+				snapshot.numberValue = (BigDecimal) allocation.get_Value("SP034_Number");
+				snapshot.longStringValue = allocation.get_ValueAsString("SP034_LongString");
+				Object booleanRaw = allocation.get_Value("SP034_Boolean");
+				if(booleanRaw != null) {
+					snapshot.booleanValue = allocation.get_ValueAsBoolean("SP034_Boolean") ? "Y" : "N";
+				}
+				int listId = allocation.get_ValueAsInt("SP034_AttributeList_ID");
+				if(listId > 0) {
+					PO listValue = listTable.getPO(listId, get_TrxName());
+					if(listValue != null) {
+						snapshot.listValueCode = listValue.get_ValueAsString("Value");
+					}
+				}
+				snapshots.computeIfAbsent(code, key -> new ArrayList<>()).add(snapshot);
+			})
+		;
+		return snapshots;
+	}
+
+	/** Re-create allocations for the new category from the captured values, matching by attribute code. */
+	private void restoreAllocationValues(int productId, int categoryId, Map<String, List<AllocationSnapshot>> preservedValues) {
+		MTable allocationTable = MTable.get(getCtx(), Changes.Table_SP034_Allocation);
+		preservedValues.forEach((code, snapshots) -> {
+			PO attribute = getAttributeCategory(code, categoryId);
+			if(attribute == null) {
+				// Attribute does not exist in the new category -> nothing to restore.
+				return;
+			}
+			int attributeId = attribute.get_ID();
+			snapshots.forEach(snapshot -> {
+				try {
+					PO allocation = allocationTable.getPO(0, get_TrxName());
+					allocation.setAD_Org_ID(0);
+					allocation.set_ValueOfColumn(I_M_Product.COLUMNNAME_M_Product_ID, productId);
+					allocation.set_ValueOfColumn("SP034_Attribute_ID", attributeId);
+					boolean hasValue = false;
+					if(!Util.isEmpty(snapshot.listValueCode, true)) {
+						PO listValue = findListValue(snapshot.listValueCode, attributeId);
+						if(listValue == null) {
+							// The previously selected list option is not valid in the new category.
+							return;
+						}
+						allocation.set_ValueOfColumn("SP034_AttributeList_ID", listValue.get_ID());
+						hasValue = true;
+					}
+					if(!Util.isEmpty(snapshot.stringValue, true)) {
+						allocation.set_ValueOfColumn("SP034_String", snapshot.stringValue);
+						hasValue = true;
+					}
+					if(snapshot.numberValue != null) {
+						allocation.set_ValueOfColumn("SP034_Number", snapshot.numberValue);
+						hasValue = true;
+					}
+					if(!Util.isEmpty(snapshot.longStringValue, true)) {
+						allocation.set_ValueOfColumn("SP034_LongString", snapshot.longStringValue);
+						hasValue = true;
+					}
+					if(snapshot.booleanValue != null) {
+						allocation.set_ValueOfColumn("SP034_Boolean", "Y".equals(snapshot.booleanValue));
+						hasValue = true;
+					}
+					if(!hasValue) {
+						return;
+					}
+					allocation.saveEx();
+				} catch (Exception e) {
+					log.warning("Could not restore value for attribute '" + code + "': " + e.getLocalizedMessage());
+				}
+			});
+		});
+	}
+
+	private PO findListValue(String value, int attributeId) {
+		return new Query(
+				getCtx(),
+				Changes.Table_SP034_AttributeList,
+				"Value = ? AND SP034_Attribute_ID = ?",
+				get_TrxName()
+			)
+			.setParameters(value, attributeId)
+			.setOnlyActiveRecords(true)
+			.first()
+		;
+	}
+
+}


### PR DESCRIPTION
…d value preservation (#2845)

## Context
When fetching a MercadoLibre category's attributes (the `Get Attributes` process), three issues were found: the import was **incomplete** (only some attributes were saved), a product that picked an **already-existing** category ended up **with no attributes to fill**, and **changing category wiped** the values the user had already loaded.

## Changes

### 1. Resilient attribute import (#2845)
- Each attribute is processed inside its own **savepoint**: if one fails, it rolls back to the savepoint and continues with the rest. Previously a single failure aborted the whole transaction (PostgreSQL marks it as aborted) and cut the import short, dropping attributes — including required ones like `BRAND`/`MODEL`.
- **Null-safe** parsing: null `value_type` → defaults to String (avoids the NPE in the `switch`); null `mandatory` → `false`.
- Attributes without a `code` are skipped (cannot persist without `Value`) and counted as errors.
- Per-attribute **logging** (position + code + type) and a final summary (`created` / `errors`).

### 2. Product↔category allocation
- The link (`SP034_ProductCategory`) and cleanup were moved out of the `if (category == null)` block (which only ran the first time a category was created globally). They now run when the product is **not** allocated to the selected category (`isAllocatedToCategory`). Without this, a product selecting a category already imported by another product was never allocated, so the UI showed no attributes to fill.

### 3. Value preservation on category change
- Before deleting the user's allocations, their values are **captured** indexed by **attribute code** (`captureAllocationValues`).
- After re-importing the new category, they are **restored** onto the equivalent attributes by code (`restoreAllocationValues`). For lists/combos, `findListValue` validates that the value **still exists** in the new attribute's list; otherwise it is skipped.
- Supports multivalued attributes. Only applies when **changing** category; re-importing the same category leaves values untouched.

## Resulting behavior
- **All** category attributes are imported (including required ones); an attribute with invalid data is isolated and logged without affecting the rest.
- The product is allocated to the chosen category → the UI offers the attributes to fill.
- Changing category keeps the values of equivalent attributes (no re-typing), discarding only those that no longer apply.

## Testing
- Re-run `Get Attributes` on a category with many attributes (e.g. MLU164548, ~89) → `created = N, errors = 0`, no cut-off.
- Pick an already-existing category for a new product → the product gets allocated and the attributes appear.
- Load values, switch to another category that shares attributes (`BRAND`, `COLOR`, …) → values are preserved; a list value that doesn't exist in the new category is skipped.

## Notes
- Requires a backend redeploy.
- `SP034_ValueType` is non-updatable in the dictionary: on re-imports, existing attributes log `Column not updateable - SP034_ValueType` (benign); `IsMandatory` is updated correctly.

### Additional context
fixes https://github.com/solop-develop/adempiere-solop/issues/2891

