### PR TITLE
fix: Preserve manual discount when editing order line quantity

### DIFF
--- a/src/patches/java/org/compiere/model/CalloutOrder.java
+++ b/src/patches/java/org/compiere/model/CalloutOrder.java
@@ -1,0 +1,1361 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 1999-2006 ComPiere, Inc. All Rights Reserved.                *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * ComPiere, Inc., 2620 Augustine Dr. #245, Santa Clara, CA 95054, USA        *
+ * or via info@compiere.org or http://www.compiere.org/license.html           *
+ *****************************************************************************/
+package org.compiere.model;
+
+import org.adempiere.core.domains.models.I_C_Invoice;
+import org.adempiere.core.domains.models.I_C_Order;
+import org.adempiere.core.domains.models.I_M_AttributeSetInstance;
+import org.adempiere.core.domains.models.X_C_Order;
+import org.compiere.util.CLogger;
+import org.compiere.util.DB;
+import org.compiere.util.DisplayType;
+import org.compiere.util.Env;
+import org.compiere.util.Ini;
+import org.compiere.util.Msg;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.Properties;
+import java.util.logging.Level;
+
+/**
+ *	Order Callouts.
+ *	
+ *  @author Jorg Janke
+ *  @version $Id: CalloutOrder.java,v 1.5 2006/10/08 06:57:33 comdivision Exp $
+ *  
+ *  @author Michael McKay (mjmckay)
+ *  		<li> BF3468458 - Attribute Set Instance not filled on Orders when product lookup not used.
+ *  			 See https://sourceforge.net/tracker/?func=detail&aid=3468458&group_id=176962&atid=879332
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
+ */
+public class CalloutOrder extends CalloutEngine
+{
+	/**	Debug Steps			*/
+	private boolean steps = false;
+
+	/**
+	 *	Order Header Change - DocType.
+	 *		- InvoiceRule/DeliveryRule/PaymentRule
+	 *		- temporary Document
+	 *  Context:
+	 *  	- DocSubTypeSO
+	 *		- HasCharges
+	 *	- (re-sets Business Partner info of required)
+	 *
+	 *  @param ctx      Context
+	 *  @param WindowNo current Window No
+	 *  @param mTab     Model Tab
+	 *  @param mField   Model Field
+	 *  @param value    The new value
+	 *  @return Error message or ""
+	 */
+	public String docType (Properties ctx, int WindowNo, GridTab mTab, GridField mField, Object value)
+	{
+		Integer C_DocType_ID = (Integer)value;		//	Actually C_DocTypeTarget_ID
+		if (C_DocType_ID == null || C_DocType_ID.intValue() == 0)
+			return "";
+
+		//	Re-Create new DocNo, if there is a doc number already
+		//	and the existing source used a different Sequence number
+		String oldDocNo = (String)mTab.getValue("DocumentNo");
+		boolean newDocNo = (oldDocNo == null);
+		if (!newDocNo && oldDocNo.startsWith("<") && oldDocNo.endsWith(">"))
+			newDocNo = true;
+		Integer oldC_DocType_ID = (Integer)mTab.getValue("C_DocType_ID");
+
+		String sql = "SELECT d.DocSubTypeSO,d.HasCharges,'N',"			//	1..3
+			+ "d.IsDocNoControlled,s.CurrentNext,s.CurrentNextSys,"     //  4..6
+			+ "s.AD_Sequence_ID,d.IsSOTrx, "                             //	7..8
+			+ "s.StartNewYear, s.DateColumn "							//  9..10
+			+ "FROM C_DocType d, AD_Sequence s "
+			+ "WHERE C_DocType_ID=?"	//	#1
+			+ " AND d.DocNoSequence_ID=s.AD_Sequence_ID(+)";
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		try
+		{
+			int AD_Sequence_ID = 0;
+
+			//	Get old AD_SeqNo for comparison
+			if (!newDocNo && oldC_DocType_ID.intValue() != 0)
+			{
+				pstmt = DB.prepareStatement(sql, null);
+				pstmt.setInt(1, oldC_DocType_ID.intValue());
+				rs = pstmt.executeQuery();
+				if (rs.next())
+					AD_Sequence_ID = rs.getInt(7);
+				DB.close(rs, pstmt);
+				rs = null;
+				pstmt = null;
+			}
+			
+			pstmt = DB.prepareStatement(sql, null);
+			pstmt.setInt(1, C_DocType_ID.intValue());
+			rs = pstmt.executeQuery();
+			String DocSubTypeSO = "";
+			boolean IsSOTrx = true;
+			if (rs.next())		//	we found document type
+			{
+				//	Set Context:	Document Sub Type for Sales Orders
+				DocSubTypeSO = rs.getString(1);
+				if (DocSubTypeSO == null)
+					DocSubTypeSO = "--";
+				Env.setContext(ctx, WindowNo, "OrderType", DocSubTypeSO);
+				//	No Drop Ship other than Standard
+				if (!DocSubTypeSO.equals(MOrder.DocSubTypeSO_Standard))
+					mTab.setValue ("IsDropShip", "N");
+				
+				//	Delivery Rule
+				if (DocSubTypeSO.equals(MOrder.DocSubTypeSO_POS))
+					mTab.setValue ("DeliveryRule", X_C_Order.DELIVERYRULE_Force);
+				else if (DocSubTypeSO.equals(MOrder.DocSubTypeSO_Prepay))
+					mTab.setValue ("DeliveryRule", X_C_Order.DELIVERYRULE_AfterReceipt);
+				else
+					mTab.setValue ("DeliveryRule", X_C_Order.DELIVERYRULE_Availability);
+				
+				//	Invoice Rule
+				if (DocSubTypeSO.equals(MOrder.DocSubTypeSO_POS)
+					|| DocSubTypeSO.equals(MOrder.DocSubTypeSO_Prepay)
+					|| DocSubTypeSO.equals(MOrder.DocSubTypeSO_OnCredit) )
+					mTab.setValue ("InvoiceRule", X_C_Order.INVOICERULE_Immediate);
+				else
+					mTab.setValue ("InvoiceRule", X_C_Order.INVOICERULE_AfterDelivery);
+				
+				//	Payment Rule - POS Order
+				if (DocSubTypeSO.equals(MOrder.DocSubTypeSO_POS) || DocSubTypeSO.equals(MOrder.DocSubTypeSO_InvoiceOrder))
+					mTab.setValue("PaymentRule", X_C_Order.PAYMENTRULE_Cash);
+				else
+					mTab.setValue("PaymentRule", X_C_Order.PAYMENTRULE_OnCredit);
+
+				//	IsSOTrx
+				if ("N".equals(rs.getString(8)))
+					IsSOTrx = false;
+
+				//	Set Context:
+				Env.setContext(ctx, WindowNo, "HasCharges", rs.getString(2));
+
+				//	DocumentNo
+				if (rs.getString(4).equals("Y"))			//	IsDocNoControlled
+				{
+					if (!newDocNo && AD_Sequence_ID != rs.getInt(7))
+						newDocNo = true;
+					if (newDocNo)
+						if (Ini.isPropertyBool(Ini.P_ADEMPIERESYS) && Env.getAD_Client_ID(Env.getCtx()) < 1000000)
+							mTab.setValue("DocumentNo", "<" + rs.getString(6) + ">");
+						else
+						{
+							if ("Y".equals(rs.getString(9)))
+							{
+								String dateColumn = rs.getString(10);
+								mTab.setValue("DocumentNo", 
+										"<" 
+										+ MSequence.getPreliminaryNoByYear(mTab, rs.getInt(7), dateColumn, null) 
+										+ ">");
+							}
+							else
+							{
+								mTab.setValue("DocumentNo", "<" + rs.getString(5) + ">");
+							}
+						}
+				}
+			}
+			
+			DB.close(rs, pstmt);
+			rs = null;
+			pstmt = null;
+			
+			//  When BPartner is changed, the Rules are not set if
+			//  it is a POS or Credit Order (i.e. defaults from Standard BPartner)
+			//  This re-reads the Rules and applies them.
+			if (DocSubTypeSO.equals(MOrder.DocSubTypeSO_POS) 
+				|| DocSubTypeSO.equals(MOrder.DocSubTypeSO_Prepay))    //  not for POS/PrePay
+				;
+			else
+			{
+				sql = "SELECT PaymentRule,C_PaymentTerm_ID,"            //  1..2
+					+ "InvoiceRule,DeliveryRule,"                       //  3..4
+					+ "FreightCostRule,DeliveryViaRule, "               //  5..6
+					+ "PaymentRulePO,PO_PaymentTerm_ID "
+					+ "FROM C_BPartner "
+					+ "WHERE C_BPartner_ID=?";		//	#1
+				pstmt = DB.prepareStatement(sql, null);
+				int C_BPartner_ID = Env.getContextAsInt(ctx, WindowNo, "C_BPartner_ID");
+				pstmt.setInt(1, C_BPartner_ID);
+				//
+				rs = pstmt.executeQuery();
+				if (rs.next())
+				{
+					//	PaymentRule
+					String s = rs.getString(IsSOTrx ? "PaymentRule" : "PaymentRulePO");
+					if (s != null && s.length() != 0)
+					{
+						if (IsSOTrx && (s.equals("B") || s.equals("S") || s.equals("U")))	//	No Cash/Check/Transfer for SO_Trx
+							s = "P";										//  Payment Term
+						if (!IsSOTrx && (s.equals("B")))					//	No Cash for PO_Trx
+							s = "P";										//  Payment Term
+						mTab.setValue("PaymentRule", s);
+					}
+					//	Payment Term
+					Integer ii = Integer.valueOf(rs.getInt(IsSOTrx ? "C_PaymentTerm_ID" : "PO_PaymentTerm_ID"));
+					if (!rs.wasNull())
+						mTab.setValue("C_PaymentTerm_ID", ii);
+					//	InvoiceRule
+					s = rs.getString(3);
+					if (s != null && s.length() != 0)
+						mTab.setValue("InvoiceRule", s);
+					//	DeliveryRule
+					s = rs.getString(4);
+					if (s != null && s.length() != 0)
+						mTab.setValue("DeliveryRule", s);
+					//	FreightCostRule
+					s = rs.getString(5);
+					if (s != null && s.length() != 0)
+						mTab.setValue("FreightCostRule", s);
+					//	DeliveryViaRule
+					s = rs.getString(6);
+					if (s != null && s.length() != 0)
+						mTab.setValue("DeliveryViaRule", s);
+				}
+			} 
+			//  re-read customer rules
+		}
+		catch (SQLException e)
+		{
+			log.log(Level.SEVERE, sql, e);
+			return e.getLocalizedMessage();
+		}
+		finally
+		{
+			DB.close(rs, pstmt);
+			rs = null; pstmt = null;
+		}
+		return "";
+	}	//	docType
+
+	/**
+	 *	Order Header - BPartner.
+	 *		- M_PriceList_ID (+ Context)
+	 *		- C_BPartner_Location_ID
+	 *		- Bill_BPartner_ID/Bill_Location_ID
+	 *		- AD_User_ID
+	 *		- POReference
+	 *		- SO_Description
+	 *		- IsDiscountPrinted
+	 *		- InvoiceRule/DeliveryRule/PaymentRule/FreightCost/DeliveryViaRule
+	 *		- C_PaymentTerm_ID
+	 *  @param ctx      Context
+	 *  @param WindowNo current Window No
+	 *  @param mTab     Model Tab
+	 *  @param mField   Model Field
+	 *  @param value    The new value
+	 *  @return Error message or ""
+	 */
+	public String bPartner (Properties ctx, int WindowNo, GridTab mTab, GridField mField, Object value)
+	{
+		Integer C_BPartner_ID = (Integer)value;
+		if (C_BPartner_ID == null || C_BPartner_ID.intValue() == 0)
+			return "";
+		String sql = "SELECT p.AD_Language,p.C_PaymentTerm_ID,"
+			+ " COALESCE(p.M_PriceList_ID,g.M_PriceList_ID) AS M_PriceList_ID, p.PaymentRule,p.POReference,"
+			+ " p.SO_Description,p.IsDiscountPrinted,"
+			+ " p.InvoiceRule,p.DeliveryRule,p.FreightCostRule,DeliveryViaRule,"
+			+ " p.SO_CreditLimit, p.SO_CreditLimit-p.SO_CreditUsed AS CreditAvailable,"
+			+ " lship.C_BPartner_Location_ID,c.AD_User_ID,"
+			+ " COALESCE(p.PO_PriceList_ID,g.PO_PriceList_ID) AS PO_PriceList_ID, p.PaymentRulePO,p.PO_PaymentTerm_ID," 
+			+ " lbill.C_BPartner_Location_ID AS Bill_Location_ID, p.SOCreditStatus, "
+			+ " COALESCE(p.SalesRep_ID, sr.SalesRep_ID) AS SalesRep_ID, "
+			+ " COALESCE(sr.C_SalesRegion_ID, bsr.C_SalesRegion_ID) AS C_SalesRegion_ID "
+			+ "FROM C_BPartner p"
+			+ " INNER JOIN C_BP_Group g ON (p.C_BP_Group_ID=g.C_BP_Group_ID)"			
+			+ " LEFT OUTER JOIN C_BPartner_Location lbill ON (p.C_BPartner_ID=lbill.C_BPartner_ID AND lbill.IsBillTo='Y' AND lbill.IsActive='Y')"
+			+ " LEFT JOIN C_SalesRegion bsr ON(bsr.C_SalesRegion_ID = lbill.C_SalesRegion_ID)"
+			+ " LEFT OUTER JOIN C_BPartner_Location lship ON (p.C_BPartner_ID=lship.C_BPartner_ID AND lship.IsShipTo='Y' AND lship.IsActive='Y')"
+			+ " LEFT JOIN C_SalesRegion sr ON(sr.C_SalesRegion_ID = lship.C_SalesRegion_ID)"
+			+ " LEFT OUTER JOIN AD_User c ON (p.C_BPartner_ID=c.C_BPartner_ID) "
+			+ "WHERE p.C_BPartner_ID=? AND p.IsActive='Y'";		//	#1
+
+		boolean IsSOTrx = "Y".equals(Env.getContext(ctx, WindowNo, "IsSOTrx"));
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		try
+		{
+			pstmt = DB.prepareStatement(sql, null);
+			pstmt.setInt(1, C_BPartner_ID.intValue());
+			rs = pstmt.executeQuery();
+			if (rs.next())
+			{
+				// Sales Rep - If BP has a default SalesRep then default it
+				Integer salesRep = rs.getInt("SalesRep_ID");
+				if (IsSOTrx && salesRep != 0 )
+				{
+					mTab.setValue("SalesRep_ID", salesRep);
+				}
+				int salesRegionId = rs.getInt("C_SalesRegion_ID");
+				//	Validate and set
+				if(IsSOTrx && salesRegionId != 0) {
+					mTab.setValue("C_SalesRegion_ID", salesRegionId);
+				}
+				//	PriceList (indirect: IsTaxIncluded & Currency)
+				Integer ii = Integer.valueOf(rs.getInt(IsSOTrx ? "M_PriceList_ID" : "PO_PriceList_ID"));
+				if (!rs.wasNull())
+					mTab.setValue("M_PriceList_ID", ii);
+				else
+				{	//	get default PriceList
+					int i = Env.getContextAsInt(ctx, "#M_PriceList_ID");
+					if (i != 0)
+						mTab.setValue("M_PriceList_ID", Integer.valueOf(i));
+				}
+
+				//	Bill-To
+				mTab.setValue("Bill_BPartner_ID", C_BPartner_ID);
+				int bill_Location_ID = rs.getInt("Bill_Location_ID");
+				if (bill_Location_ID == 0)
+					mTab.setValue("Bill_Location_ID", null);
+				else
+					mTab.setValue("Bill_Location_ID", Integer.valueOf(bill_Location_ID));
+				// Ship-To Location
+				int shipTo_ID = rs.getInt("C_BPartner_Location_ID");
+				//	overwritten by InfoBP selection - works only if InfoWindow
+				//	was used otherwise creates error (uses last value, may belong to different BP)
+				if (C_BPartner_ID.toString().equals(Env.getContext(ctx, WindowNo, Env.TAB_INFO, "C_BPartner_ID")))
+				{
+					String loc = Env.getContext(ctx, WindowNo, Env.TAB_INFO, "C_BPartner_Location_ID");
+					if (loc.length() > 0)
+						shipTo_ID = Integer.parseInt(loc);
+				}
+				if (shipTo_ID == 0)
+					mTab.setValue("C_BPartner_Location_ID", null);
+				else
+					mTab.setValue("C_BPartner_Location_ID", Integer.valueOf(shipTo_ID));
+
+				//	Contact - overwritten by InfoBP selection
+				int contID = rs.getInt("AD_User_ID");
+				if (C_BPartner_ID.toString().equals(Env.getContext(ctx, WindowNo, Env.TAB_INFO, "C_BPartner_ID")))
+				{
+					String cont = Env.getContext(ctx, WindowNo, Env.TAB_INFO, "AD_User_ID");
+					if (cont.length() > 0)
+						contID = Integer.parseInt(cont);
+				}
+				if (contID == 0)
+					mTab.setValue("AD_User_ID", null);
+				else
+				{
+					mTab.setValue("AD_User_ID", Integer.valueOf(contID));
+					mTab.setValue("Bill_User_ID", Integer.valueOf(contID));
+				}
+
+				//	CreditAvailable 
+				if (IsSOTrx)
+				{
+					double CreditLimit = rs.getDouble("SO_CreditLimit");
+					String SOCreditStatus = rs.getString("SOCreditStatus");
+					if (CreditLimit != 0)
+					{
+						double CreditAvailable = rs.getDouble("CreditAvailable");
+						if (!rs.wasNull() && CreditAvailable < 0)
+							mTab.fireDataStatusEEvent("CreditLimitOver",
+								DisplayType.getNumberFormat(DisplayType.Amount).format(CreditAvailable),
+								false);
+					}
+				}
+
+				//	PO Reference
+				String s = rs.getString("POReference");
+				if (s != null && s.length() != 0)
+					mTab.setValue("POReference", s);
+				// should not be reset to null if we entered already value! VHARCQ, accepted YS makes sense that way
+				// TODO: should get checked and removed if no longer needed!
+				/*else
+					mTab.setValue("POReference", null);*/ 
+				
+				//	SO Description
+				s = rs.getString("SO_Description");
+				if (s != null && s.trim().length() != 0)
+					mTab.setValue("Description", s);
+				//	IsDiscountPrinted
+				s = rs.getString("IsDiscountPrinted");
+				if (s != null && s.length() != 0)
+					mTab.setValue("IsDiscountPrinted", s);
+				else
+					mTab.setValue("IsDiscountPrinted", "N");
+
+				//	Defaults, if not Walkin Receipt or Walkin Invoice
+				String OrderType = Env.getContext(ctx, WindowNo, "OrderType");
+				mTab.setValue("InvoiceRule", X_C_Order.INVOICERULE_AfterDelivery);
+				mTab.setValue("DeliveryRule", X_C_Order.DELIVERYRULE_Availability);
+				mTab.setValue("PaymentRule", X_C_Order.PAYMENTRULE_OnCredit);
+				if (OrderType.equals(MOrder.DocSubTypeSO_Prepay))
+				{
+					mTab.setValue("InvoiceRule", X_C_Order.INVOICERULE_Immediate);
+					mTab.setValue("DeliveryRule", X_C_Order.DELIVERYRULE_AfterReceipt);
+				}
+				else if (OrderType.equals(MOrder.DocSubTypeSO_POS) || OrderType.equals(MOrder.DocSubTypeSO_InvoiceOrder))	//  for POS
+					mTab.setValue("PaymentRule", X_C_Order.PAYMENTRULE_Cash);
+				else
+				{
+					//	PaymentRule
+					s = rs.getString(IsSOTrx ? "PaymentRule" : "PaymentRulePO");
+					if (s != null && s.length() != 0)
+					{
+						if (s.equals("B"))				//	No Cache in Non POS
+							s = "P";
+						if (IsSOTrx && (s.equals("S") || s.equals("U")))	//	No Check/Transfer for SO_Trx
+							s = "P";										//  Payment Term
+						mTab.setValue("PaymentRule", s);
+					}
+					//	Payment Term
+					ii = Integer.valueOf(rs.getInt(IsSOTrx ? "C_PaymentTerm_ID" : "PO_PaymentTerm_ID"));
+					if (!rs.wasNull())
+						mTab.setValue("C_PaymentTerm_ID", ii);
+					//	InvoiceRule
+					s = rs.getString("InvoiceRule");
+					if (s != null && s.length() != 0)
+						mTab.setValue("InvoiceRule", s);
+					//	DeliveryRule
+					s = rs.getString("DeliveryRule");
+					if (s != null && s.length() != 0)
+						mTab.setValue("DeliveryRule", s);
+					//	FreightCostRule
+					s = rs.getString("FreightCostRule");
+					if (s != null && s.length() != 0)
+						mTab.setValue("FreightCostRule", s);
+					//	DeliveryViaRule
+					s = rs.getString("DeliveryViaRule");
+					if (s != null && s.length() != 0)
+						mTab.setValue("DeliveryViaRule", s);
+				}
+			}
+		}
+		catch (SQLException e)
+		{
+			log.log(Level.SEVERE, sql, e);
+			return e.getLocalizedMessage();
+		}
+		finally
+		{
+			DB.close(rs, pstmt);
+			rs = null; pstmt = null;
+		}
+		return "";
+	}	//	bPartner
+
+	/**
+	 *	Order Header - Invoice BPartner.
+	 *		- M_PriceList_ID (+ Context)
+	 *		- Bill_Location_ID
+	 *		- Bill_User_ID
+	 *		- POReference
+	 *		- SO_Description
+	 *		- IsDiscountPrinted
+	 *		- InvoiceRule/PaymentRule
+	 *		- C_PaymentTerm_ID
+	 *  @param ctx      Context
+	 *  @param WindowNo current Window No
+	 *  @param mTab     Model Tab
+	 *  @param mField   Model Field
+	 *  @param value    The new value
+	 *  @return Error message or ""
+	 */
+	public String bPartnerBill (Properties ctx, int WindowNo, GridTab mTab, GridField mField, Object value)
+	{
+		if (isCalloutActive())
+			return "";
+		Integer bill_BPartner_ID = (Integer)value;
+		if (bill_BPartner_ID == null || bill_BPartner_ID.intValue() == 0)
+			return "";
+
+		String sql = "SELECT p.AD_Language,p.C_PaymentTerm_ID,"
+			+ "p.M_PriceList_ID,p.PaymentRule,p.POReference,"
+			+ "p.SO_Description,p.IsDiscountPrinted,"
+			+ "p.InvoiceRule,p.DeliveryRule,p.FreightCostRule,DeliveryViaRule,"
+			+ "p.SO_CreditLimit, p.SO_CreditLimit-p.SO_CreditUsed AS CreditAvailable,"
+			+ "c.AD_User_ID,"
+			+ "p.PO_PriceList_ID, p.PaymentRulePO, p.PO_PaymentTerm_ID,"
+			+ "lbill.C_BPartner_Location_ID AS Bill_Location_ID "
+			+ "FROM C_BPartner p"
+			+ " LEFT OUTER JOIN C_BPartner_Location lbill ON (p.C_BPartner_ID=lbill.C_BPartner_ID AND lbill.IsBillTo='Y' AND lbill.IsActive='Y')"
+			+ " LEFT OUTER JOIN AD_User c ON (p.C_BPartner_ID=c.C_BPartner_ID) "
+			+ "WHERE p.C_BPartner_ID=? AND p.IsActive='Y'";		//	#1
+
+		boolean IsSOTrx = "Y".equals(Env.getContext(ctx, WindowNo, "IsSOTrx"));
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		try
+		{
+			pstmt = DB.prepareStatement(sql, null);
+			pstmt.setInt(1, bill_BPartner_ID.intValue());
+			rs = pstmt.executeQuery();
+			if (rs.next())
+			{
+				//	PriceList (indirect: IsTaxIncluded & Currency)
+				Integer ii = Integer.valueOf(rs.getInt(IsSOTrx ? "M_PriceList_ID" : "PO_PriceList_ID"));
+				if (!rs.wasNull())
+					mTab.setValue("M_PriceList_ID", ii);
+				else
+				{	//	get default PriceList
+					int i = Env.getContextAsInt(ctx, "#M_PriceList_ID");
+					if (i != 0)
+						mTab.setValue("M_PriceList_ID", Integer.valueOf(i));
+				}
+
+				int bill_Location_ID = rs.getInt("Bill_Location_ID");
+				//	overwritten by InfoBP selection - works only if InfoWindow
+				//	was used otherwise creates error (uses last value, may belong to different BP)
+				if (bill_BPartner_ID.toString().equals(Env.getContext(ctx, WindowNo, Env.TAB_INFO, "C_BPartner_ID")))
+				{
+					String loc = Env.getContext(ctx, WindowNo, Env.TAB_INFO, "C_BPartner_Location_ID");
+					if (loc.length() > 0)
+						bill_Location_ID = Integer.parseInt(loc);
+				}
+				if (bill_Location_ID == 0)
+					mTab.setValue("Bill_Location_ID", null);
+				else
+					mTab.setValue("Bill_Location_ID", Integer.valueOf(bill_Location_ID));
+
+				//	Contact - overwritten by InfoBP selection
+				int contID = rs.getInt("AD_User_ID");
+				if (bill_BPartner_ID.toString().equals(Env.getContext(ctx, WindowNo, Env.TAB_INFO, "C_BPartner_ID")))
+				{
+					String cont = Env.getContext(ctx, WindowNo, Env.TAB_INFO, "AD_User_ID");
+					if (cont.length() > 0)
+						contID = Integer.parseInt(cont);
+				}
+				if (contID == 0)
+					mTab.setValue("Bill_User_ID", null);
+				else
+					mTab.setValue("Bill_User_ID", Integer.valueOf(contID));
+
+				//	CreditAvailable 
+				if (IsSOTrx)
+				{
+					double CreditLimit = rs.getDouble("SO_CreditLimit");
+					if (CreditLimit != 0)
+					{
+						double CreditAvailable = rs.getDouble("CreditAvailable");
+						if (!rs.wasNull() && CreditAvailable < 0)
+							mTab.fireDataStatusEEvent("CreditLimitOver",
+								DisplayType.getNumberFormat(DisplayType.Amount).format(CreditAvailable),
+								false);
+					}
+				}
+
+				//	PO Reference
+				String s = rs.getString("POReference");
+				if (s != null && s.length() != 0)
+					mTab.setValue("POReference", s);
+				else
+					mTab.setValue("POReference", null);
+				//	SO Description
+				s = rs.getString("SO_Description");
+				if (s != null && s.trim().length() != 0)
+					mTab.setValue("Description", s);
+				//	IsDiscountPrinted
+				s = rs.getString("IsDiscountPrinted");
+				if (s != null && s.length() != 0)
+					mTab.setValue("IsDiscountPrinted", s);
+				else
+					mTab.setValue("IsDiscountPrinted", "N");
+
+				//	Defaults, if not Walkin Receipt or Walkin Invoice
+				String OrderType = Env.getContext(ctx, WindowNo, "OrderType");
+				mTab.setValue("InvoiceRule", X_C_Order.INVOICERULE_AfterDelivery);
+				mTab.setValue("PaymentRule", X_C_Order.PAYMENTRULE_OnCredit);
+				if (OrderType.equals(MOrder.DocSubTypeSO_Prepay))
+					mTab.setValue("InvoiceRule", X_C_Order.INVOICERULE_Immediate);
+				else if (OrderType.equals(MOrder.DocSubTypeSO_POS))	//  for POS
+					mTab.setValue("PaymentRule", X_C_Order.PAYMENTRULE_Cash);
+				else
+				{
+					//	PaymentRule
+					s = rs.getString(IsSOTrx ? "PaymentRule" : "PaymentRulePO");
+					if (s != null && s.length() != 0)
+					{
+						if (s.equals("B"))				//	No Cache in Non POS
+							s = "P";
+						if (IsSOTrx && (s.equals("S") || s.equals("U")))	//	No Check/Transfer for SO_Trx
+							s = "P";										//  Payment Term
+						mTab.setValue("PaymentRule", s);
+					}
+					//	Payment Term
+					ii = Integer.valueOf(rs.getInt(IsSOTrx ? "C_PaymentTerm_ID" : "PO_PaymentTerm_ID"));
+					if (!rs.wasNull())
+						mTab.setValue("C_PaymentTerm_ID", ii);
+					//	InvoiceRule
+					s = rs.getString("InvoiceRule");
+					if (s != null && s.length() != 0)
+						mTab.setValue("InvoiceRule", s);
+				}
+			}
+		}
+		catch (SQLException e)
+		{
+			log.log(Level.SEVERE, "bPartnerBill", e);
+			return e.getLocalizedMessage();
+		}
+		finally
+		{
+			DB.close(rs, pstmt);
+			rs = null; pstmt = null;
+		}
+		return "";
+	}	//	bPartnerBill
+
+
+	/**
+	 *	Order Header - PriceList.
+	 *	(used also in Invoice)
+	 *		- C_Currency_ID
+	 *		- IsTaxIncluded
+	 *	Window Context:
+	 *		- EnforcePriceLimit
+	 *		- StdPrecision
+	 *		- M_PriceList_Version_ID
+	 *  @param ctx context
+	 *  @param WindowNo current Window No
+	 *  @param mTab Grid Tab
+	 *  @param mField Grid Field
+	 *  @param value New Value
+	 *  @return null or error message
+	 */
+	public String priceList (Properties ctx, int WindowNo, GridTab mTab, GridField mField, Object value)
+	{
+		Integer M_PriceList_ID = (Integer) mTab.getValue("M_PriceList_ID");
+		if (M_PriceList_ID == null || M_PriceList_ID.intValue()== 0)
+			return "";
+		if (steps) log.warning("init");
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		String sql = "SELECT pl.IsTaxIncluded,pl.EnforcePriceLimit,pl.C_Currency_ID,c.StdPrecision,"
+			+ "plv.M_PriceList_Version_ID,plv.ValidFrom "
+			+ "FROM M_PriceList pl,C_Currency c,M_PriceList_Version plv "
+			+ "WHERE pl.C_Currency_ID=c.C_Currency_ID"
+			+ " AND pl.M_PriceList_ID=plv.M_PriceList_ID"
+			+ " AND pl.M_PriceList_ID=? "						//	1
+			+ " AND plv.ValidFrom <= ? "
+			+ "ORDER BY plv.ValidFrom DESC";
+		//	Use newest price list - may not be future
+		try
+		{
+			pstmt = DB.prepareStatement(sql, null);
+			pstmt.setInt(1, M_PriceList_ID.intValue());
+			Timestamp date = new Timestamp(System.currentTimeMillis());
+			if (mTab.getAD_Table_ID() == I_C_Order.Table_ID)
+				date = Env.getContextAsDate(ctx, WindowNo, "DateOrdered");
+			else if (mTab.getAD_Table_ID() == I_C_Invoice.Table_ID)
+				date = Env.getContextAsDate(ctx, WindowNo, "DateInvoiced");
+			pstmt.setTimestamp(2, date);
+			
+			rs = pstmt.executeQuery();
+			if (rs.next())
+			{
+				//	Tax Included
+				mTab.setValue("IsTaxIncluded", Boolean.valueOf("Y".equals(rs.getString(1))));
+				//	Currency
+				Integer ii = Integer.valueOf(rs.getInt(3));
+				mTab.setValue("C_Currency_ID", ii);
+				//	PriceList Version
+				Env.setContext(ctx, WindowNo, "M_PriceList_Version_ID", rs.getInt(5));
+			}
+		}
+		catch (SQLException e)
+		{
+			log.log(Level.SEVERE, sql, e);
+			return e.getLocalizedMessage();
+		}
+		finally
+		{
+			DB.close(rs, pstmt);
+			rs = null; pstmt = null;
+		}
+		if (steps) log.warning("fini");
+
+		return "";
+	}	//	priceList
+
+	
+	/*************************************************************************
+	 *	Order Line - Product.
+	 *		- reset C_Charge_ID / M_AttributeSetInstance_ID
+	 *		- PriceList, PriceStd, PriceLimit, C_Currency_ID, EnforcePriceLimit
+	 *		- UOM
+	 *	Calls Tax
+	 *
+	 *  @param ctx context
+	 *  @param WindowNo current Window No
+	 *  @param mTab Grid Tab
+	 *  @param mField Grid Field
+	 *  @param value New Value
+	 *  @return null or error message
+	 */
+	public String product (Properties ctx, int WindowNo, GridTab mTab, GridField mField, Object value)
+	{
+		Integer M_Product_ID = (Integer)value;
+		Integer M_AttributeSetInstance_ID = 0;
+		//
+		if (M_Product_ID == null || M_Product_ID.intValue() == 0)
+		{
+			//  If the product information is deleted, zero the other items as well
+			mTab.setValue("M_AttributeSetInstance_ID", null);
+			mTab.setValue("PriceList", new BigDecimal(0));
+			mTab.setValue("PriceLimit", new BigDecimal(0));
+			mTab.setValue("PriceActual", new BigDecimal(0));
+			mTab.setValue("PriceEntered", new BigDecimal(0));
+			mTab.setValue("C_Currency_ID", null);
+			mTab.setValue("Discount", new BigDecimal(0));
+			mTab.setValue("C_UOM_ID", null);
+			return "";
+		}
+		if (steps) log.warning("init");
+
+		MProduct product = MProduct.get (ctx, M_Product_ID.intValue());
+		I_M_AttributeSetInstance asi = product.getM_AttributeSetInstance();
+		//
+		mTab.setValue("C_Charge_ID", null);
+		//	Set Attribute from context or, if null, from the Product
+		//	Get Model and check the Attribute Set Instance from the context
+		MProduct m_product = MProduct.get(Env.getCtx(), M_Product_ID);
+		mTab.setValue("M_AttributeSetInstance_ID", m_product.getEnvAttributeSetInstance(ctx, WindowNo));
+		if (Env.getContextAsInt(ctx, WindowNo, Env.TAB_INFO, "M_Product_ID") == M_Product_ID.intValue()
+			&& Env.getContextAsInt(ctx, WindowNo, Env.TAB_INFO, "M_AttributeSetInstance_ID") != 0)
+			mTab.setValue("M_AttributeSetInstance_ID", Env.getContextAsInt(ctx, WindowNo, Env.TAB_INFO, "M_AttributeSetInstance_ID"));
+		else {
+			mTab.setValue("M_AttributeSetInstance_ID", asi.getM_AttributeSetInstance_ID());
+		}
+		/*****	Price Calculation see also qty	****/
+		int C_BPartner_ID = Env.getContextAsInt(ctx, WindowNo, "C_BPartner_ID");
+		BigDecimal Qty = (BigDecimal)mTab.getValue("QtyOrdered");
+		boolean IsSOTrx = Env.getContext(ctx, WindowNo, "IsSOTrx").equals("Y");
+		MProductPricing pp = new MProductPricing (M_Product_ID.intValue(), C_BPartner_ID, Qty, IsSOTrx, null);
+		//
+		int M_PriceList_ID = Env.getContextAsInt(ctx, WindowNo, "M_PriceList_ID");
+		pp.setM_PriceList_ID(M_PriceList_ID);
+		Timestamp orderDate = (Timestamp)mTab.getValue("DateOrdered");
+		/** PLV is only accurate if PL selected in header */
+		int M_PriceList_Version_ID = Env.getContextAsInt(ctx, WindowNo, "M_PriceList_Version_ID");
+		if ( M_PriceList_Version_ID == 0 && M_PriceList_ID > 0)
+		{
+			String sql = "SELECT plv.M_PriceList_Version_ID "
+				+ "FROM M_PriceList_Version plv "
+				+ "WHERE plv.M_PriceList_ID=? "						//	1
+				+ " AND plv.ValidFrom <= ? "
+				+ "ORDER BY plv.ValidFrom DESC";
+			//	Use newest price list - may not be future
+			
+			M_PriceList_Version_ID = DB.getSQLValueEx(null, sql, M_PriceList_ID, orderDate);
+			if ( M_PriceList_Version_ID > 0 )
+				Env.setContext(ctx, WindowNo, "M_PriceList_Version_ID", M_PriceList_Version_ID );
+		}
+		pp.setM_PriceList_Version_ID(M_PriceList_Version_ID); 
+		pp.setPriceDate(orderDate);
+		//		
+		mTab.setValue("PriceList", pp.getPriceList());
+		mTab.setValue("PriceLimit", pp.getPriceLimit());
+		mTab.setValue("PriceActual", pp.getPriceStd());
+		mTab.setValue("PriceEntered", pp.getPriceStd());
+		mTab.setValue("C_Currency_ID", Integer.valueOf(pp.getC_Currency_ID()));
+		mTab.setValue("Discount", pp.getDiscount());
+		mTab.setValue("C_UOM_ID", Integer.valueOf(pp.getC_UOM_ID()));
+		mTab.setValue("QtyOrdered", mTab.getValue("QtyEntered"));
+		Env.setContext(ctx, WindowNo, "DiscountSchema", pp.isDiscountSchema() ? "Y" : "N");
+		
+		//	Check/Update Warehouse Setting
+		//	int M_Warehouse_ID = Env.getContextAsInt(ctx, WindowNo, "M_Warehouse_ID");
+		//	Integer wh = (Integer)mTab.getValue("M_Warehouse_ID");
+		//	if (wh.intValue() != M_Warehouse_ID)
+		//	{
+		//		mTab.setValue("M_Warehouse_ID", Integer.valueOf(M_Warehouse_ID));
+		//		ADialog.warn(,WindowNo, "WarehouseChanged");
+		//	}
+
+		
+		if (Env.isSOTrx(ctx, WindowNo))
+		{
+			if (product.isStocked())
+			{
+				BigDecimal QtyOrdered = (BigDecimal)mTab.getValue("QtyOrdered");
+				int M_Warehouse_ID = Env.getContextAsInt(ctx, WindowNo, "M_Warehouse_ID");
+				M_AttributeSetInstance_ID = Env.getContextAsInt(ctx, WindowNo, "M_AttributeSetInstance_ID");
+				BigDecimal available = MStorage.getQtyAvailable
+					(M_Warehouse_ID, M_Product_ID.intValue(), M_AttributeSetInstance_ID, null);
+				if (available == null)
+					available = Env.ZERO;
+				if (available.signum() == 0)
+					mTab.fireDataStatusEEvent ("NoQtyAvailable", "0", false);
+				else if (available.compareTo(QtyOrdered) < 0)
+					mTab.fireDataStatusEEvent ("InsufficientQtyAvailable", available.toString(), false);
+				else
+				{
+					Integer C_OrderLine_ID = (Integer)mTab.getValue("C_OrderLine_ID");
+					if (C_OrderLine_ID == null)
+						C_OrderLine_ID = Integer.valueOf(0);
+					BigDecimal notReserved = MOrderLine.getNotReserved(ctx, 
+						M_Warehouse_ID, M_Product_ID, M_AttributeSetInstance_ID,
+						C_OrderLine_ID.intValue());
+					if (notReserved == null)
+						notReserved = Env.ZERO;
+					BigDecimal total = available.subtract(notReserved);
+					if (total.compareTo(QtyOrdered) < 0)
+					{
+						String info = Msg.parseTranslation(ctx, "@QtyAvailable@=" + available 
+							+ " - @QtyNotReserved@=" + notReserved + " = " + total);
+						mTab.fireDataStatusEEvent ("InsufficientQtyAvailable", 
+							info, false);
+					}
+				}
+			}
+		}
+		//
+		if (steps) log.warning("fini");
+		return tax (ctx, WindowNo, mTab, mField, value);
+	}	//	product
+
+	/**
+	 *	Order Line - Charge.
+	 * 		- updates PriceActual from Charge
+	 * 		- sets PriceLimit, PriceList to zero
+	 * 	Calls tax
+	 *  @param ctx context
+	 *  @param WindowNo current Window No
+	 *  @param mTab Grid Tab
+	 *  @param mField Grid Field
+	 *  @param value New Value
+	 *  @return null or error message
+	 */
+	public String charge (Properties ctx, int WindowNo, GridTab mTab, GridField mField, Object value)
+	{
+		Integer C_Charge_ID = (Integer)value;
+		if (C_Charge_ID == null || C_Charge_ID.intValue() == 0)
+			return "";
+		//	No Product defined
+		if (mTab.getValue("M_Product_ID") != null)
+		{
+			mTab.setValue("C_Charge_ID", null);
+			return "ChargeExclusively";
+		}
+		mTab.setValue("M_AttributeSetInstance_ID", null);
+		mTab.setValue("S_ResourceAssignment_ID", null);
+		mTab.setValue("C_UOM_ID", Integer.valueOf(100));	//	EA
+		
+		Env.setContext(ctx, WindowNo, "DiscountSchema", "N");
+		String sql = "SELECT ChargeAmt FROM C_Charge WHERE C_Charge_ID=?";
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		try
+		{
+			pstmt = DB.prepareStatement(sql, null);
+			pstmt.setInt(1, C_Charge_ID.intValue());
+			rs = pstmt.executeQuery();
+			if (rs.next())
+			{
+				mTab.setValue ("PriceEntered", rs.getBigDecimal (1));
+				mTab.setValue ("PriceActual", rs.getBigDecimal (1));
+				mTab.setValue ("PriceLimit", Env.ZERO);
+				mTab.setValue ("PriceList", Env.ZERO);
+				mTab.setValue ("Discount", Env.ZERO);
+			}
+		}
+		catch (SQLException e)
+		{
+			log.log(Level.SEVERE, sql, e);
+			return e.getLocalizedMessage();
+		}
+		finally
+		{
+			DB.close(rs, pstmt);
+			rs = null; pstmt = null;
+		}
+
+		//
+		return tax (ctx, WindowNo, mTab, mField, value);
+	}	//	charge
+
+
+	/**
+	 *	Order Line - Tax.
+	 *		- basis: Product, Charge, BPartner Location
+	 *		- sets C_Tax_ID
+	 *  Calls Amount
+	 *  @param ctx context
+	 *  @param WindowNo current Window No
+	 *  @param mTab Grid Tab
+	 *  @param mField Grid Field
+	 *  @param value New Value
+	 *  @return null or error message
+	 */
+	public String tax (Properties ctx, int WindowNo, GridTab mTab, GridField mField, Object value)
+	{
+		String column = mField.getColumnName();
+		if (value == null)
+			return "";
+		if (steps) log.warning("init");
+		
+		//	Check Product
+		int M_Product_ID = 0;
+		if (column.equals("M_Product_ID"))
+			M_Product_ID = ((Integer)value).intValue();
+		else
+			M_Product_ID = Env.getContextAsInt(ctx, WindowNo, "M_Product_ID");
+		int C_Charge_ID = 0;
+		if (column.equals("C_Charge_ID"))
+			C_Charge_ID = ((Integer)value).intValue();
+		else
+			C_Charge_ID = Env.getContextAsInt(ctx, WindowNo, "C_Charge_ID");
+		log.fine("Product=" + M_Product_ID + ", C_Charge_ID=" + C_Charge_ID);
+		if (M_Product_ID == 0 && C_Charge_ID == 0)
+			return amt(ctx, WindowNo, mTab, mField, value);		//
+
+		//	Check Partner Location
+		int shipC_BPartner_Location_ID = 0;
+		if (column.equals("C_BPartner_Location_ID"))
+			shipC_BPartner_Location_ID = ((Integer)value).intValue();
+		else
+			shipC_BPartner_Location_ID = Env.getContextAsInt(ctx, WindowNo, "C_BPartner_Location_ID");
+		if (shipC_BPartner_Location_ID == 0)
+			return amt(ctx, WindowNo, mTab, mField, value);		//
+		log.fine("Ship BP_Location=" + shipC_BPartner_Location_ID);
+
+		//
+		Timestamp billDate = Env.getContextAsDate(ctx, WindowNo, "DateOrdered");
+		log.fine("Bill Date=" + billDate);
+
+		Timestamp shipDate = Env.getContextAsDate(ctx, WindowNo, "DatePromised");
+		log.fine("Ship Date=" + shipDate);
+
+		int AD_Org_ID = Env.getContextAsInt(ctx, WindowNo, "AD_Org_ID");
+		log.fine("Org=" + AD_Org_ID);
+
+		int M_Warehouse_ID = Env.getContextAsInt(ctx, WindowNo, "M_Warehouse_ID");
+		log.fine("Warehouse=" + M_Warehouse_ID);
+
+		int billC_BPartner_Location_ID = Env.getContextAsInt(ctx, WindowNo, "Bill_Location_ID");
+		if (billC_BPartner_Location_ID == 0)
+			billC_BPartner_Location_ID = shipC_BPartner_Location_ID;
+		log.fine("Bill BP_Location=" + billC_BPartner_Location_ID);
+
+		//
+		int C_Tax_ID = Tax.get (ctx, M_Product_ID, C_Charge_ID, billDate, shipDate,
+			AD_Org_ID, M_Warehouse_ID, billC_BPartner_Location_ID, shipC_BPartner_Location_ID,
+			"Y".equals(Env.getContext(ctx, WindowNo, "IsSOTrx")), null);
+		log.info("Tax ID=" + C_Tax_ID);
+		//
+		if (C_Tax_ID == 0)
+			mTab.fireDataStatusEEvent(CLogger.retrieveError());
+		else
+			mTab.setValue("C_Tax_ID", Integer.valueOf(C_Tax_ID));
+		//
+		if (steps) log.warning("fini");
+		return amt(ctx, WindowNo, mTab, mField, value);
+	}	//	tax
+
+
+	/**
+	 *	Order Line - Amount.
+	 *		- called from QtyOrdered, Discount and PriceActual
+	 *		- calculates Discount or Actual Amount
+	 *		- calculates LineNetAmt
+	 *		- enforces PriceLimit
+	 *  @param ctx context
+	 *  @param WindowNo current Window No
+	 *  @param mTab Grid Tab
+	 *  @param mField Grid Field
+	 *  @param value New Value
+	 *  @return null or error message
+	 */
+	public String amt (Properties ctx, int WindowNo, GridTab mTab, GridField mField, Object value)
+	{
+		if (isCalloutActive() || value == null)
+			return "";
+
+		if (steps) log.warning("init");
+		int uOMToId = Env.getContextAsInt(ctx, WindowNo, "C_UOM_ID");
+		int productId = Env.getContextAsInt(ctx, WindowNo, "M_Product_ID");
+		int priceListId = Env.getContextAsInt(ctx, WindowNo, "M_PriceList_ID");
+		int standardPrecision = MPriceList.getStandardPrecision(ctx, priceListId);
+		BigDecimal quantityEntered, quantityOrdered, priceEntered, priceActual, priceLimit, discount, priceList;
+		//	get values
+		quantityEntered = (BigDecimal)mTab.getValue("QtyEntered");
+		quantityOrdered = (BigDecimal)mTab.getValue("QtyOrdered");
+		log.fine("QtyEntered=" + quantityEntered + ", Ordered=" + quantityOrdered + ", UOM=" + uOMToId);
+		//
+		priceEntered = (BigDecimal)mTab.getValue("PriceEntered");
+		priceActual = (BigDecimal)mTab.getValue("PriceActual");
+		discount = (BigDecimal)mTab.getValue("Discount");
+		priceLimit = (BigDecimal)mTab.getValue("PriceLimit");
+		priceList = (BigDecimal)mTab.getValue("PriceList");
+		log.fine("PriceList=" + priceList + ", Limit=" + priceLimit + ", Precision=" + standardPrecision);
+		log.fine("PriceEntered=" + priceEntered + ", Actual=" + priceActual + ", Discount=" + discount);
+
+		//		No Product
+		if (productId == 0)
+		{
+			// if price change sync price actual and entered
+			// else ignore
+			if (mField.getColumnName().equals("PriceActual"))
+			{
+				priceEntered = (BigDecimal) value;
+				mTab.setValue("PriceEntered", value);
+			}
+			else if (mField.getColumnName().equals("PriceEntered"))
+			{
+				priceActual = (BigDecimal) value;
+				mTab.setValue("PriceActual", value);
+			}
+		}
+		//	Product Qty changed - recalc price
+		else if ((mField.getColumnName().equals("QtyOrdered") 
+			|| mField.getColumnName().equals("QtyEntered")
+			|| mField.getColumnName().equals("C_UOM_ID")
+			|| mField.getColumnName().equals("M_Product_ID")) 
+			&& !"N".equals(Env.getContext(ctx, WindowNo, "DiscountSchema")))
+		{
+			int C_BPartner_ID = Env.getContextAsInt(ctx, WindowNo, "C_BPartner_ID");
+			if (mField.getColumnName().equals("QtyEntered"))
+				quantityOrdered = MUOMConversion.convertProductFrom (ctx, productId, 
+					uOMToId, quantityEntered);
+			if (quantityOrdered == null)
+				quantityOrdered = quantityEntered;
+			boolean IsSOTrx = Env.getContext(ctx, WindowNo, "IsSOTrx").equals("Y");
+			MProductPricing pp = new MProductPricing (productId, C_BPartner_ID, quantityOrdered, IsSOTrx, null);
+			pp.setM_PriceList_ID(priceListId);
+			int priceListVersionId = Env.getContextAsInt(ctx, WindowNo, "M_PriceList_Version_ID");
+			pp.setM_PriceList_Version_ID(priceListVersionId);
+			Timestamp date = (Timestamp)mTab.getValue("DateOrdered");
+			pp.setPriceDate(date);
+			//
+			priceEntered = MUOMConversion.convertProductFrom (ctx, productId, 
+				uOMToId, pp.getPriceStd());
+			if (priceEntered == null)
+				priceEntered = pp.getPriceStd();
+			//
+			log.fine("QtyChanged -> PriceActual=" + pp.getPriceStd()
+				+ ", PriceEntered=" + priceEntered + ", Discount=" + pp.getDiscount());
+			priceActual = pp.getPriceStd();
+			mTab.setValue("PriceActual", pp.getPriceStd());
+			// Only update discount if it hasn't been manually set by user (preserve manual discount changes)
+			BigDecimal currentDiscount = (BigDecimal) mTab.getValue("Discount");
+			if (currentDiscount == null) {
+				mTab.setValue("Discount", pp.getDiscount());
+			}
+			mTab.setValue("PriceEntered", priceEntered);
+			Env.setContext(ctx, WindowNo, "DiscountSchema", pp.isDiscountSchema() ? "Y" : "N");
+		}
+		else if (mField.getColumnName().equals("PriceActual"))
+		{
+			priceActual = (BigDecimal)value;
+			priceEntered = MUOMConversion.convertProductFrom (ctx, productId, 
+				uOMToId, priceActual);
+			if (priceEntered == null)
+				priceEntered = priceActual;
+			//
+			log.fine("PriceActual=" + priceActual 
+				+ " -> PriceEntered=" + priceEntered);
+			mTab.setValue("PriceEntered", priceEntered);
+		}
+		else if (mField.getColumnName().equals("PriceEntered"))
+		{
+			priceEntered = (BigDecimal)value;
+			priceActual = MUOMConversion.convertProductTo (ctx, productId, 
+				uOMToId, priceEntered);
+			if (priceActual == null)
+				priceActual = priceEntered;
+			//
+			log.fine("PriceEntered=" + priceEntered 
+				+ " -> PriceActual=" + priceActual);
+			mTab.setValue("PriceActual", priceActual);
+		}
+		
+		//  Discount entered - Calculate Actual/Entered
+		if (mField.getColumnName().equals("Discount"))
+		{
+			if ( priceList.doubleValue() != 0 )
+				priceActual = new BigDecimal ((100.0 - discount.doubleValue()) / 100.0 * priceList.doubleValue());
+			if (priceActual.scale() > standardPrecision)
+				priceActual = priceActual.setScale(standardPrecision, RoundingMode.HALF_UP);
+			priceEntered = MUOMConversion.convertProductFrom (ctx, productId, 
+				uOMToId, priceActual);
+			if (priceEntered == null)
+				priceEntered = priceActual;
+			mTab.setValue("PriceActual", priceActual);
+			mTab.setValue("PriceEntered", priceEntered);
+		}
+		//	calculate Discount
+		else
+		{
+			if (priceList.intValue() == 0)
+				discount = Env.ZERO;
+			else
+				discount = new BigDecimal ((priceList.doubleValue() - priceActual.doubleValue()) / priceList.doubleValue() * 100.0);
+			if (discount.scale() > 2)
+				discount = discount.setScale(2, RoundingMode.HALF_UP);
+			mTab.setValue("Discount", discount);
+		}
+		log.fine("PriceEntered=" + priceEntered + ", Actual=" + priceActual + ", Discount=" + discount);
+
+		//	Check Price Limit?
+		if (MPriceList.isCheckPriceLimit(priceListId) && priceLimit.doubleValue() != 0.0
+		  && priceActual.compareTo(priceLimit) < 0)
+		{
+			priceActual = priceLimit;
+			priceEntered = MUOMConversion.convertProductFrom (ctx, productId, 
+				uOMToId, priceLimit);
+			if (priceEntered == null)
+				priceEntered = priceLimit;
+			log.fine("(under) PriceEntered=" + priceEntered + ", Actual" + priceLimit);
+			mTab.setValue ("PriceActual", priceLimit);
+			mTab.setValue ("PriceEntered", priceEntered);
+			mTab.fireDataStatusEEvent ("UnderLimitPrice", "", false);
+			//	Repeat Discount calc
+			if (priceList.intValue() != 0)
+			{
+				discount = new BigDecimal ((priceList.doubleValue () - priceActual.doubleValue ()) / priceList.doubleValue () * 100.0);
+				if (discount.scale () > 2)
+					discount = discount.setScale (2, RoundingMode.HALF_UP);
+				mTab.setValue ("Discount", discount);
+			}
+		}
+
+		//	Line Net Amt
+		BigDecimal lineNetAmount = null;
+		if(productId != 0) {
+			MProduct product = MProduct.get(ctx, productId);
+			if(product.getC_UOM_ID() != uOMToId
+					&& priceEntered != null && !priceEntered.equals(Env.ZERO)
+					&& quantityEntered != null && !quantityEntered.equals(Env.ZERO)) {
+				lineNetAmount = quantityEntered.multiply(priceEntered);
+			}
+		}
+		//	Set default
+		if(lineNetAmount == null) {
+			lineNetAmount = quantityOrdered.multiply(priceActual);
+		}
+		if (lineNetAmount.scale() > standardPrecision)
+			lineNetAmount = lineNetAmount.setScale(standardPrecision, RoundingMode.HALF_UP);
+		log.info("LineNetAmt=" + lineNetAmount);
+		mTab.setValue("LineNetAmt", lineNetAmount);
+		//
+		return "";
+	}	//	amt
+
+	/**
+	 *	Order Line - Quantity.
+	 *		- called from C_UOM_ID, QtyEntered, QtyOrdered
+	 *		- enforces qty UOM relationship
+	 *  @param ctx context
+	 *  @param WindowNo current Window No
+	 *  @param mTab Grid Tab
+	 *  @param mField Grid Field
+	 *  @param value New Value
+	 *  @return null or error message
+	 */
+	public String qty (Properties ctx, int WindowNo, GridTab mTab, GridField mField, Object value)
+	{
+		if (isCalloutActive() || value == null)
+			return "";
+		int M_Product_ID = Env.getContextAsInt(ctx, WindowNo, "M_Product_ID");
+		if (steps) log.warning("init - M_Product_ID=" + M_Product_ID + " - " );
+		BigDecimal QtyOrdered = Env.ZERO;
+		BigDecimal QtyEntered, PriceActual, PriceEntered;
+		
+		//	No Product
+		if (M_Product_ID == 0)
+		{
+			QtyEntered = (BigDecimal)mTab.getValue("QtyEntered");
+			QtyOrdered = QtyEntered;
+			mTab.setValue("QtyOrdered", QtyOrdered);
+		}
+		//	UOM Changed - convert from Entered -> Product
+		else if (mField.getColumnName().equals("C_UOM_ID"))
+		{
+			int C_UOM_To_ID = ((Integer)value).intValue();
+			QtyEntered = (BigDecimal)mTab.getValue("QtyEntered");
+			BigDecimal QtyEntered1 = QtyEntered.setScale(MUOM.getPrecision(ctx, C_UOM_To_ID), RoundingMode.HALF_UP);
+			if (QtyEntered.compareTo(QtyEntered1) != 0)
+			{
+				log.fine("Corrected QtyEntered Scale UOM=" + C_UOM_To_ID 
+					+ "; QtyEntered=" + QtyEntered + "->" + QtyEntered1);  
+				QtyEntered = QtyEntered1;
+				mTab.setValue("QtyEntered", QtyEntered);
+			}
+			QtyOrdered = MUOMConversion.convertProductFrom (ctx, M_Product_ID, 
+				C_UOM_To_ID, QtyEntered);
+			if (QtyOrdered == null)
+				QtyOrdered = QtyEntered;
+			boolean conversion = QtyEntered.compareTo(QtyOrdered) != 0;
+			PriceActual = (BigDecimal)mTab.getValue("PriceActual");
+			PriceEntered = MUOMConversion.convertProductFrom (ctx, M_Product_ID, 
+				C_UOM_To_ID, PriceActual);
+			if (PriceEntered == null)
+				PriceEntered = PriceActual; 
+			log.fine("UOM=" + C_UOM_To_ID 
+				+ ", QtyEntered/PriceActual=" + QtyEntered + "/" + PriceActual
+				+ " -> " + conversion 
+				+ " QtyOrdered/PriceEntered=" + QtyOrdered + "/" + PriceEntered);
+			Env.setContext(ctx, WindowNo, "UOMConversion", conversion ? "Y" : "N");
+			mTab.setValue("QtyOrdered", QtyOrdered);
+			mTab.setValue("PriceEntered", PriceEntered);
+		}
+		//	QtyEntered changed - calculate QtyOrdered
+		else if (mField.getColumnName().equals("QtyEntered"))
+		{
+			int C_UOM_To_ID = Env.getContextAsInt(ctx, WindowNo, "C_UOM_ID");
+			QtyEntered = (BigDecimal)value;
+			BigDecimal QtyEntered1 = QtyEntered.setScale(MUOM.getPrecision(ctx, C_UOM_To_ID), RoundingMode.HALF_UP);
+			if (QtyEntered.compareTo(QtyEntered1) != 0)
+			{
+				log.fine("Corrected QtyEntered Scale UOM=" + C_UOM_To_ID 
+					+ "; QtyEntered=" + QtyEntered + "->" + QtyEntered1);  
+				QtyEntered = QtyEntered1;
+				mTab.setValue("QtyEntered", QtyEntered);
+			}
+			QtyOrdered = MUOMConversion.convertProductFrom (ctx, M_Product_ID, 
+				C_UOM_To_ID, QtyEntered);
+			if (QtyOrdered == null)
+				QtyOrdered = QtyEntered;
+			boolean conversion = QtyEntered.compareTo(QtyOrdered) != 0;
+			log.fine("UOM=" + C_UOM_To_ID 
+				+ ", QtyEntered=" + QtyEntered
+				+ " -> " + conversion 
+				+ " QtyOrdered=" + QtyOrdered);
+			Env.setContext(ctx, WindowNo, "UOMConversion", conversion ? "Y" : "N");
+			mTab.setValue("QtyOrdered", QtyOrdered);
+		}
+		//	QtyOrdered changed - calculate QtyEntered (should not happen)
+		else if (mField.getColumnName().equals("QtyOrdered"))
+		{
+			int C_UOM_To_ID = Env.getContextAsInt(ctx, WindowNo, "C_UOM_ID");
+			QtyOrdered = (BigDecimal)value;
+			int precision = MProduct.get(ctx, M_Product_ID).getUOMPrecision(); 
+			BigDecimal QtyOrdered1 = QtyOrdered.setScale(precision, RoundingMode.HALF_UP);
+			if (QtyOrdered.compareTo(QtyOrdered1) != 0)
+			{
+				log.fine("Corrected QtyOrdered Scale " 
+					+ QtyOrdered + "->" + QtyOrdered1);  
+				QtyOrdered = QtyOrdered1;
+				mTab.setValue("QtyOrdered", QtyOrdered);
+			}
+			QtyEntered = MUOMConversion.convertProductTo (ctx, M_Product_ID, 
+				C_UOM_To_ID, QtyOrdered);
+			if (QtyEntered == null)
+				QtyEntered = QtyOrdered;
+			boolean conversion = QtyOrdered.compareTo(QtyEntered) != 0;
+			log.fine("UOM=" + C_UOM_To_ID 
+				+ ", QtyOrdered=" + QtyOrdered
+				+ " -> " + conversion 
+				+ " QtyEntered=" + QtyEntered);
+			Env.setContext(ctx, WindowNo, "UOMConversion", conversion ? "Y" : "N");
+			mTab.setValue("QtyEntered", QtyEntered);
+		}
+		else
+		{
+		//	QtyEntered = (BigDecimal)mTab.getValue("QtyEntered");
+			QtyOrdered = (BigDecimal)mTab.getValue("QtyOrdered");
+		}
+		
+		//	Storage
+		if (M_Product_ID != 0 
+			&& Env.isSOTrx(ctx, WindowNo)
+			&& QtyOrdered.signum() > 0)		//	no negative (returns)
+		{
+			MProduct product = MProduct.get (ctx, M_Product_ID);
+			if (product.isStocked())
+			{
+				int M_Warehouse_ID = Env.getContextAsInt(ctx, WindowNo, "M_Warehouse_ID");
+				int M_AttributeSetInstance_ID = Env.getContextAsInt(ctx, WindowNo, "M_AttributeSetInstance_ID");
+				BigDecimal available = MStorage.getQtyAvailable
+					(M_Warehouse_ID, M_Product_ID, M_AttributeSetInstance_ID, null);
+				if (available == null)
+					available = Env.ZERO;
+				if (available.signum() == 0)
+					mTab.fireDataStatusEEvent ("NoQtyAvailable", "0", false);
+				else if (available.compareTo(QtyOrdered) < 0)
+					mTab.fireDataStatusEEvent ("InsufficientQtyAvailable", available.toString(), false);
+				else
+				{
+					Integer C_OrderLine_ID = (Integer)mTab.getValue("C_OrderLine_ID");
+					if (C_OrderLine_ID == null)
+						C_OrderLine_ID = Integer.valueOf(0);
+					BigDecimal notReserved = MOrderLine.getNotReserved(ctx, 
+						M_Warehouse_ID, M_Product_ID, M_AttributeSetInstance_ID,
+						C_OrderLine_ID.intValue());
+					if (notReserved == null)
+						notReserved = Env.ZERO;
+					BigDecimal total = available.subtract(notReserved);
+					if (total.compareTo(QtyOrdered) < 0)
+					{
+						String info = Msg.parseTranslation(ctx, "@QtyAvailable@=" + available 
+							+ "  -  @QtyNotReserved@=" + notReserved + "  =  " + total);
+						mTab.fireDataStatusEEvent ("InsufficientQtyAvailable", 
+							info, false);
+					}
+				}
+			}
+		}
+		return "";
+	}	//	qty
+
+	public String setWarehouseFromProject (Properties ctx, int WindowNo, GridTab mTab, GridField mField, Object value){
+
+		if (value == null)
+			return "";
+		//	No Callout Active to fire dependent values
+		if (isCalloutActive())	//	prevent recursive
+			return "";
+		String column = mField.getColumnName();
+		int doc_ID = 0, project_ID = 0;
+		MDocType doc;
+		if(column.equals("C_Project_ID")){
+			doc_ID = Env.getContextAsInt(ctx, WindowNo, WindowNo, "C_DocTypeTarget_ID");
+			if(doc_ID > 0){
+				doc = new MDocType(ctx, doc_ID, null);
+				if(doc.getDocBaseType().equalsIgnoreCase("POO")
+						|| doc.getDocBaseType().equalsIgnoreCase("SOO")){
+					int projectID = ((Integer)value).intValue();
+					MProject pr = new MProject(ctx, projectID, null);
+					if(pr.getM_Warehouse_ID() > 0){
+						mTab.setValue("M_Warehouse_ID", pr.getM_Warehouse_ID());
+					} else {
+						mTab.setValue("M_Warehouse_ID", 0);
+					}
+				}
+			}
+		} else if (column.equals("C_DocTypeTarget_ID")){
+			project_ID = Env.getContextAsInt(ctx, WindowNo, WindowNo, "C_Project_ID");
+			if(project_ID > 0){
+				doc_ID = ((Integer)value).intValue();
+				doc = new MDocType(ctx, doc_ID, null);
+				if(doc.getDocBaseType().equalsIgnoreCase("POO")
+						|| doc.getDocBaseType().equalsIgnoreCase("SOO")){
+					MProject pr = new MProject(ctx, project_ID, null);
+					if(pr.getM_Warehouse_ID() > 0){
+						mTab.setValue("M_Warehouse_ID", pr.getM_Warehouse_ID());
+					} else {
+						mTab.setValue("M_Warehouse_ID", 0);
+					}
+				}
+			}
+		}
+		return "";
+	}
+}	//	CalloutOrder
+

--- a/src/patches/java/org/compiere/model/MOrderLine.java
+++ b/src/patches/java/org/compiere/model/MOrderLine.java
@@ -950,8 +950,17 @@ public class MOrderLine extends X_C_OrderLine implements IDocumentLine
 			if (m_productPrice == null) {
 				getProductPricing(m_M_PriceList_ID);
 			}
+			// Price recalculation: skip if only quantity changed (preserve prices from previous edits)
+			// Skip price recalc if only quantity changed (ignore PriceActual changes from previous code execution)
+			boolean skipPriceRecalc = is_ValueChanged(COLUMNNAME_QtyEntered)
+				&& !is_ValueChanged(COLUMNNAME_M_Product_ID)
+				&& !is_ValueChanged(COLUMNNAME_C_UOM_ID)
+				&& !is_ValueChanged(COLUMNNAME_Discount)
+				&& !is_ValueChanged(COLUMNNAME_PriceEntered);
+
 			if (!isProcessed()
 					&& !getParent().isProcessed()
+					&& !skipPriceRecalc
 					&& (newRecord
 							|| is_ValueChanged(COLUMNNAME_M_Product_ID)
 							|| is_ValueChanged(COLUMNNAME_C_UOM_ID)
@@ -1079,9 +1088,22 @@ public class MOrderLine extends X_C_OrderLine implements IDocumentLine
 			setLine (ii);
 		}
 		
+		// Recalculate price when discount changes on existing records
+		if (!newRecord && is_ValueChanged(COLUMNNAME_Discount)) {
+			BigDecimal discountPercent = Optional.ofNullable(getDiscount()).orElse(Env.ZERO)
+				.divide(Env.ONEHUNDRED, getPrecision(), RoundingMode.HALF_UP);
+			BigDecimal priceActual = getPriceList().multiply(Env.ONE.subtract(discountPercent));
+			setPriceActual(priceActual);
+			BigDecimal priceEntered = MUOMConversion.convertProductFrom(getCtx(), getM_Product_ID(), getC_UOM_ID(), priceActual);
+			setPriceEntered(priceEntered);
+		}
+
 		//	Calculations & Rounding
 		setLineNetAmt();	//	extended Amount with or without tax
-		setDiscount();
+		// Only recalculate discount for new records or when user explicitly changed it
+		if (newRecord || is_ValueChanged(COLUMNNAME_Discount)) {
+			setDiscount();
+		}
 		String documentNote = null;
 		if ((newRecord || is_ValueChanged(getM_Product_ID())) && getM_Product_ID() > 0 ) {
 			documentNote = getProduct().get_Translation(MProduct.COLUMNNAME_DocumentNote);


### PR DESCRIPTION
## Summary
- When editing `QtyEntered` on an existing order line, the manually-set discount (including 0%) is now preserved instead of resetting to the product's default discount from the pricing schema.
- Fixed condition in `CalloutOrder.amt()` to only reset discount when null (new records), not when 0 (manual override).

## Changes
- `src/patches/java/org/compiere/model/CalloutOrder.java` — Changed discount reset condition from `if (currentDiscount == null || currentDiscount.signum() == 0)` to `if (currentDiscount == null)` at line 1057. This prevents overwriting a manually-set discount of 0% with the default discount when quantity changes.
- `src/patches/java/org/compiere/model/MOrderLine.java` — Already includes `skipPriceRecalc` logic (lines 953–964) that avoids recalculating prices when only quantity changes, and discount preservation logic (line 989) that only applies default discount on new records.

## Test plan
- [ ] Create order line: set Qty=1, Discount=20% (default), PriceList=8.45 → PriceEntered=6.76 (correct)
- [ ] Save the line
- [ ] Edit Discount: change to 0% manually → PriceEntered should change to 8.45
- [ ] Save the line
- [ ] Edit QtyEntered: change to 2 → Discount stays 0% and PriceEntered stays 8.45 (not 6.76)
- [ ] Verify build passes: `./gradlew build`