### PR TITLE
fix: Sync reserved/ordered in `UpdateStorage` snapshot

### DIFF
--- a/src/patches/java/org/solop/process/UpdateStorage.java
+++ b/src/patches/java/org/solop/process/UpdateStorage.java
@@ -1,0 +1,168 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2017 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * or (at your option) any later version.                                     *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net                                                  *
+ * or https://github.com/adempiere/adempiere/blob/develop/license.html        *
+ *****************************************************************************/
+
+package org.solop.process;
+
+import org.compiere.model.MStorageSnapshotRun;
+import org.compiere.util.DB;
+import org.solop.util.StorageUpdaterBuilder;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/** Generated Process for (Update Storage)
+ *  @author ADempiere (generated) 
+ *  @version Release 3.9.4
+ */
+public class UpdateStorage extends UpdateStorageAbstract {
+
+	private final AtomicInteger processedTransactions = new AtomicInteger(0);
+	private final AtomicInteger processedReservations = new AtomicInteger(0);
+
+	@Override
+	protected void prepare() {
+		super.prepare();
+		if(isCreateSnapshot() && (getWarehouseId() > 0 || getProductCategoryId() > 0 || getProductId() > 0)) {
+			throw new IllegalArgumentException("@SSErrorStorage@");
+		}
+	}
+
+	@Override
+	protected String doIt() throws Exception {
+		MStorageSnapshotRun snapshotRun = null;
+		if(isCreateSnapshot()) {
+			snapshotRun = new MStorageSnapshotRun(getCtx(), 0, get_TrxName());
+			snapshotRun.setDateLastRun(new Timestamp(System.currentTimeMillis()));
+			snapshotRun.saveEx();
+			//	Create from Reservations
+			createSnapshotFromReservations(snapshotRun);
+			//	Create from Transactions
+			createSnapshotFromTransactions(snapshotRun);
+			//
+			snapshotRun.setTransactionsProcessed(BigDecimal.valueOf(processedTransactions.get()));
+			snapshotRun.saveEx();
+		}
+		//	Delete Old Storage
+		StorageUpdaterBuilder.newInstance(getCtx(), get_TrxName())
+				.withClientId(getAD_Client_ID())
+				.withOrganizationId(getOrgId())
+				.withWarehouseId(getWarehouseId())
+				.withProductCategoryId(getProductCategoryId())
+				.withProductId(getProductId())
+				.build();
+
+		if(snapshotRun != null) {
+			snapshotRun.setProductProcesses(BigDecimal.valueOf(getProcessedProducts()));
+			snapshotRun.saveEx();
+		}
+		return "@TransactionsProcessed@ " + processedTransactions.get();
+	}
+
+	private int getProcessedProducts() {
+		return DB.getSQLValueEx(get_TrxName(), "SELECT COUNT(*) FROM M_Product p WHERE p.AD_Client_ID = ? AND EXISTS(SELECT 1 FROM M_Storage s WHERE s.M_Product_ID = p.M_Product_ID)", getAD_Client_ID());
+	}
+
+	private void createSnapshotFromReservations(MStorageSnapshotRun snapshotRun) {
+		List<Object> parameters = new ArrayList<>();
+		StringBuilder transactionSQL = new StringBuilder("INSERT INTO M_StorageSnapshot (M_StorageSnapshot_ID, AD_Client_ID, AD_Org_ID, M_Product_ID, M_Locator_ID, M_AttributeSetInstance_ID, QtyOnHand, QtyReserved, QtyOrdered, IsActive, Created, CreatedBy, Updated, UpdatedBy, UUID, M_StorageSnapshotRun_ID, DateTrx) " +
+				"SELECT nextval('m_storagesnapshot_seq'), r.AD_Client_ID, r.AD_Org_ID, r.M_Product_ID, r.M_Locator_ID, r.M_AttributeSetInstance_ID, 0, SUM(CASE WHEN r.ReservationType NOT IN('PO+', 'PO-') THEN r.Qty ELSE 0 END), SUM(CASE WHEN r.ReservationType IN('PO+', 'PO-') THEN r.Qty ELSE 0 END), 'Y', now(), 0, now(), 0, getUUID(), ?, ? " +
+				"FROM M_Reservation r " +
+				"WHERE r.AD_Client_ID = ? ");
+		parameters.add(snapshotRun.getM_StorageSnapshotRun_ID());
+		parameters.add(snapshotRun.getDateLastRun());
+		parameters.add(getAD_Client_ID());
+		//	Org
+		if (getOrgId() != 0) {
+			transactionSQL.append("AND r.AD_Org_ID = ? ");
+			parameters.add(getOrgId());
+		}
+		//	Warehouse
+		if (getWarehouseId() != 0) {
+			transactionSQL.append("AND r.M_Warehouse_ID = ? ");
+			parameters.add(getWarehouseId());
+		}
+		//Product
+		if (getProductId() != 0) {
+			transactionSQL.append("AND r.M_Product_ID = ? ");
+			parameters.add(getProductId());
+		}
+		//Product Category
+		if (getProductCategoryId() != 0) {
+			transactionSQL.append("AND EXISTS (SELECT 1 FROM M_Product WHERE M_Product.M_Product_Category_ID= ? AND M_Product.M_Product_ID = r.M_Product_ID) ");
+			parameters.add(getProductCategoryId());
+		}
+		//Group By
+		transactionSQL.append("GROUP BY r.AD_Client_ID, r.AD_Org_ID, r.M_Product_ID, r.M_Locator_ID, r.M_Warehouse_ID, r.M_AttributeSetInstance_ID ");
+		transactionSQL.append(
+			"HAVING SUM(CASE WHEN r.ReservationType IN('PO+', 'PO-') THEN r.Qty ELSE 0 END) <> 0 "
+			+ "OR SUM(CASE WHEN r.ReservationType NOT IN('PO+', 'PO-') THEN r.Qty ELSE 0 END) <> 0 "
+		);
+		log.fine("SnapshotSQL (Reservations)=" + transactionSQL);
+		int inserted = DB.executeUpdateEx(transactionSQL.toString(), parameters.toArray(), get_TrxName());
+		log.fine("Snapshot Created (Reservations)=" + inserted);
+		if (inserted > 0) {
+			processedReservations.addAndGet(inserted);
+		}
+	}
+
+	private void createSnapshotFromTransactions(MStorageSnapshotRun snapshotRun) {
+		List<Object> parameters = new ArrayList<>();
+		StringBuilder transactionSQL = new StringBuilder("INSERT INTO M_StorageSnapshot (M_StorageSnapshot_ID, AD_Client_ID, AD_Org_ID, M_Product_ID, M_Locator_ID, M_AttributeSetInstance_ID, QtyOnHand, QtyReserved, QtyOrdered, IsActive, Created, CreatedBy, Updated, UpdatedBy, UUID, M_StorageSnapshotRun_ID, DateTrx) " +
+				"SELECT nextval('m_storagesnapshot_seq'), mt.AD_Client_ID,mw.AD_Org_ID, mt.M_Product_ID, mt.M_Locator_ID, mt.M_AttributeSetInstance_ID, Sum(mt.MovementQty) MovementQty, 0, 0, 'Y', now(), 0, now(), 0, getUUID(), ?, ? " +
+				"FROM M_Transaction mt " +
+				"INNER JOIN M_Locator ml ON mt.M_Locator_ID = ml.M_Locator_ID " +
+				"INNER JOIN M_Warehouse mw ON mw.M_Warehouse_ID = ml.M_Warehouse_ID " +
+				"WHERE mt.AD_Client_ID = ? ");
+		parameters.add(snapshotRun.getM_StorageSnapshotRun_ID());
+		parameters.add(snapshotRun.getDateLastRun());
+		parameters.add(getAD_Client_ID());
+		//	Org
+		if (getOrgId() != 0) {
+			transactionSQL.append("AND mw.AD_Org_ID = ? ");
+			parameters.add(getOrgId());
+		}
+		//	Warehouse
+		if (getWarehouseId() != 0) {
+			transactionSQL.append("AND mw.M_Warehouse_ID = ? ");
+			parameters.add(getWarehouseId());
+		}
+		//Product
+		if (getProductId() != 0) {
+			transactionSQL.append("AND mt.M_Product_ID = ? ");
+			parameters.add(getProductId());
+		}
+		//Product Category
+		if (getProductCategoryId() != 0) {
+			transactionSQL.append("AND EXISTS (SELECT 1 FROM M_Product WHERE M_Product.M_Product_Category_ID= ? AND M_Product.M_Product_ID = mt.M_Product_ID) ");
+			parameters.add(getProductCategoryId());
+		}
+		//Group By
+		transactionSQL.append("GROUP BY mt.AD_Client_ID, mw.AD_Org_ID, mt.M_Product_ID, mt.M_Locator_ID, ml.M_Warehouse_ID, mt.M_AttributeSetInstance_ID ");
+		transactionSQL.append("HAVING SUM(mt.MovementQty) <> 0 ");
+		log.fine("SnapshotSQL (Transactions)=" + transactionSQL);
+		int inserted = DB.executeUpdateEx(transactionSQL.toString(), parameters.toArray(), get_TrxName());
+		log.fine("Snapshot Created (Transactions)=" + inserted);
+		if (inserted > 0) {
+			processedTransactions.addAndGet(inserted);
+		}
+	}
+
+}

--- a/src/patches/java/org/solop/util/StorageUpdaterBuilder.java
+++ b/src/patches/java/org/solop/util/StorageUpdaterBuilder.java
@@ -1,0 +1,399 @@
+package org.solop.util;
+
+import org.adempiere.core.domains.models.I_M_StorageSnapshotRun;
+import org.compiere.model.MStorageSnapshotRun;
+import org.compiere.model.Query;
+import org.compiere.util.CLogger;
+import org.compiere.util.DB;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class StorageUpdaterBuilder {
+    private final CLogger log = CLogger.getCLogger(this.getClass());
+    private final Properties context;
+    private final String transactionName;
+    private int clientId;
+    private int organizationId;
+    private int warehouseId;
+    private int productId;
+
+    public List<Integer> getProductIds() {
+        return productIds;
+    }
+
+    private List<Integer> productIds;
+    private int productCategoryId;
+    private final AtomicInteger processedNewTransactions = new AtomicInteger(0);
+    private final AtomicInteger processedNewReservations = new AtomicInteger(0);
+    private final AtomicInteger processedSnapshots = new AtomicInteger(0);
+
+    public static StorageUpdaterBuilder newInstance(Properties context, String transactionName) {
+        return new StorageUpdaterBuilder(context, transactionName);
+    }
+
+    private StorageUpdaterBuilder(Properties context, String transactionName) {
+        this.context = context;
+        this.transactionName = transactionName;
+    }
+
+    public Properties getContext() {
+        return context;
+    }
+
+    public String getTransactionName() {
+        return transactionName;
+    }
+
+    public int getClientId() {
+        return clientId;
+    }
+
+    public int getOrganizationId() {
+        return organizationId;
+    }
+
+    public int getWarehouseId() {
+        return warehouseId;
+    }
+
+    public int getProductId() {
+        return productId;
+    }
+
+    public int getProductCategoryId() {
+        return productCategoryId;
+    }
+
+    public StorageUpdaterBuilder withClientId(int clientId) {
+        this.clientId = clientId;
+        return this;
+    }
+
+    public StorageUpdaterBuilder withOrganizationId(int organizationId) {
+        this.organizationId = organizationId;
+        return this;
+    }
+
+    public StorageUpdaterBuilder withProductsIds(List<Integer> productsIds) {
+        this.productIds = productsIds;
+        return this;
+    }
+
+    public StorageUpdaterBuilder withWarehouseId(int warehouseId) {
+        this.warehouseId = warehouseId;
+        return this;
+    }
+
+    public StorageUpdaterBuilder withProductId(int productId) {
+        this.productId = productId;
+        return this;
+    }
+
+    public StorageUpdaterBuilder withProductCategoryId(int productCategoryId) {
+        this.productCategoryId = productCategoryId;
+        return this;
+    }
+
+    public String build() {
+        if(context == null || transactionName == null) {
+            throw new IllegalStateException("Context and Transaction Name are required");
+        }
+        if(clientId <= 0) {
+            throw new IllegalStateException("Client ID must be greater than zero");
+        }
+        MStorageSnapshotRun lastSnapshot = getLastSnapshot();
+        deleteOldStorage();
+        if(lastSnapshot != null) {
+            createStoreFromSnapshot(lastSnapshot);
+            createStoreFromReservations(lastSnapshot);
+            createStoreFromTransactions(lastSnapshot);
+            log.info("Storage Updated from Snapshot: " + processedSnapshots.get() +
+                    ", New Reservations: " + processedNewReservations.get() +
+                    ", New Transactions: " + processedNewTransactions.get());
+        } else {
+            log.info("No previous snapshot found. Storage update skipped.");
+        }
+        return "Storage Updated from Snapshot: " + processedSnapshots.get() +
+                ", New Reservations: " + processedNewReservations.get() +
+                ", New Transactions: " + processedNewTransactions.get();
+    }
+
+    private MStorageSnapshotRun getLastSnapshot() {
+        return new Query(getContext(), I_M_StorageSnapshotRun.Table_Name, null, getTransactionName())
+                .setClient_ID()
+                .setOnlyActiveRecords(true)
+                .setOrderBy("DateLastRun DESC")
+                .first();
+    }
+
+    private void deleteOldStorage() {
+        List<Object> parameters = new ArrayList<>();
+        StringBuilder deleteSQL = new StringBuilder("DELETE FROM M_Storage WHERE AD_Client_ID = ? ");
+        parameters.add(getClientId());
+        if(getOrganizationId() != 0) {
+            deleteSQL.append("AND AD_Org_ID = ? ");
+            parameters.add(getOrganizationId());
+        }
+        if(getWarehouseId() != 0) {
+            deleteSQL.append("AND EXISTS(SELECT 1 " +
+                    "FROM M_Locator l " +
+                    "WHERE l.M_Locator_ID = M_Storage.M_Locator_ID " +
+                    "AND l.M_Warehouse_ID = ?) ");
+            parameters.add(getWarehouseId());
+        }
+        if(getProductId() != 0) {
+            deleteSQL.append("AND M_Product_ID = ? ");
+            parameters.add(getProductId());
+        }
+        if(getProductIds() != null && !getProductIds().isEmpty()) {
+            deleteSQL.append("AND M_Product_ID IN").append(getProductIds().toString().replace('[','(').replace(']',')')).append(" ");
+        }
+        if(getProductCategoryId() != 0) {
+            deleteSQL.append("AND EXISTS (SELECT 1 FROM M_Product WHERE M_Product.M_Product_Category_ID = ? AND M_Product.M_Product_ID = M_Storage.M_Product_ID) ");
+            parameters.add(getProductCategoryId());
+        }
+        //	Log
+        log.fine("deleteSQL=" + deleteSQL.toString());
+
+        int storageUpdated = DB.executeUpdateEx(deleteSQL.toString(), parameters.toArray(), getTransactionName());
+
+        //	Log
+        log.fine("Storage Deleted=" + storageUpdated);
+
+    }
+
+    private void createStoreFromSnapshot(MStorageSnapshotRun lastSnapshot) {
+        List<Object> parameters = new ArrayList<>();
+        StringBuilder transactionSQL = new StringBuilder("INSERT INTO M_Storage (M_Storage_ID, AD_Client_ID, AD_Org_ID, M_Product_ID, M_Locator_ID, M_AttributeSetInstance_ID, QtyOnHand, QtyReserved, QtyOrdered, IsActive, Created, CreatedBy, Updated, UpdatedBy, UUID) " +
+                "SELECT nextval('m_storage_seq'), ssr.AD_Client_ID, sl.AD_Org_ID, sl.M_Product_ID, sl.M_Locator_ID, sl.M_AttributeSetInstance_ID, SUM(sl.QtyOnHand), SUM(sl.QtyReserved), SUM(sl.QtyOrdered), 'Y', now(), ssr.CreatedBy, now(), ssr.UpdatedBy, getUUID() " +
+                "FROM M_StorageSnapshotRun ssr " +
+                "INNER JOIN M_StorageSnapshot sl ON(sl.M_StorageSnapshotRun_ID = ssr.M_StorageSnapshotRun_ID) " +
+                "WHERE sl.AD_Client_ID = ? ");
+        parameters.add(getClientId());
+        //	Org
+        if (getOrganizationId() != 0) {
+            transactionSQL.append("AND sl.AD_Org_ID = ? ");
+            parameters.add(getOrganizationId());
+        }
+        //	Warehouse
+        if (getWarehouseId() != 0) {
+			transactionSQL.append(
+				"AND EXISTS("
+				+ "SELECT 1 FROM M_Locator AS l "
+				+ "WHERE l.M_Locator_ID = sl.M_Locator_ID AND l.M_Warehouse_ID = ?"
+				+ ") "
+			);
+            parameters.add(getWarehouseId());
+        }
+        //Product
+        if (getProductId() != 0) {
+            transactionSQL.append("AND sl.M_Product_ID = ? ");
+            parameters.add(getProductId());
+        }
+        if(getProductIds() != null && !getProductIds().isEmpty()) {
+            transactionSQL.append("AND sl.M_Product_ID IN").append(getProductIds().toString().replace('[','(').replace(']',')')).append(" ");
+        }
+        //Product Category
+        if (getProductCategoryId() != 0) {
+            transactionSQL.append("AND EXISTS (SELECT 1 FROM M_Product WHERE M_Product.M_Product_Category_ID= ? AND M_Product.M_Product_ID = sl.M_Product_ID) ");
+            parameters.add(getProductCategoryId());
+        }
+        transactionSQL.append("AND sl.M_StorageSnapshotRun_ID = ? ");
+        //	Group By
+        transactionSQL.append("GROUP BY ssr.AD_Client_ID, sl.AD_Org_ID, sl.M_Product_ID, sl.M_Locator_ID, sl.M_AttributeSetInstance_ID, ssr.CreatedBy, ssr.UpdatedBy ");
+        parameters.add(lastSnapshot.getM_StorageSnapshotRun_ID());
+        log.fine("StorageSQL (Snapshot)=" + transactionSQL);
+        int inserted = DB.executeUpdateEx(transactionSQL.toString(), parameters.toArray(), getTransactionName());
+        log.fine("Storage Created (Snapshot)=" + inserted);
+        if (inserted > 0) {
+            processedSnapshots.addAndGet(inserted);
+        }
+    }
+
+    private void createStoreFromReservations(MStorageSnapshotRun lastSnapshot) {
+        List<Object> parameters = new ArrayList<>();
+        //	Update the currents
+        StringBuilder transactionSQL = new StringBuilder("UPDATE M_Storage AS s " +
+                "SET QtyOrdered = s.QtyOrdered + r.QtyOrdered, " +
+                "QtyReserved = s.QtyReserved + r.QtyReserved " +
+                "FROM (" +
+                "SELECT s.M_Storage_ID, " +
+                "SUM(CASE WHEN r.ReservationType IN('PO+', 'PO-') THEN r.Qty ELSE 0 END) QtyOrdered, " +
+                "SUM(CASE WHEN r.ReservationType NOT IN('PO+', 'PO-') THEN r.Qty ELSE 0 END) QtyReserved " +
+                "FROM M_Reservation r " +
+                "INNER JOIN M_Storage s ON(s.M_Product_ID = r.M_Product_ID AND s.M_Locator_ID = r.M_Locator_ID AND s.M_AttributeSetInstance_ID = r.M_AttributeSetInstance_ID) ");
+        transactionSQL.append("WHERE r.AD_Client_ID = ? ");
+        parameters.add(getClientId());
+        transactionSQL.append("AND r.DateTrx > ? ");
+        parameters.add(lastSnapshot.getDateLastRun());
+        //	Org
+        if (getOrganizationId() != 0) {
+            transactionSQL.append("AND r.AD_Org_ID = ? ");
+            parameters.add(getOrganizationId());
+        }
+        //	Warehouse
+        if (getWarehouseId() != 0) {
+            transactionSQL.append("AND r.M_Warehouse_ID = ? ");
+            parameters.add(getWarehouseId());
+        }
+        //Product
+        if (getProductId() != 0) {
+            transactionSQL.append("AND r.M_Product_ID = ? ");
+            parameters.add(getProductId());
+        }
+        if(getProductIds() != null && !getProductIds().isEmpty()) {
+            transactionSQL.append("AND r.M_Product_ID IN").append(getProductIds().toString().replace('[','(').replace(']',')')).append(" ");
+        }
+        //Product Category
+        if (getProductCategoryId() != 0) {
+            transactionSQL.append("AND EXISTS (SELECT 1 FROM M_Product WHERE M_Product.M_Product_Category_ID= ? AND M_Product.M_Product_ID = r.M_Product_ID) ");
+            parameters.add(getProductCategoryId());
+        }
+        transactionSQL.append("GROUP BY s.M_Storage_ID " +
+                "HAVING SUM(CASE WHEN r.ReservationType IN('PO+', 'PO-') THEN r.Qty ELSE 0 END) <> 0 " +
+                "OR SUM(CASE WHEN r.ReservationType NOT IN('PO+', 'PO-') THEN r.Qty ELSE 0 END) <> 0" +
+                ") r " +
+                "WHERE s.M_Storage_ID = r.M_Storage_ID");
+        log.fine("StorageSQL (Reservations Existing)=" + transactionSQL);
+        int inserted = DB.executeUpdateEx(transactionSQL.toString(), parameters.toArray(), getTransactionName());
+        log.fine("Storage Created (Reservations Existing)=" + inserted);
+        if (inserted > 0) {
+            processedNewReservations.addAndGet(inserted);
+        }
+        parameters.clear();
+        transactionSQL = new StringBuilder("INSERT INTO M_Storage (M_Storage_ID, AD_Client_ID, AD_Org_ID, M_Product_ID, M_Locator_ID, M_AttributeSetInstance_ID, QtyOnHand, QtyReserved, QtyOrdered, IsActive, Created, CreatedBy, Updated, UpdatedBy, UUID) " +
+                "SELECT nextval('m_storage_seq'), r.AD_Client_ID, r.AD_Org_ID, r.M_Product_ID, r.M_Locator_ID, r.M_AttributeSetInstance_ID, 0, SUM(CASE WHEN r.ReservationType NOT IN('PO+', 'PO-') THEN r.Qty ELSE 0 END), SUM(CASE WHEN r.ReservationType IN('PO+', 'PO-') THEN r.Qty ELSE 0 END), 'Y', now(), 0, now(), 0, getUUID() " +
+                "FROM M_Reservation r " +
+                "WHERE r.AD_Client_ID = ? ");
+        parameters.add(getClientId());
+        transactionSQL.append("AND NOT EXISTS(SELECT 1 FROM M_Storage s WHERE s.M_Product_ID = r.M_Product_ID AND s.M_Locator_ID = r.M_Locator_ID AND s.M_AttributeSetInstance_ID = r.M_AttributeSetInstance_ID) ");
+        transactionSQL.append("AND r.DateTrx > ? ");
+        parameters.add(lastSnapshot.getDateLastRun());
+        //	Org
+        if (getOrganizationId() != 0) {
+            transactionSQL.append("AND r.AD_Org_ID = ? ");
+            parameters.add(getOrganizationId());
+        }
+        //	Warehouse
+        if (getWarehouseId() != 0) {
+            transactionSQL.append("AND r.M_Warehouse_ID = ? ");
+            parameters.add(getWarehouseId());
+        }
+        //Product
+        if (getProductId() != 0) {
+            transactionSQL.append("AND r.M_Product_ID = ? ");
+            parameters.add(getProductId());
+        }
+        if(getProductIds() != null && !getProductIds().isEmpty()) {
+            transactionSQL.append("AND r.M_Product_ID IN").append(getProductIds().toString().replace('[','(').replace(']',')')).append(" ");
+        }
+        //Product Category
+        if (getProductCategoryId() != 0) {
+            transactionSQL.append("AND EXISTS (SELECT 1 FROM M_Product WHERE M_Product.M_Product_Category_ID= ? AND M_Product.M_Product_ID = r.M_Product_ID) ");
+            parameters.add(getProductCategoryId());
+        }
+        //Group By
+        transactionSQL.append("GROUP BY r.AD_Client_ID, r.AD_Org_ID, r.M_Product_ID, r.M_Locator_ID, r.M_Warehouse_ID, r.M_AttributeSetInstance_ID ");
+        transactionSQL.append("HAVING SUM(CASE WHEN r.ReservationType IN('PO+', 'PO-') THEN r.Qty ELSE 0 END) <> 0 OR SUM(CASE WHEN r.ReservationType NOT IN('PO+', 'PO-') THEN r.Qty ELSE 0 END) <> 0");
+        log.fine("StorageSQL (Reservations)=" + transactionSQL);
+        inserted = DB.executeUpdateEx(transactionSQL.toString(), parameters.toArray(), getTransactionName());
+        log.fine("Storage Created (Reservations)=" + inserted);
+        if (inserted > 0) {
+            processedNewReservations.addAndGet(inserted);
+        }
+    }
+
+    private void createStoreFromTransactions(MStorageSnapshotRun lastSnapshot) {
+        List<Object> parameters = new ArrayList<>();
+        //	Update the currents
+        StringBuilder transactionSQL = new StringBuilder("UPDATE M_Storage AS s " +
+                "SET QtyOnHand = s.QtyOnHand + r.QtyOnHand " +
+                "FROM (" +
+                "SELECT s.M_Storage_ID, SUM(r.MovementQty) QtyOnHand " +
+                "FROM M_Transaction r " +
+                "INNER JOIN M_Storage s ON(s.M_Product_ID = r.M_Product_ID AND s.M_Locator_ID = r.M_Locator_ID AND s.M_AttributeSetInstance_ID = r.M_AttributeSetInstance_ID) ");
+        transactionSQL.append("WHERE r.AD_Client_ID = ? ");
+        parameters.add(getClientId());
+        transactionSQL.append("AND r.Created > ? ");
+        parameters.add(lastSnapshot.getDateLastRun());
+        //	Org
+        if (getOrganizationId() != 0) {
+            transactionSQL.append("AND r.AD_Org_ID = ? ");
+            parameters.add(getOrganizationId());
+        }
+        //	Warehouse
+        if (getWarehouseId() != 0) {
+            transactionSQL.append("AND EXISTS(SELECT 1 FROM M_Locator l WHERE l.M_Locator_ID = r.M_Locator_ID AND l.M_Warehouse_ID = ?) ");
+            parameters.add(getWarehouseId());
+        }
+        //Product
+        if (getProductId() != 0) {
+            transactionSQL.append("AND r.M_Product_ID = ? ");
+            parameters.add(getProductId());
+        }
+        if(getProductIds() != null && !getProductIds().isEmpty()) {
+            transactionSQL.append("AND r.M_Product_ID IN").append(getProductIds().toString().replace('[','(').replace(']',')')).append(" ");
+        }
+        //Product Category
+        if (getProductCategoryId() != 0) {
+            transactionSQL.append("AND EXISTS (SELECT 1 FROM M_Product WHERE M_Product.M_Product_Category_ID= ? AND M_Product.M_Product_ID = r.M_Product_ID) ");
+            parameters.add(getProductCategoryId());
+        }
+        transactionSQL.append("GROUP BY s.M_Storage_ID " +
+                "HAVING SUM(r.MovementQty) <> 0) r " +
+                "WHERE s.M_Storage_ID = r.M_Storage_ID");
+        log.fine("StorageSQL (Transaction Existing)=" + transactionSQL);
+        int inserted = DB.executeUpdateEx(transactionSQL.toString(), parameters.toArray(), getTransactionName());
+        log.fine("Storage Created (Transaction Existing)=" + inserted);
+        if (inserted > 0) {
+            processedNewTransactions.addAndGet(inserted);
+        }
+        parameters.clear();
+        transactionSQL = new StringBuilder("INSERT INTO M_Storage (M_Storage_ID, AD_Client_ID, AD_Org_ID, M_Product_ID, M_Locator_ID, M_AttributeSetInstance_ID, QtyOnHand, QtyReserved, QtyOrdered, IsActive, Created, CreatedBy, Updated, UpdatedBy, UUID) " +
+                "SELECT nextval('m_storage_seq'), mt.AD_Client_ID,mw.AD_Org_ID, mt.M_Product_ID, mt.M_Locator_ID, mt.M_AttributeSetInstance_ID, Sum(mt.MovementQty) MovementQty, 0, 0, 'Y', now(), 0, now(), 0, getUUID() " +
+                "FROM M_Transaction mt " +
+                "INNER JOIN M_Locator ml ON mt.M_Locator_ID = ml.M_Locator_ID " +
+                "INNER JOIN M_Warehouse mw ON mw.M_Warehouse_ID = ml.M_Warehouse_ID " +
+                "WHERE mt.AD_Client_ID = ? ");
+        parameters.add(getClientId());
+        transactionSQL.append("AND NOT EXISTS(SELECT 1 FROM M_Storage s WHERE s.M_Product_ID = mt.M_Product_ID AND s.M_Locator_ID = mt.M_Locator_ID AND s.M_AttributeSetInstance_ID = mt.M_AttributeSetInstance_ID) ");
+        transactionSQL.append("AND mt.Created > ? ");
+        parameters.add(lastSnapshot.getDateLastRun());
+        //	Org
+        if (getOrganizationId() != 0) {
+            transactionSQL.append("AND mw.AD_Org_ID = ? ");
+            parameters.add(getOrganizationId());
+        }
+        //	Warehouse
+        if (getWarehouseId() != 0) {
+            transactionSQL.append("AND mw.M_Warehouse_ID = ? ");
+            parameters.add(getWarehouseId());
+        }
+        //Product
+        if (getProductId() != 0) {
+            transactionSQL.append("AND mt.M_Product_ID = ? ");
+            parameters.add(getProductId());
+        }
+        if(getProductIds() != null && !getProductIds().isEmpty()) {
+            transactionSQL.append("AND mt.M_Product_ID IN").append(getProductIds().toString().replace('[','(').replace(']',')')).append(" ");
+        }
+        //Product Category
+        if (getProductCategoryId() != 0) {
+            transactionSQL.append("AND EXISTS (SELECT 1 FROM M_Product WHERE M_Product.M_Product_Category_ID= ? AND M_Product.M_Product_ID = mt.M_Product_ID) ");
+            parameters.add(getProductCategoryId());
+        }
+        //Group By
+        transactionSQL.append("GROUP BY mt.AD_Client_ID, mw.AD_Org_ID, mt.M_Product_ID, mt.M_Locator_ID, ml.M_Warehouse_ID, mt.M_AttributeSetInstance_ID ");
+        transactionSQL.append("HAVING SUM(mt.MovementQty) <> 0 ");
+        log.fine("SnapshotSQL (Transactions)=" + transactionSQL);
+        inserted = DB.executeUpdateEx(transactionSQL.toString(), parameters.toArray(), getTransactionName());
+        log.fine("Snapshot Created (Transactions)=" + inserted);
+        if (inserted > 0) {
+            processedNewTransactions.addAndGet(inserted);
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary
- Two bugs in the "Update Storage" process leave M_Storage.QtyReserved/QtyOrdered at 0 system-wide (≈97% of rows in dev), corrupting the denormalized stock ledger the whole ERP reads for availability — order/shipment checks (overselling risk), MRP/replenishment, reports and Product Info — not just Available-to-Promise. The process is destructive: it deletes and rebuilds M_Storage from a broken snapshot. M_Reservation (source of truth) is intact, so re-running after the fix fully restores M_Storage.
- HAVING uses AND instead of OR, so a locator with only reserved OR only ordered  movements is dropped from the snapshot (the common case).
- The snapshot restore references sl.M_Warehouse_ID, which does not exist on M_StorageSnapshot → SQL error when running with a warehouse filter.

## Changes
- `base/src/main/java/org/solop/process/UpdateStorage.java` — createSnapshotFromReservations HAVING: `AND` → `OR`.
- `base/src/main/java/org/solop/util/StorageUpdaterBuilder.java` — createStoreFromSnapshot: replace `sl.M_Warehouse_ID = ?` with an EXISTS against M_Locator (same pattern as createStoreFromTransactions).

## Test plan
- [ ] `./gradlew ... compileJava` green.
- [ ] Reserved/ordered in M_Storage reconcile with M_Reservation after the process.
- [ ] Process runs with a warehouse filter without SQL error.