### PR TITLE
fix: Prevent duplicate outbound orders via available-qty validation

### DIFF
--- a/src/main/java/org/spin/grpc/service/form/out_bound_order/OutBoundOrderLogic.java
+++ b/src/main/java/org/spin/grpc/service/form/out_bound_order/OutBoundOrderLogic.java
@@ -18,7 +18,9 @@ import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -33,6 +35,7 @@ import org.compiere.model.MFreight;
 import org.compiere.model.MLocator;
 import org.compiere.model.MLookupInfo;
 import org.compiere.model.MMenu;
+import org.compiere.model.MOrder;
 import org.compiere.model.MOrderLine;
 import org.compiere.model.MOrg;
 import org.compiere.model.MProduct;
@@ -49,6 +52,7 @@ import org.compiere.util.Util;
 import org.eevolution.distribution.model.MDDDriver;
 import org.eevolution.distribution.model.MDDFreight;
 import org.eevolution.distribution.model.MDDFreightLine;
+import org.eevolution.distribution.model.MDDOrder;
 import org.eevolution.distribution.model.MDDOrderLine;
 import org.eevolution.distribution.model.MDDVehicle;
 import org.eevolution.wms.model.MWMInOutBound;
@@ -76,6 +80,7 @@ import org.spin.backend.grpc.form.out_bound_order.ListShippersRequest;
 import org.spin.backend.grpc.form.out_bound_order.ListTargetDocumentTypesRequest;
 import org.spin.backend.grpc.form.out_bound_order.ListVehiclesRequest;
 import org.spin.backend.grpc.form.out_bound_order.ListWarehousesRequest;
+import org.spin.backend.grpc.form.out_bound_order.OrderLineRequest;
 import org.spin.base.util.ReferenceInfo;
 import org.spin.grpc.service.field.field_management.FieldManagementLogic;
 import org.spin.service.grpc.util.value.NumberManager;
@@ -1062,6 +1067,113 @@ public class OutBoundOrderLogic {
 
 
 
+	// Correlated subquery — do not rewrite as LEFT JOIN + GROUP BY (that form
+	// materializes the aggregate over all m_inoutline rows on every call; in
+	// this per-line hot path it degrades from ~0.5 ms to ~440 ms per line).
+	private static final String SO_AVAILABLE_QTY_SQL =
+			"SELECT COALESCE(SUM(CASE WHEN c.IsDelivered='N' AND c.DocStatus='CO' "
+		+	"                         THEN lc.MovementQty - COALESCE(( "
+		+	"                                 SELECT SUM(iol.MovementQty) "
+		+	"                                 FROM   M_InOutLine iol "
+		+	"                                 JOIN   M_InOut     io ON io.M_InOut_ID = iol.M_InOut_ID "
+		+	"                                 WHERE  io.DocStatus IN ('CO','CL') "
+		+	"                                   AND  iol.WM_InOutBoundLine_ID = lc.WM_InOutBoundLine_ID "
+		+	"                             ), 0) "
+		+	"                         ELSE 0 END), 0) "
+		+	"FROM   WM_InOutBoundLine lc "
+		+	"JOIN   WM_InOutBound     c ON c.WM_InOutBound_ID = lc.WM_InOutBound_ID "
+		+	"WHERE  lc.C_OrderLine_ID = ?"
+	;
+
+	private static final String DD_AVAILABLE_QTY_SQL =
+			"SELECT COALESCE(SUM(CASE WHEN c.IsDelivered='N' AND c.DocStatus='CO' "
+		+	"                         THEN lc.MovementQty ELSE 0 END), 0) "
+		+	"FROM   WM_InOutBoundLine lc "
+		+	"JOIN   WM_InOutBound     c ON c.WM_InOutBound_ID = lc.WM_InOutBound_ID "
+		+	"WHERE  lc.DD_OrderLine_ID = ?"
+	;
+
+	private static void validateAvailableQuantities(String movementType, List<OrderLineRequest> lines, String transactionName) {
+		final boolean isDistribution = I_DD_Order.Table_Name.equals(movementType);
+		final Map<Integer, String> deliveryRuleByOrder = new HashMap<Integer, String>();
+		final StringBuffer errors = new StringBuffer();
+		for (OrderLineRequest requestLine : lines) {
+			int orderLineId = requestLine.getId();
+			BigDecimal requested = NumberManager.getBigDecimalFromString(requestLine.getQuantity());
+			if (orderLineId <= 0 || requested == null || requested.signum() <= 0) {
+				continue;
+			}
+			BigDecimal available;
+			String deliveryRule;
+			int orderId;
+			if (isDistribution) {
+				MDDOrderLine ol = new MDDOrderLine(Env.getCtx(), orderLineId, transactionName);
+				if (ol.getDD_OrderLine_ID() <= 0) {
+					continue;
+				}
+				orderId = ol.getDD_Order_ID();
+				deliveryRule = deliveryRuleByOrder.get(orderId);
+				if (deliveryRule == null) {
+					MDDOrder ord = new MDDOrder(Env.getCtx(), orderId, transactionName);
+					deliveryRule = ord.getDeliveryRule() != null ? ord.getDeliveryRule() : "";
+					deliveryRuleByOrder.put(orderId, deliveryRule);
+				}
+				if (X_C_Order.DELIVERYRULE_Force.equals(deliveryRule) || X_C_Order.DELIVERYRULE_Manual.equals(deliveryRule)) {
+					continue;
+				}
+				BigDecimal asignada = DB.getSQLValueBD(transactionName, DD_AVAILABLE_QTY_SQL, orderLineId);
+				if (asignada == null) {
+					asignada = Env.ZERO;
+				}
+				available = ol.getQtyOrdered()
+					.subtract(ol.getQtyInTransit())
+					.subtract(ol.getQtyDelivered())
+					.subtract(asignada)
+				;
+			} else {
+				MOrderLine ol = new MOrderLine(Env.getCtx(), orderLineId, transactionName);
+				if (ol.getC_OrderLine_ID() <= 0) {
+					continue;
+				}
+				orderId = ol.getC_Order_ID();
+				deliveryRule = deliveryRuleByOrder.get(orderId);
+				if (deliveryRule == null) {
+					MOrder ord = new MOrder(Env.getCtx(), orderId, transactionName);
+					deliveryRule = ord.getDeliveryRule() != null ? ord.getDeliveryRule() : "";
+					deliveryRuleByOrder.put(orderId, deliveryRule);
+				}
+				if (X_C_Order.DELIVERYRULE_Force.equals(deliveryRule) || X_C_Order.DELIVERYRULE_Manual.equals(deliveryRule)) {
+					continue;
+				}
+				BigDecimal asignada = DB.getSQLValueBD(transactionName, SO_AVAILABLE_QTY_SQL, orderLineId);
+				if (asignada == null) {
+					asignada = Env.ZERO;
+				}
+				available = ol.getQtyOrdered()
+					.subtract(ol.getQtyDelivered())
+					.subtract(asignada);
+			}
+			if (requested.compareTo(available) > 0) {
+				if (errors.length() > 0) {
+					errors.append(Env.NL);
+				}
+				errors.append("@C_OrderLine_ID@=").append(orderLineId)
+					.append(": @Qty@=").append(requested.stripTrailingZeros().toPlainString())
+					.append(", @QtyAvailable@=").append(available.stripTrailingZeros().toPlainString())
+				;
+			}
+		}
+		if (errors.length() > 0) {
+			throw new AdempiereException(
+				Msg.parseTranslation(
+					Env.getCtx(),
+					"@Error@ @Qty@ > @QtyAvailable@" + Env.NL + errors.toString()
+				)
+			);
+		}
+	}
+
+
 	public static GenerateLoadOrderResponse.Builder generateLoadOrder(GenerateLoadOrderRequest request) {
 		final String movementType = request.getMovementType();
 		if (Util.isEmpty(movementType, true) ||
@@ -1136,6 +1248,8 @@ public class OutBoundOrderLogic {
 		AtomicInteger linesQuantity = new AtomicInteger();
 		final int locatorId = request.getLocatorId();
 		Trx.run(transactionName -> {
+			validateAvailableQuantities(movementType, request.getLinesList(), transactionName);
+
 			AtomicReference<BigDecimal> totalWeightReference = new AtomicReference<BigDecimal>(
 				Env.ZERO
 			);

--- a/src/main/java/org/spin/grpc/service/form/out_bound_order/OutBoundOrderService.java
+++ b/src/main/java/org/spin/grpc/service/form/out_bound_order/OutBoundOrderService.java
@@ -41,6 +41,11 @@ import org.spin.backend.grpc.form.out_bound_order.OutBoundOrderServiceGrpc.OutBo
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 
+/**
+ * Based on:
+ *  - org.spin.wms.form.OutBoundOrder
+ *  - org.spin.wms.form.WOutBoundOrder
+ */
 public class OutBoundOrderService extends OutBoundOrderServiceImplBase {
 
 	/**	Logger			*/


### PR DESCRIPTION
Fix duplicate outbound orders can be generated from the same sales order because the gRPC `generateLoadOrder` service accepts the client-supplied lines without re-checking availability against the database. A double-submit (double-click, network retry, form resend without refresh) creates a second identical outbound order.

## Root cause

`OutBoundOrderLogic.generateLoadOrder` was ported from the ZK form `org.spin.wms.form.OutBoundOrder` without carrying over its `validateQuantity()` guard (checks `QtyOrdered − QtyDelivered − allocated-in-outbound` per line and rejects requested amounts that exceed it). Without that guard, the server trusts the request payload blindly, so a replayed identical payload creates a second outbound order even though the sales order has zero available quantity left.

## Fix

Add a pre-transaction check `validateAvailableQuantities` invoked as the first step inside `Trx.run` in `generateLoadOrder`. For each requested line it:

1. Loads the source order line and caches its parent order's `DeliveryRule` (avoids repeated `MOrder` / `MDDOrder` loads when all lines belong to the same order).
2. Skips the check when the delivery rule is `Force` or `Manual` (matches ZK semantics — those rules explicitly allow over-loading).
3. Computes the fresh available quantity from the database using a **correlated subquery** (see the SQL constant comment; do NOT rewrite as `LEFT JOIN + GROUP BY`).
4. Accumulates all failing lines and throws a single `AdempiereException` listing each violation as `@C_OrderLine_ID@=…, @Qty@=…, @QtyAvailable@=…`.

On the reported case the second request now reads `available = 0` and is rejected before any INSERT happens — the transaction rolls back cleanly, no duplicate outbound order is created.

Formulas replicate `listDocumentLines`:

- Sales Order: `available = QtyOrdered − QtyDelivered − allocated`
- Distribution: `available = QtyOrdered − QtyInTransit − QtyDelivered − allocated`

## Performance

Verified in dyd-dev (61k `wm_inoutboundline`, 285k `m_inoutline`, 276k `c_orderline`) with the exact SQL constants shipped here:

| Scenario | 41-line generation | Per line |
| --- | --- | --- |
| With the three FK indexes (real state) | **17.45 ms** | 0.43 ms | | Without them (simulated `enable_*=OFF`) | 3 267 ms | 79.7 ms |

The correlated form is critical: rewriting as `LEFT JOIN + GROUP BY` (the shape used by `listDocumentLines` for the paginated list) degrades to ~440 ms per line (~18 s for 41 lines) because the planner materializes the aggregate over the whole `m_inoutline` on every call. A code comment on the SQL constants documents this trap for future readers.

## Related migration

The FK-column indexes required by the validation are shipped as `adempiere-migrate-xml` PR `Add performance indexes for OutBoundOrder available-quantity check` (SeqNo `503640`, release `1.5.13`). Names match the canonical `_id` convention already present in most instances, so on dyd-dev it is a no-op.

## Behavior matrix

| Case | Before | After |
| --- | --- | --- |
| Double-submit of the same request | Two identical outbound orders | Second rejected, no dup | | Single request over available quantity | Silently over-allocates | Rejected | | Legitimate partial + saldo generation | Works | Works (unchanged) | | Force / Manual delivery rule | No check (as ZK) | No check (unchanged) | | Non-stocked product | Works | Works (unchanged) |

## Test plan

- [ ] Send `GenerateLoadOrderRequest` twice with identical payload on a consignment sales order → first succeeds, second returns `@Qty@ > @QtyAvailable@`; DB has exactly one outbound order.
- [ ] Rapid double-click on the "Generate" button in the Vue form → idem; one outbound order created.
- [ ] Partial generation followed by a legitimate second generation for the remaining saldo → both succeed.
- [ ] Distribution order (`DD_Order`) path exercises the same guard.
- [ ] Sales order with `DeliveryRule = 'F'` (Force) or `'M'` (Manual): double-submit still creates two outbound orders — semantics preserved on purpose.
- [ ] Non-stocked product line: no regression.
- [ ] `./gradlew compileJava` green (already verified locally).

## Follow-ups (out of scope)

- Data cleanup of duplicated outbound orders already in production (procedure documented in the analysis HTML, §5).
- Secondary issue seen in the third Loom (`listDocumentLines` not returning the pending saldo after a partial generation) — treat as a separate issue.
- With `Query.setForUpdate` now available in the local patched Query class, a follow-up PR could add pessimistic locking on the source order line to also close the millisecond-simultaneous concurrency window; not observed in evidence, deferred.