### PR TITLE
fix: Gate tenant_id validation on DB binding flag

### DIFF
--- a/src/patches/java/org/spin/service/grpc/authentication/SessionManager.java
+++ b/src/patches/java/org/spin/service/grpc/authentication/SessionManager.java
@@ -70,6 +70,7 @@ import org.spin.eca52.util.JWTUtil;
 import org.spin.model.MADToken;
 import org.spin.model.MADTokenDefinition;
 import org.spin.service.grpc.util.base.PreferenceUtil;
+import org.spin.service.grpc.util.value.BooleanManager;
 import org.spin.service.grpc.util.value.NumberManager;
 import org.spin.util.IThirdPartyAccessGenerator;
 import org.spin.util.ITokenGenerator;
@@ -298,18 +299,21 @@ public class SessionManager {
 				closeExpiredSessionQuietly(expired);
 				throw expired;
 			}
-			// Opportunistic validation: if the token carries a tenant_id claim
-			// (issued by a build with ECA52_JWT_BIND_TO_DATABASE=Y), require it
-			// to match this installation's tenant. Tokens without the claim
-			// (pre-2026-05-14 builds) are allowed through — the rest of the
-			// flow still cross-validates the JWT user/client against the
-			// AD_Session row loaded from DB.
-			String tokenTenantId = claims.getPayload().get(CLAIM_TENANT_ID, String.class);
-			if (tokenTenantId != null) {
-				String currentTenantId = getTenantId();
-				if (!tokenTenantId.equals(currentTenantId)) {
-					log.warning("JWT tenant_id mismatch");
-					throw new AdempiereException("@Invalid@ @AD_Session_ID@");
+			// Tenant binding is symmetric with claim emission: only enforce the
+			// tenant_id claim when this installation binds tokens to its database
+			// (ECA52_JWT_BIND_TO_DATABASE=Y) — the same flag that gates emission.
+			// With binding off (default), tokens minted by another service against
+			// the same database (e.g. Sabana, whose tenant_id is a readable routing
+			// key, not this installation's hash) must be accepted; the flow still
+			// cross-validates the JWT user/client against the AD_Session row below.
+			if (isDatabaseBindingEnabled()) {
+				String tokenTenantId = claims.getPayload().get(CLAIM_TENANT_ID, String.class);
+				if (tokenTenantId != null) {
+					String currentTenantId = getTenantId();
+					if (!tokenTenantId.equals(currentTenantId)) {
+						log.warning("JWT tenant_id mismatch");
+						throw new AdempiereException("@Invalid@ @AD_Session_ID@");
+					}
 				}
 			}
 			sessionId = NumberManager.getIntFromString(
@@ -629,7 +633,7 @@ public class SessionManager {
 		if (Util.isEmpty(value, true)) {
 			value = Ini.getProperty("ECA52_JWT_BIND_TO_DATABASE");
 		}
-		return "Y".equalsIgnoreCase(value) || "true".equalsIgnoreCase(value);
+		return BooleanManager.getBooleanFromString(value);
 	}
 
 	private static SecretKey getJWT_SecretKey() {


### PR DESCRIPTION
## Summary
- `getSessionFromToken` rejected any bearer whose `tenant_id` claim did not equal `getTenantId()` (SHA-256 of the DB name), even with `ECA52_JWT_BIND_TO_DATABASE` disabled — contradicting the flag's documented contract ("gates HMAC derivation and the tenant_id claim emission and validation"). This blocked federated tokens minted by another service against the same database — e.g. Sabana, whose `tenant_id` is a readable tenant-routing key, not this installation's hash — with `@Invalid@ @AD_Session_ID@` (401), breaking shared-cookie SSO into the Vue app.
- With binding disabled (default), the tenant_id claim is now ignored; identity is still cross-validated by `jti` → AD_Session + user/client + not-processed checks.

## Changes
- `src/patches/java/org/spin/service/grpc/authentication/SessionManager.java`: wrap the `tenant_id` mismatch check in `if (isDatabaseBindingEnabled())`, the same flag that already gates claim emission.
- `src/patches/java/org/spin/service/grpc/authentication/SessionManager.java`: `isDatabaseBindingEnabled()` now parses the flag via `BooleanManager.getBooleanFromString(value)` instead of an inline `"Y"/"true"` comparison.
- `jwt/xml/migration/10330_ECA52_Add_SysConfig_JWT_Bind_To_Database.xml`: add the `ECA52_JWT_BIND_TO_DATABASE` SysConfig (EntityType `ECA52`, `ConfigurationLevel=S`, default `N`, centralized ID `50181`) so operators can toggle DB binding from the UI.

## Notes
- Default when the `ECA52_JWT_BIND_TO_DATABASE` SysConfig is absent: `false` (binding off) — unchanged; the migration just makes the flag explicit and UI-editable.
- When binding is enabled, behavior is unchanged (the claim is still enforced).
- With binding off, cross-tenant safety relies on the existing user/client cross-validation against the AD_Session row and a single-database-per-installation deployment.

## Test plan
- [x] `./gradlew compileJava` green (verified locally).
- [ ] Migration `10330` applies cleanly (AD_SysConfig `ECA52_JWT_BIND_TO_DATABASE` created, value `N`).
- [ ] Deploy grpc-server + Sabana (readable tenant_id, from main).
- [ ] `SAB token -> GET /api/security/session-info` goes 401 -> 200.
- [ ] `ADE token -> GET /api/security/session-info` stays 200 (no regression).
- [ ] With `ECA52_JWT_BIND_TO_DATABASE=Y`, a foreign tenant_id is still rejected.