### PR TITLE
fix: normalize AD_Language in preferences and add typed PreferenceUtil getters

### DIFF
--- a/src/patches/java/org/compiere/model/MPreference.java
+++ b/src/patches/java/org/compiere/model/MPreference.java
@@ -1,0 +1,176 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 1999-2006 ComPiere, Inc. All Rights Reserved.                *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * ComPiere, Inc., 2620 Augustine Dr. #245, Santa Clara, CA 95054, USA        *
+ * or via info@compiere.org or http://www.compiere.org/license.html           *
+ *****************************************************************************/
+package org.compiere.model;
+
+import java.sql.ResultSet;
+import java.util.Properties;
+
+import org.adempiere.core.domains.models.X_AD_Preference;
+import org.compiere.util.DB;
+import org.compiere.util.Util;
+
+/**
+ *	Preference Model
+ *	
+ *  @author Jorg Janke
+ *  @version $Id: MPreference.java,v 1.3 2006/07/30 00:51:03 jjanke Exp $
+ */
+public class MPreference extends X_AD_Preference
+{
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = -5098559160325123593L;
+	/**	Null Indicator				*/
+	public static String		NULL = "null";
+	
+	/**
+	 * 	Standatrd Constructor
+	 *	@param ctx ctx
+	 *	@param AD_Preference_ID id
+	 *	@param trxName transaction
+	 */
+	public MPreference(Properties ctx, int AD_Preference_ID, String trxName)
+	{
+		super(ctx, AD_Preference_ID, trxName);
+		if (AD_Preference_ID == 0)
+		{
+		//	setAD_Preference_ID (0);
+		//	setAttribute (null);
+		//	setValue (null);
+		}
+	}	//	MPreference
+
+	/**
+	 * 	Load Contsructor
+	 *	@param ctx context
+	 *	@param rs result set
+	 *	@param trxName transaction
+	 */
+	public MPreference(Properties ctx, ResultSet rs, String trxName)
+	{
+		super(ctx, rs, trxName);
+	}	//	MPreference
+
+	/**
+	 * 	Full Constructor
+	 *	@param ctx context
+	 *	@param Attribute attribute
+	 *	@param Value value
+	 *	@param trxName trx
+	 */
+	public MPreference (Properties ctx, String Attribute, String Value, String trxName)
+	{
+		this (ctx, 0, trxName);
+		setAttribute (Attribute);
+		setValue (Value);
+	}	//	MPreference
+
+	/** Attribute name that stores the user's preferred language. */
+	private static final String ATTRIBUTE_LANGUAGE = "Language";
+
+	/**
+	 * 	Before Save
+	 *	@param newRecord
+	 *	@return true if can be saved
+	 */
+	protected boolean beforeSave (boolean newRecord)
+	{
+		String value = getValue();
+		if (value == null)
+			value = "";
+		if (value.equals("-1"))
+			setValue("");
+		// Defense-in-depth: any preference row holding the user's language
+		// must store a valid AD_Language code (e.g. "es_MX"), never a
+		// localized display name (e.g. "Español (MX)"). Legacy ZK UI
+		// flows persisted the display name directly, which downstream
+		// consumers then forwarded as an identifier — breaking the menu
+		// API, Elasticsearch index resolution, and print engines.
+		if (ATTRIBUTE_LANGUAGE.equals(getAttribute()) && !Util.isEmpty(getValue(), true)) {
+			String normalized = normalizeLanguageCode(getValue());
+			if (!Util.isEmpty(normalized, true)) {
+				setValue(normalized);
+			}
+		}
+		return true;
+	}	//	beforeSave
+
+	/**
+	 * Resolve any language string into a canonical {@code AD_Language}
+	 * code by a tiered lookup against {@code AD_Language}. The input
+	 * length picks the column to match:
+	 * <ol>
+	 *   <li><b>2-char ISO</b> ({@code "es"}, {@code "en"}) → matched
+	 *       against {@code LanguageISO}, returning the system/base
+	 *       AD_Language for that ISO.</li>
+	 *   <li><b>Exact AD_Language code</b> ({@code "es_MX"}, {@code
+	 *       "en_US"}) → matched against {@code AD_Language}.</li>
+	 *   <li><b>Anything else</b> (display names like {@code "Español
+	 *       (MX)"}) → matched against {@code Name} or {@code PrintName}.</li>
+	 * </ol>
+	 * Returns null when no tier produces a match — the caller leaves the
+	 * raw value in place so legacy data is not destroyed.
+	 */
+	public static String normalizeLanguageCode(String input) {
+		if (Util.isEmpty(input, true)) {
+			return null;
+		}
+		String trimmed = input.trim();
+		if (trimmed.length() == 2) {
+			return DB.getSQLValueString(
+				null,
+				"SELECT AD_Language FROM AD_Language "
+					+ "WHERE UPPER(LanguageISO) = UPPER(?) "
+					+ "AND (IsSystemLanguage = 'Y' OR IsBaseLanguage = 'Y') "
+					+ "AND ROWNUM = 1",
+				trimmed
+			);
+		}
+		String code = DB.getSQLValueString(
+			null,
+			"SELECT AD_Language FROM AD_Language "
+				+ "WHERE UPPER(AD_Language) = UPPER(?) "
+				+ "AND ROWNUM = 1",
+			trimmed
+		);
+		if (!Util.isEmpty(code, true)) {
+			return code;
+		}
+		return DB.getSQLValueString(
+			null,
+			"SELECT AD_Language FROM AD_Language "
+				+ "WHERE (UPPER(Name) = UPPER(?) OR UPPER(PrintName) = UPPER(?)) "
+				+ "AND ROWNUM = 1",
+			trimmed, trimmed
+		);
+	}
+
+	/**
+	 * 	String Representation
+	 *	@return info
+	 */
+	public String toString ()
+	{
+		StringBuffer sb = new StringBuffer ("MPreference[");
+		sb.append (get_ID()).append("-")
+			.append(getAttribute()).append("-").append(getValue())
+			.append ("]");
+		return sb.toString ();
+	}	//	toString
+	
+}	//	MPreference

--- a/src/patches/java/org/spin/service/grpc/util/base/PreferenceUtil.java
+++ b/src/patches/java/org/spin/service/grpc/util/base/PreferenceUtil.java
@@ -21,7 +21,6 @@ import java.util.List;
 import org.adempiere.core.domains.models.I_AD_Preference;
 import org.compiere.model.MPreference;
 import org.compiere.model.Query;
-import org.compiere.util.DB;
 import org.compiere.util.Env;
 import org.compiere.util.Util;
 
@@ -142,61 +141,13 @@ public class PreferenceUtil {
 
 
 	/**
-	 * Normalise a language string into a valid {@code AD_Language} code by a
-	 * tiered lookup against {@code AD_Language}. The dispatcher chooses the
-	 * column to match by the length of the input:
-	 *
-	 * <ol>
-	 *   <li><b>2-char ISO</b> ({@code "es"}, {@code "en"}) → matched against
-	 *       {@code LanguageISO}, returning the system/base AD_Language for
-	 *       that ISO. This handles legacy data where the Vue language
-	 *       dropdown stored only the ISO code.</li>
-	 *   <li><b>Exact AD_Language code</b> ({@code "es_MX"}, {@code "en_US"})
-	 *       → matched against {@code AD_Language}. Fast happy path.</li>
-	 *   <li><b>Anything else</b> (e.g. {@code "Español (MX)"}, the display
-	 *       name written by the ZK UI login flow) → matched against
-	 *       {@code Name} or {@code PrintName}. This is the recovery path
-	 *       for legacy display-name data already in the table.</li>
-	 * </ol>
-	 *
-	 * Returns null when no tier produces a match — callers fall back to a
-	 * system default.
+	 * Thin wrapper around {@link MPreference#normalizeLanguageCode(String)}
+	 * so the tiered lookup against {@code AD_Language} lives in a single
+	 * place. Returns the canonical {@code AD_Language} code, or null when
+	 * the input does not match any row.
 	 */
 	private static String normalizeLanguageCode(String input) {
-		if (Util.isEmpty(input, true)) {
-			return null;
-		}
-		String trimmed = input.trim();
-
-		if (trimmed.length() == 2) {
-			return DB.getSQLValueString(
-				null,
-				"SELECT AD_Language FROM AD_Language "
-					+ "WHERE UPPER(LanguageISO) = UPPER(?) "
-					+ "AND (IsSystemLanguage = 'Y' OR IsBaseLanguage = 'Y') "
-					+ "AND ROWNUM = 1",
-				trimmed
-			);
-		}
-
-		String code = DB.getSQLValueString(
-			null,
-			"SELECT AD_Language FROM AD_Language "
-				+ "WHERE UPPER(AD_Language) = UPPER(?) "
-				+ "AND ROWNUM = 1",
-			trimmed
-		);
-		if (!Util.isEmpty(code, true)) {
-			return code;
-		}
-
-		return DB.getSQLValueString(
-			null,
-			"SELECT AD_Language FROM AD_Language "
-				+ "WHERE (UPPER(Name) = UPPER(?) OR UPPER(PrintName) = UPPER(?)) "
-				+ "AND ROWNUM = 1",
-			trimmed, trimmed
-		);
+		return MPreference.normalizeLanguageCode(input);
 	}
 
 


### PR DESCRIPTION

## Summary
- `MPreference.beforeSave` now normalizes the `Language` attribute to a valid `AD_Language` code at storage time, regardless of which caller wrote the row.
- A new public `MPreference.normalizeLanguageCode(String)` exposes a tiered lookup (2-char ISO → `LanguageISO`, full code → `AD_Language`, anything else → `Name`/`PrintName`) as the single source of truth for resolving any language string into a canonical code.
- `PreferenceUtil` gains typed, validated getters (`getLanguagePreference`, `getRolePreference`, `getClientPreference`, `getOrganizationPreference`, `getWarehousePreference`) and delegates its internal normalization to `MPreference.normalizeLanguageCode`, eliminating the duplicated SQL.
- `PreferenceUtil.saveSessionPreferences` skips the language write when the supplied value does not normalize, so a junk caller cannot overwrite a previously good row.

## Root cause
Legacy UI flows (most visibly the ZK UI login/role flow) persisted the localized display name returned by `Language.getName()` — e.g. `"Español (MX)"` — into `AD_Preference.Value` for the `Language` attribute. Downstream consumers that read the preference as an identifier (gRPC `session-info`, the Vue/Tepuy menu API, Elasticsearch index resolution, print engines) then forwarded that value as a query parameter, breaking with HTTP 500 when no index/locale could be resolved from a display name. With multiple callers writing to `AD_Preference` across the platform, a single point of normalization at the model layer is needed so the data shape is invariant to the writer.

## Changes
### `org/compiere/model/MPreference.java`
- New constant `ATTRIBUTE_LANGUAGE = "Language"` used by `beforeSave`.
- `beforeSave` now invokes the new `normalizeLanguageCode` for rows whose `Attribute` is `Language`, replacing the stored value with the canonical `AD_Language` code when a match is found. When no row matches, the raw value is left in place so existing data is not destroyed.
- New `public static String normalizeLanguageCode(String input)` — tiered SQL lookup against `AD_Language`, returns `null` when the input does not resolve.
- New imports: `org.compiere.util.DB`, `org.compiere.util.Util`.

### `org/spin/service/grpc/util/base/PreferenceUtil.java`
- New `getPreferenceValue(int userId, String attributeName)` — fetches the most recent value of one preference for a user.
- New `parseIdOrNegative(String value)` — parses an `AD_*_ID` from preference text, returning `-1` for missing/non-numeric values so callers can fall back to a system default and never trust unparseable data.
- New typed getters: `getLanguagePreference`, `getRolePreference`, `getClientPreference`, `getOrganizationPreference`, `getWarehousePreference`. These collapse the previous loop-and-switch retrieval pattern at call sites and document the validation expectations (role/org callers MUST re-check access — privilege-escalation defense).
- `saveSessionPreferences`: for the `Language` row, the new value is normalized via the shared `MPreference` helper before being written; when normalization returns `null` (the caller passed a display name or unknown string) the iteration `continue`s, leaving the existing row untouched.
- Internal `normalizeLanguageCode` is reduced to a thin wrapper that delegates to `MPreference.normalizeLanguageCode`, so the SQL lives in one place.
- Removed unused `org.compiere.util.DB` import.

## Compatibility
- Existing rows in `AD_Preference` are not migrated. They auto-heal on the next `save()` cycle thanks to `MPreference.beforeSave`, and the read path (`PreferenceUtil.getLanguagePreference`) tolerates the legacy display-name format during the transition.
- No public API was removed. `getSessionPreferences` and `saveSessionPreferences` keep their existing signatures; the new typed getters are additive.
- No DDL changes; the new SQL is read-only and uses `ROWNUM = 1` for cross-DB compatibility.

## Test plan
- [ ] On a database where `AD_Preference` contains rows with a display-name value for `Attribute = 'Language'` (e.g. `Español (MX)`), trigger any update of that row (role switch, login flow that saves preferences) and verify the value is rewritten to the matching `AD_Language` code (`es_MX`).
- [ ] Insert a fresh `AD_Preference` row programmatically with the language attribute set to a 2-char ISO (`es`), save, and confirm `Value` is stored as the canonical AD_Language code.
- [ ] Insert with an unknown string (e.g. `xyz`), save, and confirm the value is left in place (no exception, no overwrite to `null`).
- [ ] Call `PreferenceUtil.getLanguagePreference` on a row known to hold a legacy display name and confirm it returns the canonical code.
- [ ] Call `PreferenceUtil.saveSessionPreferences` with `language = "Español (MX)"` for a user who already has a valid stored language; confirm the stored value is NOT overwritten (skip-on-junk guarantee).
- [ ] Build downstream services that consume `adempiere-core` (e.g. the gRPC server and report-engine) against this version and confirm no compilation regressions.

### Additional context
fixes https://github.com/solop-develop/adempiere-solop/issues/2948