### PR TITLE
fix: Apply page limit when listing notices and users

### DIFF
--- a/src/main/java/org/spin/grpc/service/NoticeManagement.java
+++ b/src/main/java/org/spin/grpc/service/NoticeManagement.java
@@ -266,7 +266,7 @@ public class NoticeManagement extends NoticeManagementImplBase {
 		;
 
 		queryNotices
-			// .setLimit(limit, offset)
+			.setLimit(limit, offset)
 			.getIDsAsList()
 			.forEach(noticeId -> {
 				Notice.Builder builder = convertNotice(noticeId);
@@ -376,7 +376,7 @@ public class NoticeManagement extends NoticeManagementImplBase {
 		;
 
 		queryNotices
-			// .setLimit(limit, offset)
+			.setLimit(limit, offset)
 			.getIDsAsList()
 			.forEach(userId -> {
 				User.Builder builder = convertUser(userId);


### PR DESCRIPTION
## Summary
- `ListNotices` and `ListUsers` computed `limit` and `offset`, reported `record_count`, and returned a `next_page_token`, but ran the query with `setLimit` commented out. Every notice of the user (and every employee/sales rep) was returned on each call regardless of the requested `page_size`, and the response advertised a next page that had in fact already been sent. Since each id is then materialised individually — `convertNotice` builds an `MNote` and `convertUser` a user per row — the endpoint also issued one database round trip per record. On an instance where the dashboard notices panel is enabled this froze the browser tab while it rendered the whole list, and put avoidable load on the server (issue #25044).

## Changes
- `src/main/java/org/spin/grpc/service/NoticeManagement.java` — uncomment `.setLimit(limit, offset)` in `listNotices` and `listUsers`, so the already-computed paging is actually applied. Matches how every other paginated service in this package calls it.

## Test plan
- [ ] `ListNotices` with a user holding more notices than the page size returns exactly `page_size` records (default 50 via `LimitUtil.getPageSize`).
- [ ] `record_count` still reports the full total, and following `next_page_token` walks the remaining pages without repeating or skipping records.
- [ ] The last page returns an empty `next_page_token`.
- [ ] Same checks for `ListUsers`.
- [ ] Query count per request no longer scales with the total number of notices.