### PR TITLE
fix: Skip redundant preference reload in getSessionInfo

### DIFF
--- a/src/main/java/org/spin/grpc/service/Security.java
+++ b/src/main/java/org/spin/grpc/service/Security.java
@@ -1369,8 +1369,12 @@ public class Security extends SecurityImplBase {
 	private SessionInfo.Builder getSessionInfo(SessionInfoRequest request) {
 		Properties context = Env.getCtx();
 		MSession session = MSession.get(context, false);
-		//	Load default preference values
-		SessionManager.loadDefaultSessionValues(context, Env.getAD_Language(context));
+		//	Default preference values are already loaded per-request by the auth interceptor
+		//	(SessionManager.getSessionFromToken / Keycloak resolveSession -> loadDefaultSessionValues),
+		//	so we must not reload them here: doing so repeated a full AcctSchema/Preference/default-values
+		//	pass (~10-20 ms) on every session-info reload.
+		// SessionManager.loadDefaultSessionValues(context, Env.getAD_Language(context));
+
 		//	Session values
 		SessionInfo.Builder builder = SessionInfo.newBuilder();
 		builder.setId(


### PR DESCRIPTION
## Summary
- `Security.getSessionInfo` called `SessionManager.loadDefaultSessionValues(...)` even though the gRPC auth interceptor had already loaded the full context (preferences, accounting schema, default values) for the same request, so every session-info call ran that ~10-20 ms pass a second time.

## Changes
- `src/main/java/org/spin/grpc/service/Security.java` — remove the redundant `loadDefaultSessionValues(...)` call in `getSessionInfo`; the context is already populated per request by `AuthorizationServerInterceptor`. A comment was left explaining why it must not be reloaded here.

## Why it is safe
- `GetSessionInfo` is not among the methods that bypass the interceptor, and all three interceptor paths load the context before the service method runs: local HMAC (`SessionManager.getSessionFromToken`), Keycloak existing session (`loadExistingSessionContext`) and Keycloak new session (`createNewSessionContext`).
- The removed call used the same `context` and `Env.getAD_Language(context)`, so the second pass produced an identical result; `populateDefaultPreferences(...)` still reads the already-populated context.
- Login and change-role are untouched — their first (non-redundant) `loadDefaultSessionValues` call remains.

## Test plan
- [x] `./gradlew classes` compiles.
- [ ] Reload the UI / call GetSessionInfo: session, role, organization, warehouse and default preferences are returned unchanged.
- [ ] Login and change-role still resolve the correct context.