### PR TITLE
fix: Stop infinite recursion on warehouse source

### DIFF
--- a/src/main/java/org/spin/grpc/service/MaterialManagement.java
+++ b/src/main/java/org/spin/grpc/service/MaterialManagement.java
@@ -921,6 +921,12 @@ public class MaterialManagement extends MaterialManagementImplBase {
 	}
 
 	private Warehouse.Builder convertAvailableWarehouse(int warehouseId) {
+		return convertAvailableWarehouse(
+			warehouseId,
+			true
+		);
+	}
+	private Warehouse.Builder convertAvailableWarehouse(int warehouseId, boolean includeSource) {
 		MWarehouse warehouse = MWarehouse.get(Env.getCtx(), warehouseId);
 		if (warehouseId == 0) {
 			warehouse = new Query(
@@ -933,10 +939,17 @@ public class MaterialManagement extends MaterialManagementImplBase {
 			;
 		}
 		return convertAvailableWarehouse(
-			warehouse
+			warehouse,
+			includeSource
 		);
 	}
 	private Warehouse.Builder convertAvailableWarehouse(MWarehouse warehouse) {
+		return convertAvailableWarehouse(
+			warehouse,
+			true
+		);
+	}
+	private Warehouse.Builder convertAvailableWarehouse(MWarehouse warehouse, boolean includeSource) {
 		Warehouse.Builder builder = Warehouse.newBuilder();
 		if (warehouse == null) {
 			return builder;
@@ -964,9 +977,16 @@ public class MaterialManagement extends MaterialManagementImplBase {
 				warehouse.isInTransit()
 			)
 		;
-		if (warehouse.getM_WarehouseSource_ID() > 0) {
+		// Only resolve one nesting level for the source warehouse. The Warehouse
+		// message references itself (warehouse_source), so recursing again would
+		// loop forever when a warehouse points to itself or forms a cycle
+		// (e.g. A -> B -> A). includeSource is false on the nested call to stop.
+		if (includeSource
+				&& warehouse.getM_WarehouseSource_ID() > 0
+				&& warehouse.getM_WarehouseSource_ID() != warehouse.getM_Warehouse_ID()) {
 			Warehouse.Builder builderSource = convertAvailableWarehouse(
-				warehouse.getM_WarehouseSource_ID()
+				warehouse.getM_WarehouseSource_ID(),
+				false
 			);
 			builder.setWarehouseSource(builderSource);
 		}


### PR DESCRIPTION
Request 3183

## Summary
- The material-management "available warehouses" endpoint entered infinite recursion and crashed the RPC with "Application error processing RPC" whenever a warehouse's source referenced itself or formed a cycle (A -> B -> A). The `Warehouse` proto message is self-referential (`warehouse_source` is itself a `Warehouse`), and `convertAvailableWarehouse` followed the `M_WarehouseSource_ID` chain with no bound, producing a `StackOverflowError`. This change resolves the source warehouse to a single nesting level so the conversion always terminates.

## Changes
- `src/main/java/org/spin/grpc/service/MaterialManagement.java` — add an `includeSource` flag to `convertAvailableWarehouse` (both the `int` and `MWarehouse` overloads). The nested source call passes `includeSource = false`, so only one level of `warehouse_source` is populated. Also skip the source when `M_WarehouseSource_ID` equals the warehouse's own id (self-reference guard).

## Test plan
- [ ] Regression: `GET /api/material-management/warehouses?search_value=&page_size=50` returns the list with `warehouse_source` populated one level deep for warehouses that have a valid source.
- [ ] Fixed reproduction: with a warehouse whose `M_WarehouseSource_ID` points to itself (or forms a cycle), the same request returns normally instead of looping and returning "Application error processing RPC".
- [ ] `./gradlew compileJava` green.