### PR TITLE
 fix: Paginate entity change logs endpoint 

### DIFF
--- a/src/main/java/org/spin/grpc/service/LogsInfo.java
+++ b/src/main/java/org/spin/grpc/service/LogsInfo.java
@@ -370,12 +370,23 @@ public class LogsInfo extends LogsImplBase {
 			.setParameters(parameters)
 		;
 
+		//	Get page and count
+		String nexPageToken = null;
+		int pageNumber = LimitUtil.getPageNumber(SessionManager.getSessionUuid(), request.getPageToken());
+		int limit = LimitUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * limit;
 		int count = query.count();
-		ListEntityLogsResponse.Builder builder = ListEntityLogsResponse.newBuilder()
-			.setRecordCount(count)
-		;
+		builder.setRecordCount(count);
+		if(count > offset && count > limit) {
+			nexPageToken = LimitUtil.getPagePrefix(SessionManager.getSessionUuid()) + (pageNumber + 1);
+		}
+		builder.setNextPageToken(
+			TextManager.getValidString(nexPageToken)
+		);
 
 		List<MChangeLog> recordLogList = query
+			.setLimit(limit, offset)
+			.setOrderBy(I_AD_ChangeLog.COLUMNNAME_Updated + " DESC")
 			.<MChangeLog>list()
 		;
 

--- a/src/main/java/org/spin/grpc/service/LogsInfo.java
+++ b/src/main/java/org/spin/grpc/service/LogsInfo.java
@@ -376,7 +376,9 @@ public class LogsInfo extends LogsImplBase {
 		int limit = LimitUtil.getPageSize(request.getPageSize());
 		int offset = (pageNumber - 1) * limit;
 		int count = query.count();
-		builder.setRecordCount(count);
+		ListEntityLogsResponse.Builder builder = ListEntityLogsResponse.newBuilder()
+			.setRecordCount(count)
+		;
 		if(count > offset && count > limit) {
 			nexPageToken = LimitUtil.getPagePrefix(SessionManager.getSessionUuid()) + (pageNumber + 1);
 		}


### PR DESCRIPTION
## Summary
- `listEntityLogs` fetched every `AD_ChangeLog` row for a record with no limit, so high-traffic records (e.g. the default POS `C_BPartner`) returned unbounded payloads that froze the browser on `/api/logs/entities/{table}/{id}`.

## Changes
- `src/main/java/org/spin/grpc/service/LogsInfo.java` — apply `LimitUtil` pagination (page size/token, `setLimit`, order by `Updated DESC`) to `listEntityLogs`, matching the pattern already used by `listWorkflowLogs`; set `next_page_token` on the response.

## Test plan
- [ ] Request logs for a record with a large change history and confirm the response is capped to page size instead of returning all rows
- [ ] Confirm `record_count` still reflects the true total and `next_page_token` is set when more pages exist
- [ ] Verify existing records with few changes still return correctly with no regressions