### PR TITLE
feat: Add S_ContractLine column to HR and service model classes

### DIFF
--- a/src/patches/java/org/adempiere/core/domains/models/I_HR_AttendanceBatch.java
+++ b/src/patches/java/org/adempiere/core/domains/models/I_HR_AttendanceBatch.java
@@ -1,0 +1,388 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2017 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * or (at your option) any later version.                                     *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net                                                  *
+ * or https://github.com/adempiere/adempiere/blob/develop/license.html        *
+ *****************************************************************************/
+package org.adempiere.core.domains.models;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import org.compiere.model.MTable;
+import org.compiere.util.KeyNamePair;
+
+/** Generated Interface for HR_AttendanceBatch
+ *  @author Adempiere (generated) 
+ *  @version Release 3.9.4
+ */
+public interface I_HR_AttendanceBatch 
+{
+
+    /** TableName=HR_AttendanceBatch */
+    public static final String Table_Name = "HR_AttendanceBatch";
+
+    /** AD_Table_ID=54498 */
+    public static final int Table_ID = MTable.getTable_ID(Table_Name);
+
+    KeyNamePair Model = new KeyNamePair(Table_ID, Table_Name);
+
+    /** AccessLevel = 3 - Client - Org 
+     */
+    BigDecimal accessLevel = BigDecimal.valueOf(3);
+
+    /** Load Meta Data */
+
+    /** Column name AD_Client_ID */
+    public static final String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
+
+	/** Get Client.
+	  * Client/Tenant for this installation.
+	  */
+	public int getAD_Client_ID();
+
+    /** Column name AD_Org_ID */
+    public static final String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
+
+	/** Set Organization.
+	  * Organizational entity within client
+	  */
+	public void setAD_Org_ID (int AD_Org_ID);
+
+	/** Get Organization.
+	  * Organizational entity within client
+	  */
+	public int getAD_Org_ID();
+
+    /** Column name C_BPartner_ID */
+    public static final String COLUMNNAME_C_BPartner_ID = "C_BPartner_ID";
+
+	/** Set Business Partner .
+	  * Identifies a Business Partner
+	  */
+	public void setC_BPartner_ID (int C_BPartner_ID);
+
+	/** Get Business Partner .
+	  * Identifies a Business Partner
+	  */
+	public int getC_BPartner_ID();
+
+	public org.adempiere.core.domains.models.I_C_BPartner getC_BPartner() throws RuntimeException;
+
+    /** Column name C_DocType_ID */
+    public static final String COLUMNNAME_C_DocType_ID = "C_DocType_ID";
+
+	/** Set Document Type.
+	  * Document type or rules
+	  */
+	public void setC_DocType_ID (int C_DocType_ID);
+
+	/** Get Document Type.
+	  * Document type or rules
+	  */
+	public int getC_DocType_ID();
+
+	public org.adempiere.core.domains.models.I_C_DocType getC_DocType() throws RuntimeException;
+
+    /** Column name Created */
+    public static final String COLUMNNAME_Created = "Created";
+
+	/** Get Created.
+	  * Date this record was created
+	  */
+	public Timestamp getCreated();
+
+    /** Column name CreatedBy */
+    public static final String COLUMNNAME_CreatedBy = "CreatedBy";
+
+	/** Get Created By.
+	  * User who created this records
+	  */
+	public int getCreatedBy();
+
+    /** Column name DateDoc */
+    public static final String COLUMNNAME_DateDoc = "DateDoc";
+
+	/** Set Document Date.
+	  * Date of the Document
+	  */
+	public void setDateDoc (Timestamp DateDoc);
+
+	/** Get Document Date.
+	  * Date of the Document
+	  */
+	public Timestamp getDateDoc();
+
+    /** Column name Description */
+    public static final String COLUMNNAME_Description = "Description";
+
+	/** Set Description.
+	  * Optional short description of the record
+	  */
+	public void setDescription (String Description);
+
+	/** Get Description.
+	  * Optional short description of the record
+	  */
+	public String getDescription();
+
+    /** Column name DocAction */
+    public static final String COLUMNNAME_DocAction = "DocAction";
+
+	/** Set Document Action.
+	  * The targeted status of the document
+	  */
+	public void setDocAction (String DocAction);
+
+	/** Get Document Action.
+	  * The targeted status of the document
+	  */
+	public String getDocAction();
+
+    /** Column name DocStatus */
+    public static final String COLUMNNAME_DocStatus = "DocStatus";
+
+	/** Set Document Status.
+	  * The current status of the document
+	  */
+	public void setDocStatus (String DocStatus);
+
+	/** Get Document Status.
+	  * The current status of the document
+	  */
+	public String getDocStatus();
+
+    /** Column name DocumentNo */
+    public static final String COLUMNNAME_DocumentNo = "DocumentNo";
+
+	/** Set Document No.
+	  * Document sequence number of the document
+	  */
+	public void setDocumentNo (String DocumentNo);
+
+	/** Get Document No.
+	  * Document sequence number of the document
+	  */
+	public String getDocumentNo();
+
+    /** Column name HR_AttendanceBatch_ID */
+    public static final String COLUMNNAME_HR_AttendanceBatch_ID = "HR_AttendanceBatch_ID";
+
+	/** Set Attendance Batch	  */
+	public void setHR_AttendanceBatch_ID (int HR_AttendanceBatch_ID);
+
+	/** Get Attendance Batch	  */
+	public int getHR_AttendanceBatch_ID();
+
+    /** Column name HR_Employee_ID */
+    public static final String COLUMNNAME_HR_Employee_ID = "HR_Employee_ID";
+
+	/** Set Payroll Employee	  */
+	public void setHR_Employee_ID (int HR_Employee_ID);
+
+	/** Get Payroll Employee	  */
+	public int getHR_Employee_ID();
+
+	public org.adempiere.core.domains.models.I_HR_Employee getHR_Employee() throws RuntimeException;
+
+    /** Column name HR_ShiftSchedule_ID */
+    public static final String COLUMNNAME_HR_ShiftSchedule_ID = "HR_ShiftSchedule_ID";
+
+	/** Set Shift Schedule.
+	  * Shift Schedule
+	  */
+	public void setHR_ShiftSchedule_ID (int HR_ShiftSchedule_ID);
+
+	/** Get Shift Schedule.
+	  * Shift Schedule
+	  */
+	public int getHR_ShiftSchedule_ID();
+
+	public org.adempiere.core.domains.models.I_HR_ShiftSchedule getHR_ShiftSchedule() throws RuntimeException;
+
+    /** Column name HR_WorkShift_ID */
+    public static final String COLUMNNAME_HR_WorkShift_ID = "HR_WorkShift_ID";
+
+	/** Set Work Shift.
+	  * Work Shift
+	  */
+	public void setHR_WorkShift_ID (int HR_WorkShift_ID);
+
+	/** Get Work Shift.
+	  * Work Shift
+	  */
+	public int getHR_WorkShift_ID();
+
+	public org.adempiere.core.domains.models.I_HR_WorkShift getHR_WorkShift() throws RuntimeException;
+
+    /** Column name IsActive */
+    public static final String COLUMNNAME_IsActive = "IsActive";
+
+	/** Set Active.
+	  * The record is active in the system
+	  */
+	public void setIsActive (boolean IsActive);
+
+	/** Get Active.
+	  * The record is active in the system
+	  */
+	public boolean isActive();
+
+    /** Column name IsApproved */
+    public static final String COLUMNNAME_IsApproved = "IsApproved";
+
+	/** Set Approved.
+	  * Indicates if this document requires approval
+	  */
+	public void setIsApproved (boolean IsApproved);
+
+	/** Get Approved.
+	  * Indicates if this document requires approval
+	  */
+	public boolean isApproved();
+
+    /** Column name IsAttendanceGenerated */
+    public static final String COLUMNNAME_IsAttendanceGenerated = "IsAttendanceGenerated";
+
+	/** Set Attendance Generated.
+	  * Attendance Generated automatically
+	  */
+	public void setIsAttendanceGenerated (boolean IsAttendanceGenerated);
+
+	/** Get Attendance Generated.
+	  * Attendance Generated automatically
+	  */
+	public boolean isAttendanceGenerated();
+
+    /** Column name IsLeave */
+    public static final String COLUMNNAME_IsLeave = "IsLeave";
+
+	/** Set Leave.
+	  * This document is generated from a leave
+	  */
+	public void setIsLeave (boolean IsLeave);
+
+	/** Get Leave.
+	  * This document is generated from a leave
+	  */
+	public boolean isLeave();
+
+    /** Column name Processed */
+    public static final String COLUMNNAME_Processed = "Processed";
+
+	/** Set Processed.
+	  * The document has been processed
+	  */
+	public void setProcessed (boolean Processed);
+
+	/** Get Processed.
+	  * The document has been processed
+	  */
+	public boolean isProcessed();
+
+    /** Column name Processing */
+    public static final String COLUMNNAME_Processing = "Processing";
+
+	/** Set Process Now	  */
+	public void setProcessing (boolean Processing);
+
+	/** Get Process Now	  */
+	public boolean isProcessing();
+
+    /** Column name S_Contract_ID */
+    public static final String COLUMNNAME_S_Contract_ID = "S_Contract_ID";
+
+	/** Set Contract.
+	  * Contract
+	  */
+	public void setS_Contract_ID (int S_Contract_ID);
+
+	/** Get Contract.
+	  * Contract
+	  */
+	public int getS_Contract_ID();
+
+	public org.adempiere.core.domains.models.I_S_Contract getS_Contract() throws RuntimeException;
+
+    /** Column name S_ContractLine_ID */
+    public static final String COLUMNNAME_S_ContractLine_ID = "S_ContractLine_ID";
+
+	/** Set ContractLine.
+	  * ContractLine
+	  */
+	public void setS_ContractLine_ID (int S_ContractLine_ID);
+
+	/** Get ContractLine.
+	  * ContractLine
+	  */
+	public int getS_ContractLine_ID();
+
+	public org.adempiere.core.domains.models.I_S_ContractLine getS_ContractLine() throws RuntimeException;
+
+    /** Column name S_ResourceAssignment_ID */
+    public static final String COLUMNNAME_S_ResourceAssignment_ID = "S_ResourceAssignment_ID";
+
+	/** Set Resource Assignment.
+	  * Resource Assignment
+	  */
+	public void setS_ResourceAssignment_ID (int S_ResourceAssignment_ID);
+
+	/** Get Resource Assignment.
+	  * Resource Assignment
+	  */
+	public int getS_ResourceAssignment_ID();
+
+    /** Column name S_ServiceSchedule_ID */
+    public static final String COLUMNNAME_S_ServiceSchedule_ID = "S_ServiceSchedule_ID";
+
+	/** Set Service Schedule ID.
+	  * Weekly visit pattern for a service plan
+	  */
+	public void setS_ServiceSchedule_ID (int S_ServiceSchedule_ID);
+
+	/** Get Service Schedule ID.
+	  * Weekly visit pattern for a service plan
+	  */
+	public int getS_ServiceSchedule_ID();
+
+	public org.adempiere.core.domains.models.I_S_ServiceSchedule getS_ServiceSchedule() throws RuntimeException;
+
+    /** Column name Updated */
+    public static final String COLUMNNAME_Updated = "Updated";
+
+	/** Get Updated.
+	  * Date this record was updated
+	  */
+	public Timestamp getUpdated();
+
+    /** Column name UpdatedBy */
+    public static final String COLUMNNAME_UpdatedBy = "UpdatedBy";
+
+	/** Get Updated By.
+	  * User who updated this records
+	  */
+	public int getUpdatedBy();
+
+    /** Column name UUID */
+    public static final String COLUMNNAME_UUID = "UUID";
+
+	/** Set Immutable Universally Unique Identifier.
+	  * Immutable Universally Unique Identifier
+	  */
+	public void setUUID (String UUID);
+
+	/** Get Immutable Universally Unique Identifier.
+	  * Immutable Universally Unique Identifier
+	  */
+	public String getUUID();
+}

--- a/src/patches/java/org/adempiere/core/domains/models/I_HR_AttendanceRecord.java
+++ b/src/patches/java/org/adempiere/core/domains/models/I_HR_AttendanceRecord.java
@@ -1,0 +1,327 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2017 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * or (at your option) any later version.                                     *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net                                                  *
+ * or https://github.com/adempiere/adempiere/blob/develop/license.html        *
+ *****************************************************************************/
+package org.adempiere.core.domains.models;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import org.compiere.model.MTable;
+import org.compiere.util.KeyNamePair;
+
+/** Generated Interface for HR_AttendanceRecord
+ *  @author Adempiere (generated) 
+ *  @version Release 3.9.4
+ */
+public interface I_HR_AttendanceRecord 
+{
+
+    /** TableName=HR_AttendanceRecord */
+    public static final String Table_Name = "HR_AttendanceRecord";
+
+    /** AD_Table_ID=54499 */
+    public static final int Table_ID = MTable.getTable_ID(Table_Name);
+
+    KeyNamePair Model = new KeyNamePair(Table_ID, Table_Name);
+
+    /** AccessLevel = 3 - Client - Org 
+     */
+    BigDecimal accessLevel = BigDecimal.valueOf(3);
+
+    /** Load Meta Data */
+
+    /** Column name AD_Client_ID */
+    public static final String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
+
+	/** Get Client.
+	  * Client/Tenant for this installation.
+	  */
+	public int getAD_Client_ID();
+
+    /** Column name AD_Org_ID */
+    public static final String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
+
+	/** Set Organization.
+	  * Organizational entity within client
+	  */
+	public void setAD_Org_ID (int AD_Org_ID);
+
+	/** Get Organization.
+	  * Organizational entity within client
+	  */
+	public int getAD_Org_ID();
+
+    /** Column name AttendanceTime */
+    public static final String COLUMNNAME_AttendanceTime = "AttendanceTime";
+
+	/** Set Attendance Time.
+	  * Attendance Time for Employee
+	  */
+	public void setAttendanceTime (Timestamp AttendanceTime);
+
+	/** Get Attendance Time.
+	  * Attendance Time for Employee
+	  */
+	public Timestamp getAttendanceTime();
+
+    /** Column name Comments */
+    public static final String COLUMNNAME_Comments = "Comments";
+
+	/** Set Comments.
+	  * Comments or additional information
+	  */
+	public void setComments (String Comments);
+
+	/** Get Comments.
+	  * Comments or additional information
+	  */
+	public String getComments();
+
+    /** Column name C_Project_ID */
+    public static final String COLUMNNAME_C_Project_ID = "C_Project_ID";
+
+	/** Set Project.
+	  * Financial Project
+	  */
+	public void setC_Project_ID (int C_Project_ID);
+
+	/** Get Project.
+	  * Financial Project
+	  */
+	public int getC_Project_ID();
+
+	public org.adempiere.core.domains.models.I_C_Project getC_Project() throws RuntimeException;
+
+    /** Column name Created */
+    public static final String COLUMNNAME_Created = "Created";
+
+	/** Get Created.
+	  * Date this record was created
+	  */
+	public Timestamp getCreated();
+
+    /** Column name CreatedBy */
+    public static final String COLUMNNAME_CreatedBy = "CreatedBy";
+
+	/** Get Created By.
+	  * User who created this records
+	  */
+	public int getCreatedBy();
+
+    /** Column name HR_AttendanceBatch_ID */
+    public static final String COLUMNNAME_HR_AttendanceBatch_ID = "HR_AttendanceBatch_ID";
+
+	/** Set Attendance Batch	  */
+	public void setHR_AttendanceBatch_ID (int HR_AttendanceBatch_ID);
+
+	/** Get Attendance Batch	  */
+	public int getHR_AttendanceBatch_ID();
+
+	public org.adempiere.core.domains.models.I_HR_AttendanceBatch getHR_AttendanceBatch() throws RuntimeException;
+
+    /** Column name HR_AttendanceRecord_ID */
+    public static final String COLUMNNAME_HR_AttendanceRecord_ID = "HR_AttendanceRecord_ID";
+
+	/** Set Attendance Record.
+	  * Attendance Record
+	  */
+	public void setHR_AttendanceRecord_ID (int HR_AttendanceRecord_ID);
+
+	/** Get Attendance Record.
+	  * Attendance Record
+	  */
+	public int getHR_AttendanceRecord_ID();
+
+    /** Column name IsActive */
+    public static final String COLUMNNAME_IsActive = "IsActive";
+
+	/** Set Active.
+	  * The record is active in the system
+	  */
+	public void setIsActive (boolean IsActive);
+
+	/** Get Active.
+	  * The record is active in the system
+	  */
+	public boolean isActive();
+
+    /** Column name IsOfflineMark */
+    public static final String COLUMNNAME_IsOfflineMark = "IsOfflineMark";
+
+	/** Set Offline Mark.
+	  * Attendance mark was made without internet connection and synced later
+	  */
+	public void setIsOfflineMark (boolean IsOfflineMark);
+
+	/** Get Offline Mark.
+	  * Attendance mark was made without internet connection and synced later
+	  */
+	public boolean isOfflineMark();
+
+    /** Column name IsOutOfTime */
+    public static final String COLUMNNAME_IsOutOfTime = "IsOutOfTime";
+
+	/** Set Out of Time.
+	  * Attendance mark was made outside the time tolerance (10 minutes)
+	  */
+	public void setIsOutOfTime (boolean IsOutOfTime);
+
+	/** Get Out of Time.
+	  * Attendance mark was made outside the time tolerance (10 minutes)
+	  */
+	public boolean isOutOfTime();
+
+    /** Column name IsOutOfZone */
+    public static final String COLUMNNAME_IsOutOfZone = "IsOutOfZone";
+
+	/** Set Out of Zone.
+	  * Attendance mark was made outside the geofence radius of the client location
+	  */
+	public void setIsOutOfZone (boolean IsOutOfZone);
+
+	/** Get Out of Zone.
+	  * Attendance mark was made outside the geofence radius of the client location
+	  */
+	public boolean isOutOfZone();
+
+    /** Column name Latitude */
+    public static final String COLUMNNAME_Latitude = "Latitude";
+
+	/** Set Latitude.
+	  * Latitude is a geographic coordinate that specifies the north–south position of a point on the Earth's surface.
+	  */
+	public void setLatitude (BigDecimal Latitude);
+
+	/** Get Latitude.
+	  * Latitude is a geographic coordinate that specifies the north–south position of a point on the Earth's surface.
+	  */
+	public BigDecimal getLatitude();
+
+    /** Column name Longitude */
+    public static final String COLUMNNAME_Longitude = "Longitude";
+
+	/** Set Longitude.
+	  * Longitude  is a geographic coordinate that specifies the east–west position of a point on the Earth's surface, or the surface of a celestial body
+	  */
+	public void setLongitude (BigDecimal Longitude);
+
+	/** Get Longitude.
+	  * Longitude  is a geographic coordinate that specifies the east–west position of a point on the Earth's surface, or the surface of a celestial body
+	  */
+	public BigDecimal getLongitude();
+
+    /** Column name Processed */
+    public static final String COLUMNNAME_Processed = "Processed";
+
+	/** Set Processed.
+	  * The document has been processed
+	  */
+	public void setProcessed (boolean Processed);
+
+	/** Get Processed.
+	  * The document has been processed
+	  */
+	public boolean isProcessed();
+
+    /** Column name S_Contract_ID */
+    public static final String COLUMNNAME_S_Contract_ID = "S_Contract_ID";
+
+	/** Set Contract.
+	  * Contract
+	  */
+	public void setS_Contract_ID (int S_Contract_ID);
+
+	/** Get Contract.
+	  * Contract
+	  */
+	public int getS_Contract_ID();
+
+	public org.adempiere.core.domains.models.I_S_Contract getS_Contract() throws RuntimeException;
+
+    /** Column name S_ContractLine_ID */
+    public static final String COLUMNNAME_S_ContractLine_ID = "S_ContractLine_ID";
+
+	/** Set ContractLine.
+	  * ContractLine
+	  */
+	public void setS_ContractLine_ID (int S_ContractLine_ID);
+
+	/** Get ContractLine.
+	  * ContractLine
+	  */
+	public int getS_ContractLine_ID();
+
+	public org.adempiere.core.domains.models.I_S_ContractLine getS_ContractLine() throws RuntimeException;
+
+    /** Column name SeqNo */
+    public static final String COLUMNNAME_SeqNo = "SeqNo";
+
+	/** Set Sequence.
+	  * Method of ordering records;
+ lowest number comes first
+	  */
+	public void setSeqNo (int SeqNo);
+
+	/** Get Sequence.
+	  * Method of ordering records;
+ lowest number comes first
+	  */
+	public int getSeqNo();
+
+    /** Column name S_ResourceAssignment_ID */
+    public static final String COLUMNNAME_S_ResourceAssignment_ID = "S_ResourceAssignment_ID";
+
+	/** Set Resource Assignment.
+	  * Resource Assignment
+	  */
+	public void setS_ResourceAssignment_ID (int S_ResourceAssignment_ID);
+
+	/** Get Resource Assignment.
+	  * Resource Assignment
+	  */
+	public int getS_ResourceAssignment_ID();
+
+	public org.adempiere.core.domains.models.I_S_ResourceAssignment getS_ResourceAssignment() throws RuntimeException;
+
+    /** Column name Updated */
+    public static final String COLUMNNAME_Updated = "Updated";
+
+	/** Get Updated.
+	  * Date this record was updated
+	  */
+	public Timestamp getUpdated();
+
+    /** Column name UpdatedBy */
+    public static final String COLUMNNAME_UpdatedBy = "UpdatedBy";
+
+	/** Get Updated By.
+	  * User who updated this records
+	  */
+	public int getUpdatedBy();
+
+    /** Column name UUID */
+    public static final String COLUMNNAME_UUID = "UUID";
+
+	/** Set Immutable Universally Unique Identifier.
+	  * Immutable Universally Unique Identifier
+	  */
+	public void setUUID (String UUID);
+
+	/** Get Immutable Universally Unique Identifier.
+	  * Immutable Universally Unique Identifier
+	  */
+	public String getUUID();
+}

--- a/src/patches/java/org/adempiere/core/domains/models/I_HR_Incidence.java
+++ b/src/patches/java/org/adempiere/core/domains/models/I_HR_Incidence.java
@@ -1,0 +1,455 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2017 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * or (at your option) any later version.                                     *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net                                                  *
+ * or https://github.com/adempiere/adempiere/blob/develop/license.html        *
+ *****************************************************************************/
+package org.adempiere.core.domains.models;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import org.compiere.model.MTable;
+import org.compiere.util.KeyNamePair;
+
+/** Generated Interface for HR_Incidence
+ *  @author Adempiere (generated) 
+ *  @version Release 3.9.4
+ */
+public interface I_HR_Incidence 
+{
+
+    /** TableName=HR_Incidence */
+    public static final String Table_Name = "HR_Incidence";
+
+    /** AD_Table_ID=54501 */
+    public static final int Table_ID = MTable.getTable_ID(Table_Name);
+
+    KeyNamePair Model = new KeyNamePair(Table_ID, Table_Name);
+
+    /** AccessLevel = 3 - Client - Org 
+     */
+    BigDecimal accessLevel = BigDecimal.valueOf(3);
+
+    /** Load Meta Data */
+
+    /** Column name AD_Client_ID */
+    public static final String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
+
+	/** Get Client.
+	  * Client/Tenant for this installation.
+	  */
+	public int getAD_Client_ID();
+
+    /** Column name AD_Org_ID */
+    public static final String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
+
+	/** Set Organization.
+	  * Organizational entity within client
+	  */
+	public void setAD_Org_ID (int AD_Org_ID);
+
+	/** Get Organization.
+	  * Organizational entity within client
+	  */
+	public int getAD_Org_ID();
+
+    /** Column name Amt */
+    public static final String COLUMNNAME_Amt = "Amt";
+
+	/** Set Amount.
+	  * Amount
+	  */
+	public void setAmt (BigDecimal Amt);
+
+	/** Get Amount.
+	  * Amount
+	  */
+	public BigDecimal getAmt();
+
+    /** Column name C_BPartner_ID */
+    public static final String COLUMNNAME_C_BPartner_ID = "C_BPartner_ID";
+
+	/** Set Business Partner .
+	  * Identifies a Business Partner
+	  */
+	public void setC_BPartner_ID (int C_BPartner_ID);
+
+	/** Get Business Partner .
+	  * Identifies a Business Partner
+	  */
+	public int getC_BPartner_ID();
+
+	public org.adempiere.core.domains.models.I_C_BPartner getC_BPartner() throws RuntimeException;
+
+    /** Column name C_DocType_ID */
+    public static final String COLUMNNAME_C_DocType_ID = "C_DocType_ID";
+
+	/** Set Document Type.
+	  * Document type or rules
+	  */
+	public void setC_DocType_ID (int C_DocType_ID);
+
+	/** Get Document Type.
+	  * Document type or rules
+	  */
+	public int getC_DocType_ID();
+
+	public org.adempiere.core.domains.models.I_C_DocType getC_DocType() throws RuntimeException;
+
+    /** Column name C_Project_ID */
+    public static final String COLUMNNAME_C_Project_ID = "C_Project_ID";
+
+	/** Set Project.
+	  * Financial Project
+	  */
+	public void setC_Project_ID (int C_Project_ID);
+
+	/** Get Project.
+	  * Financial Project
+	  */
+	public int getC_Project_ID();
+
+	public org.adempiere.core.domains.models.I_C_Project getC_Project() throws RuntimeException;
+
+    /** Column name Created */
+    public static final String COLUMNNAME_Created = "Created";
+
+	/** Get Created.
+	  * Date this record was created
+	  */
+	public Timestamp getCreated();
+
+    /** Column name CreatedBy */
+    public static final String COLUMNNAME_CreatedBy = "CreatedBy";
+
+	/** Get Created By.
+	  * User who created this records
+	  */
+	public int getCreatedBy();
+
+    /** Column name DateDoc */
+    public static final String COLUMNNAME_DateDoc = "DateDoc";
+
+	/** Set Document Date.
+	  * Date of the Document
+	  */
+	public void setDateDoc (Timestamp DateDoc);
+
+	/** Get Document Date.
+	  * Date of the Document
+	  */
+	public Timestamp getDateDoc();
+
+    /** Column name Description */
+    public static final String COLUMNNAME_Description = "Description";
+
+	/** Set Description.
+	  * Optional short description of the record
+	  */
+	public void setDescription (String Description);
+
+	/** Get Description.
+	  * Optional short description of the record
+	  */
+	public String getDescription();
+
+    /** Column name DocAction */
+    public static final String COLUMNNAME_DocAction = "DocAction";
+
+	/** Set Document Action.
+	  * The targeted status of the document
+	  */
+	public void setDocAction (String DocAction);
+
+	/** Get Document Action.
+	  * The targeted status of the document
+	  */
+	public String getDocAction();
+
+    /** Column name DocStatus */
+    public static final String COLUMNNAME_DocStatus = "DocStatus";
+
+	/** Set Document Status.
+	  * The current status of the document
+	  */
+	public void setDocStatus (String DocStatus);
+
+	/** Get Document Status.
+	  * The current status of the document
+	  */
+	public String getDocStatus();
+
+    /** Column name DocumentNo */
+    public static final String COLUMNNAME_DocumentNo = "DocumentNo";
+
+	/** Set Document No.
+	  * Document sequence number of the document
+	  */
+	public void setDocumentNo (String DocumentNo);
+
+	/** Get Document No.
+	  * Document sequence number of the document
+	  */
+	public String getDocumentNo();
+
+    /** Column name DocumentNote */
+    public static final String COLUMNNAME_DocumentNote = "DocumentNote";
+
+	/** Set Document Note.
+	  * Additional information for a Document
+	  */
+	public void setDocumentNote (String DocumentNote);
+
+	/** Get Document Note.
+	  * Additional information for a Document
+	  */
+	public String getDocumentNote();
+
+    /** Column name HR_AttendanceBatch_ID */
+    public static final String COLUMNNAME_HR_AttendanceBatch_ID = "HR_AttendanceBatch_ID";
+
+	/** Set Attendance Batch	  */
+	public void setHR_AttendanceBatch_ID (int HR_AttendanceBatch_ID);
+
+	/** Get Attendance Batch	  */
+	public int getHR_AttendanceBatch_ID();
+
+	public org.adempiere.core.domains.models.I_HR_AttendanceBatch getHR_AttendanceBatch() throws RuntimeException;
+
+    /** Column name HR_Concept_ID */
+    public static final String COLUMNNAME_HR_Concept_ID = "HR_Concept_ID";
+
+	/** Set Global Payroll Concept.
+	  * The Payroll Concept allows to define all the perception and deductions elements needed to define a payroll.
+	  */
+	public void setHR_Concept_ID (int HR_Concept_ID);
+
+	/** Get Global Payroll Concept.
+	  * The Payroll Concept allows to define all the perception and deductions elements needed to define a payroll.
+	  */
+	public int getHR_Concept_ID();
+
+	public org.adempiere.core.domains.models.I_HR_Concept getHR_Concept() throws RuntimeException;
+
+    /** Column name HR_Employee_ID */
+    public static final String COLUMNNAME_HR_Employee_ID = "HR_Employee_ID";
+
+	/** Set Payroll Employee	  */
+	public void setHR_Employee_ID (int HR_Employee_ID);
+
+	/** Get Payroll Employee	  */
+	public int getHR_Employee_ID();
+
+	public org.adempiere.core.domains.models.I_HR_Employee getHR_Employee() throws RuntimeException;
+
+    /** Column name HR_Incidence_ID */
+    public static final String COLUMNNAME_HR_Incidence_ID = "HR_Incidence_ID";
+
+	/** Set Employee Incidence	  */
+	public void setHR_Incidence_ID (int HR_Incidence_ID);
+
+	/** Get Employee Incidence	  */
+	public int getHR_Incidence_ID();
+
+    /** Column name HR_ShiftIncidence_ID */
+    public static final String COLUMNNAME_HR_ShiftIncidence_ID = "HR_ShiftIncidence_ID";
+
+	/** Set Shift Incidence.
+	  * Shift Incidence Configuration
+	  */
+	public void setHR_ShiftIncidence_ID (int HR_ShiftIncidence_ID);
+
+	/** Get Shift Incidence.
+	  * Shift Incidence Configuration
+	  */
+	public int getHR_ShiftIncidence_ID();
+
+	public org.adempiere.core.domains.models.I_HR_ShiftIncidence getHR_ShiftIncidence() throws RuntimeException;
+
+    /** Column name IsActive */
+    public static final String COLUMNNAME_IsActive = "IsActive";
+
+	/** Set Active.
+	  * The record is active in the system
+	  */
+	public void setIsActive (boolean IsActive);
+
+	/** Get Active.
+	  * The record is active in the system
+	  */
+	public boolean isActive();
+
+    /** Column name IsApproved */
+    public static final String COLUMNNAME_IsApproved = "IsApproved";
+
+	/** Set Approved.
+	  * Indicates if this document requires approval
+	  */
+	public void setIsApproved (boolean IsApproved);
+
+	/** Get Approved.
+	  * Indicates if this document requires approval
+	  */
+	public boolean isApproved();
+
+    /** Column name IsManual */
+    public static final String COLUMNNAME_IsManual = "IsManual";
+
+	/** Set Manual.
+	  * This is a manual process
+	  */
+	public void setIsManual (boolean IsManual);
+
+	/** Get Manual.
+	  * This is a manual process
+	  */
+	public boolean isManual();
+
+    /** Column name Processed */
+    public static final String COLUMNNAME_Processed = "Processed";
+
+	/** Set Processed.
+	  * The document has been processed
+	  */
+	public void setProcessed (boolean Processed);
+
+	/** Get Processed.
+	  * The document has been processed
+	  */
+	public boolean isProcessed();
+
+    /** Column name Processing */
+    public static final String COLUMNNAME_Processing = "Processing";
+
+	/** Set Process Now	  */
+	public void setProcessing (boolean Processing);
+
+	/** Get Process Now	  */
+	public boolean isProcessing();
+
+    /** Column name Qty */
+    public static final String COLUMNNAME_Qty = "Qty";
+
+	/** Set Quantity.
+	  * Quantity
+	  */
+	public void setQty (BigDecimal Qty);
+
+	/** Get Quantity.
+	  * Quantity
+	  */
+	public BigDecimal getQty();
+
+    /** Column name S_Contract_ID */
+    public static final String COLUMNNAME_S_Contract_ID = "S_Contract_ID";
+
+	/** Set Contract.
+	  * Contract
+	  */
+	public void setS_Contract_ID (int S_Contract_ID);
+
+	/** Get Contract.
+	  * Contract
+	  */
+	public int getS_Contract_ID();
+
+	public org.adempiere.core.domains.models.I_S_Contract getS_Contract() throws RuntimeException;
+
+    /** Column name S_ContractLine_ID */
+    public static final String COLUMNNAME_S_ContractLine_ID = "S_ContractLine_ID";
+
+	/** Set ContractLine.
+	  * ContractLine
+	  */
+	public void setS_ContractLine_ID (int S_ContractLine_ID);
+
+	/** Get ContractLine.
+	  * ContractLine
+	  */
+	public int getS_ContractLine_ID();
+
+	public org.adempiere.core.domains.models.I_S_ContractLine getS_ContractLine() throws RuntimeException;
+
+    /** Column name ServiceDate */
+    public static final String COLUMNNAME_ServiceDate = "ServiceDate";
+
+	/** Set Service date.
+	  * Date service was provided
+	  */
+	public void setServiceDate (Timestamp ServiceDate);
+
+	/** Get Service date.
+	  * Date service was provided
+	  */
+	public Timestamp getServiceDate();
+
+    /** Column name S_TimeExpense_ID */
+    public static final String COLUMNNAME_S_TimeExpense_ID = "S_TimeExpense_ID";
+
+	/** Set Expense Report.
+	  * Time and Expense Report
+	  */
+	public void setS_TimeExpense_ID (int S_TimeExpense_ID);
+
+	/** Get Expense Report.
+	  * Time and Expense Report
+	  */
+	public int getS_TimeExpense_ID();
+
+	public org.adempiere.core.domains.models.I_S_TimeExpense getS_TimeExpense() throws RuntimeException;
+
+    /** Column name S_TimeExpenseLine_ID */
+    public static final String COLUMNNAME_S_TimeExpenseLine_ID = "S_TimeExpenseLine_ID";
+
+	/** Set Expense Line.
+	  * Time and Expense Report Line
+	  */
+	public void setS_TimeExpenseLine_ID (int S_TimeExpenseLine_ID);
+
+	/** Get Expense Line.
+	  * Time and Expense Report Line
+	  */
+	public int getS_TimeExpenseLine_ID();
+
+	public org.adempiere.core.domains.models.I_S_TimeExpenseLine getS_TimeExpenseLine() throws RuntimeException;
+
+    /** Column name Updated */
+    public static final String COLUMNNAME_Updated = "Updated";
+
+	/** Get Updated.
+	  * Date this record was updated
+	  */
+	public Timestamp getUpdated();
+
+    /** Column name UpdatedBy */
+    public static final String COLUMNNAME_UpdatedBy = "UpdatedBy";
+
+	/** Get Updated By.
+	  * User who updated this records
+	  */
+	public int getUpdatedBy();
+
+    /** Column name UUID */
+    public static final String COLUMNNAME_UUID = "UUID";
+
+	/** Set Immutable Universally Unique Identifier.
+	  * Immutable Universally Unique Identifier
+	  */
+	public void setUUID (String UUID);
+
+	/** Get Immutable Universally Unique Identifier.
+	  * Immutable Universally Unique Identifier
+	  */
+	public String getUUID();
+}

--- a/src/patches/java/org/adempiere/core/domains/models/I_S_ResourceAssignment.java
+++ b/src/patches/java/org/adempiere/core/domains/models/I_S_ResourceAssignment.java
@@ -1,0 +1,538 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2017 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * or (at your option) any later version.                                     *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net                                                  *
+ * or https://github.com/adempiere/adempiere/blob/develop/license.html        *
+ *****************************************************************************/
+package org.adempiere.core.domains.models;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import org.compiere.model.MTable;
+import org.compiere.util.KeyNamePair;
+
+/** Generated Interface for S_ResourceAssignment
+ *  @author Adempiere (generated) 
+ *  @version Release 3.9.4
+ */
+public interface I_S_ResourceAssignment 
+{
+
+    /** TableName=S_ResourceAssignment */
+    public static final String Table_Name = "S_ResourceAssignment";
+
+    /** AD_Table_ID=485 */
+    public static final int Table_ID = MTable.getTable_ID(Table_Name);
+
+    KeyNamePair Model = new KeyNamePair(Table_ID, Table_Name);
+
+    /** AccessLevel = 1 - Org 
+     */
+    BigDecimal accessLevel = BigDecimal.valueOf(1);
+
+    /** Load Meta Data */
+
+    /** Column name AD_Client_ID */
+    public static final String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
+
+	/** Get Client.
+	  * Client/Tenant for this installation.
+	  */
+	public int getAD_Client_ID();
+
+    /** Column name AD_Org_ID */
+    public static final String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
+
+	/** Set Organization.
+	  * Organizational entity within client
+	  */
+	public void setAD_Org_ID (int AD_Org_ID);
+
+	/** Get Organization.
+	  * Organizational entity within client
+	  */
+	public int getAD_Org_ID();
+
+    /** Column name AssignDateFrom */
+    public static final String COLUMNNAME_AssignDateFrom = "AssignDateFrom";
+
+	/** Set Assign From.
+	  * Assign resource from
+	  */
+	public void setAssignDateFrom (Timestamp AssignDateFrom);
+
+	/** Get Assign From.
+	  * Assign resource from
+	  */
+	public Timestamp getAssignDateFrom();
+
+    /** Column name AssignDateTo */
+    public static final String COLUMNNAME_AssignDateTo = "AssignDateTo";
+
+	/** Set Assign To.
+	  * Assign resource until
+	  */
+	public void setAssignDateTo (Timestamp AssignDateTo);
+
+	/** Get Assign To.
+	  * Assign resource until
+	  */
+	public Timestamp getAssignDateTo();
+
+    /** Column name AssignmentSourceType */
+    public static final String COLUMNNAME_AssignmentSourceType = "AssignmentSourceType";
+
+	/** Set Assignment Source Type.
+	  * How this assignment was originated: (P)lan, (M)anual, (S)ubstitution, (R)eassignment
+	  */
+	public void setAssignmentSourceType (String AssignmentSourceType);
+
+	/** Get Assignment Source Type.
+	  * How this assignment was originated: (P)lan, (M)anual, (S)ubstitution, (R)eassignment
+	  */
+	public String getAssignmentSourceType();
+
+    /** Column name AssignmentStatus */
+    public static final String COLUMNNAME_AssignmentStatus = "AssignmentStatus";
+
+	/** Set Assignment Status.
+	  * Operational status: PL(Planned), PC(ToCoordinate), IP(InProgress), CO(Confirmed), PA(PendingAuth), AP(Approved), CA(Cancelled), NA(NotAttended)
+	  */
+	public void setAssignmentStatus (String AssignmentStatus);
+
+	/** Get Assignment Status.
+	  * Operational status: PL(Planned), PC(ToCoordinate), IP(InProgress), CO(Confirmed), PA(PendingAuth), AP(Approved), CA(Cancelled), NA(NotAttended)
+	  */
+	public String getAssignmentStatus();
+
+    /** Column name C_Activity_ID */
+    public static final String COLUMNNAME_C_Activity_ID = "C_Activity_ID";
+
+	/** Set Activity.
+	  * Business Activity
+	  */
+	public void setC_Activity_ID (int C_Activity_ID);
+
+	/** Get Activity.
+	  * Business Activity
+	  */
+	public int getC_Activity_ID();
+
+	public I_C_Activity getC_Activity() throws RuntimeException;
+
+    /** Column name C_BPartner_ID */
+    public static final String COLUMNNAME_C_BPartner_ID = "C_BPartner_ID";
+
+	/** Set Business Partner .
+	  * Identifies a Business Partner
+	  */
+	public void setC_BPartner_ID (int C_BPartner_ID);
+
+	/** Get Business Partner .
+	  * Identifies a Business Partner
+	  */
+	public int getC_BPartner_ID();
+
+	public I_C_BPartner getC_BPartner() throws RuntimeException;
+
+    /** Column name C_BPartner_Location_ID */
+    public static final String COLUMNNAME_C_BPartner_Location_ID = "C_BPartner_Location_ID";
+
+	/** Set Partner Location.
+	  * Identifies the (ship to) address for this Business Partner
+	  */
+	public void setC_BPartner_Location_ID (int C_BPartner_Location_ID);
+
+	/** Get Partner Location.
+	  * Identifies the (ship to) address for this Business Partner
+	  */
+	public int getC_BPartner_Location_ID();
+
+	public I_C_BPartner_Location getC_BPartner_Location() throws RuntimeException;
+
+    /** Column name C_Campaign_ID */
+    public static final String COLUMNNAME_C_Campaign_ID = "C_Campaign_ID";
+
+	/** Set Campaign.
+	  * Marketing Campaign
+	  */
+	public void setC_Campaign_ID (int C_Campaign_ID);
+
+	/** Get Campaign.
+	  * Marketing Campaign
+	  */
+	public int getC_Campaign_ID();
+
+	public I_C_Campaign getC_Campaign() throws RuntimeException;
+
+    /** Column name C_Project_ID */
+    public static final String COLUMNNAME_C_Project_ID = "C_Project_ID";
+
+	/** Set Project.
+	  * Financial Project
+	  */
+	public void setC_Project_ID (int C_Project_ID);
+
+	/** Get Project.
+	  * Financial Project
+	  */
+	public int getC_Project_ID();
+
+	public I_C_Project getC_Project() throws RuntimeException;
+
+    /** Column name Created */
+    public static final String COLUMNNAME_Created = "Created";
+
+	/** Get Created.
+	  * Date this record was created
+	  */
+	public Timestamp getCreated();
+
+    /** Column name CreatedBy */
+    public static final String COLUMNNAME_CreatedBy = "CreatedBy";
+
+	/** Get Created By.
+	  * User who created this records
+	  */
+	public int getCreatedBy();
+
+    /** Column name Description */
+    public static final String COLUMNNAME_Description = "Description";
+
+	/** Set Description.
+	  * Optional short description of the record
+	  */
+	public void setDescription (String Description);
+
+	/** Get Description.
+	  * Optional short description of the record
+	  */
+	public String getDescription();
+
+    /** Column name HR_Leave_ID */
+    public static final String COLUMNNAME_HR_Leave_ID = "HR_Leave_ID";
+
+	/** Set Leave.
+	  * The Leave Credit History of an Employee
+	  */
+	public void setHR_Leave_ID (int HR_Leave_ID);
+
+	/** Get Leave.
+	  * The Leave Credit History of an Employee
+	  */
+	public int getHR_Leave_ID();
+
+	public org.adempiere.core.domains.models.I_HR_Leave getHR_Leave() throws RuntimeException;
+
+    /** Column name IsActive */
+    public static final String COLUMNNAME_IsActive = "IsActive";
+
+	/** Set Active.
+	  * The record is active in the system
+	  */
+	public void setIsActive (boolean IsActive);
+
+	/** Get Active.
+	  * The record is active in the system
+	  */
+	public boolean isActive();
+
+    /** Column name IsConfirmed */
+    public static final String COLUMNNAME_IsConfirmed = "IsConfirmed";
+
+	/** Set Confirmed.
+	  * Assignment is confirmed
+	  */
+	public void setIsConfirmed (boolean IsConfirmed);
+
+	/** Get Confirmed.
+	  * Assignment is confirmed
+	  */
+	public boolean isConfirmed();
+
+    /** Column name IsManuallyModified */
+    public static final String COLUMNNAME_IsManuallyModified = "IsManuallyModified";
+
+	/** Set Manually Modified.
+	  * When Y, this assignment is protected from automatic regeneration by plan changes
+	  */
+	public void setIsManuallyModified (boolean IsManuallyModified);
+
+	/** Get Manually Modified.
+	  * When Y, this assignment is protected from automatic regeneration by plan changes
+	  */
+	public boolean isManuallyModified();
+
+    /** Column name Name */
+    public static final String COLUMNNAME_Name = "Name";
+
+	/** Set Name.
+	  * Alphanumeric identifier of the entity
+	  */
+	public void setName (String Name);
+
+	/** Get Name.
+	  * Alphanumeric identifier of the entity
+	  */
+	public String getName();
+
+    /** Column name PreviousResource_ID */
+    public static final String COLUMNNAME_PreviousResource_ID = "PreviousResource_ID";
+
+	/** Set Previous Resource.
+	  * Resource that was assigned before the last modification. Audit trail.
+	  */
+	public void setPreviousResource_ID (int PreviousResource_ID);
+
+	/** Get Previous Resource.
+	  * Resource that was assigned before the last modification. Audit trail.
+	  */
+	public int getPreviousResource_ID();
+
+	public org.adempiere.core.domains.models.I_S_Resource getPreviousResource() throws RuntimeException;
+
+    /** Column name Qty */
+    public static final String COLUMNNAME_Qty = "Qty";
+
+	/** Set Quantity.
+	  * Quantity
+	  */
+	public void setQty (BigDecimal Qty);
+
+	/** Get Quantity.
+	  * Quantity
+	  */
+	public BigDecimal getQty();
+
+    /** Column name ReplanReason */
+    public static final String COLUMNNAME_ReplanReason = "ReplanReason";
+
+	/** Set Replan Reason.
+	  * Free text reason entered by coordinator when replanning this assignment
+	  */
+	public void setReplanReason (String ReplanReason);
+
+	/** Get Replan Reason.
+	  * Free text reason entered by coordinator when replanning this assignment
+	  */
+	public String getReplanReason();
+
+    /** Column name R_Request_ID */
+    public static final String COLUMNNAME_R_Request_ID = "R_Request_ID";
+
+	/** Set Request.
+	  * Request from a Business Partner or Prospect
+	  */
+	public void setR_Request_ID (int R_Request_ID);
+
+	/** Get Request.
+	  * Request from a Business Partner or Prospect
+	  */
+	public int getR_Request_ID();
+
+	public I_R_Request getR_Request() throws RuntimeException;
+
+    /** Column name S_Contract_ID */
+    public static final String COLUMNNAME_S_Contract_ID = "S_Contract_ID";
+
+	/** Set Contract.
+	  * Contract
+	 */
+	public void setS_Contract_ID (int S_Contract_ID);
+
+	/** Get Contract.
+	 * Contract
+	 */
+	public int getS_Contract_ID();
+
+	public I_S_Contract getS_Contract() throws RuntimeException;
+
+
+	/** Column name S_ContractLine_ID */
+    public static final String COLUMNNAME_S_ContractLine_ID = "S_ContractLine_ID";
+
+	/** Set ContractLine.
+	  * ContractLine
+	  */
+	public void setS_ContractLine_ID (int S_ContractLine_ID);
+
+	/** Get ContractLine.
+	  * ContractLine
+	  */
+	public int getS_ContractLine_ID();
+
+	public org.adempiere.core.domains.models.I_S_ContractLine getS_ContractLine() throws RuntimeException;
+
+    /** Column name S_ResourceAssignment_ID */
+    public static final String COLUMNNAME_S_ResourceAssignment_ID = "S_ResourceAssignment_ID";
+
+	/** Set Resource Assignment.
+	  * Resource Assignment
+	  */
+	public void setS_ResourceAssignment_ID (int S_ResourceAssignment_ID);
+
+	/** Get Resource Assignment.
+	  * Resource Assignment
+	  */
+	public int getS_ResourceAssignment_ID();
+
+    /** Column name S_Resource_ID */
+    public static final String COLUMNNAME_S_Resource_ID = "S_Resource_ID";
+
+	/** Set Resource.
+	  * Resource
+	  */
+	public void setS_Resource_ID (int S_Resource_ID);
+
+	/** Get Resource.
+	  * Resource
+	  */
+	public int getS_Resource_ID();
+
+	public org.adempiere.core.domains.models.I_S_Resource getS_Resource() throws RuntimeException;
+
+    /** Column name S_Resource_Plan_ID */
+    public static final String COLUMNNAME_S_Resource_Plan_ID = "S_Resource_Plan_ID";
+
+	/** Set Plan Resource.
+	  * Original titular resource as defined in the service plan. NEVER modified after creation.
+	  */
+	public void setS_Resource_Plan_ID (int S_Resource_Plan_ID);
+
+	/** Get Plan Resource.
+	  * Original titular resource as defined in the service plan. NEVER modified after creation.
+	  */
+	public int getS_Resource_Plan_ID();
+
+	public org.adempiere.core.domains.models.I_S_Resource getS_Resource_Plan() throws RuntimeException;
+
+    /** Column name S_ServicePlan_ID */
+    public static final String COLUMNNAME_S_ServicePlan_ID = "S_ServicePlan_ID";
+
+	/** Set Service Plan ID.
+	  * Operational service plan
+	  */
+	public void setS_ServicePlan_ID (int S_ServicePlan_ID);
+
+	/** Get Service Plan ID.
+	  * Operational service plan
+	  */
+	public int getS_ServicePlan_ID();
+
+	public org.adempiere.core.domains.models.I_S_ServicePlan getS_ServicePlan() throws RuntimeException;
+
+    /** Column name S_ServiceSchedule_ID */
+    public static final String COLUMNNAME_S_ServiceSchedule_ID = "S_ServiceSchedule_ID";
+
+	/** Set Service Schedule ID.
+	  * Weekly visit pattern for a service plan
+	  */
+	public void setS_ServiceSchedule_ID (int S_ServiceSchedule_ID);
+
+	/** Get Service Schedule ID.
+	  * Weekly visit pattern for a service plan
+	  */
+	public int getS_ServiceSchedule_ID();
+
+	public org.adempiere.core.domains.models.I_S_ServiceSchedule getS_ServiceSchedule() throws RuntimeException;
+
+    /** Column name Updated */
+    public static final String COLUMNNAME_Updated = "Updated";
+
+	/** Get Updated.
+	  * Date this record was updated
+	  */
+	public Timestamp getUpdated();
+
+    /** Column name UpdatedBy */
+    public static final String COLUMNNAME_UpdatedBy = "UpdatedBy";
+
+	/** Get Updated By.
+	  * User who updated this records
+	  */
+	public int getUpdatedBy();
+
+    /** Column name User1_ID */
+    public static final String COLUMNNAME_User1_ID = "User1_ID";
+
+	/** Set User List 1.
+	  * User defined list element #1
+	  */
+	public void setUser1_ID (int User1_ID);
+
+	/** Get User List 1.
+	  * User defined list element #1
+	  */
+	public int getUser1_ID();
+
+	public I_C_ElementValue getUser1() throws RuntimeException;
+
+    /** Column name User2_ID */
+    public static final String COLUMNNAME_User2_ID = "User2_ID";
+
+	/** Set User List 2.
+	  * User defined list element #2
+	  */
+	public void setUser2_ID (int User2_ID);
+
+	/** Get User List 2.
+	  * User defined list element #2
+	  */
+	public int getUser2_ID();
+
+	public I_C_ElementValue getUser2() throws RuntimeException;
+
+    /** Column name User3_ID */
+    public static final String COLUMNNAME_User3_ID = "User3_ID";
+
+	/** Set User List 3.
+	  * User defined list element #3
+	  */
+	public void setUser3_ID (int User3_ID);
+
+	/** Get User List 3.
+	  * User defined list element #3
+	  */
+	public int getUser3_ID();
+
+	public I_C_ElementValue getUser3() throws RuntimeException;
+
+    /** Column name User4_ID */
+    public static final String COLUMNNAME_User4_ID = "User4_ID";
+
+	/** Set User List 4.
+	  * User defined list element #4
+	  */
+	public void setUser4_ID (int User4_ID);
+
+	/** Get User List 4.
+	  * User defined list element #4
+	  */
+	public int getUser4_ID();
+
+	public I_C_ElementValue getUser4() throws RuntimeException;
+
+    /** Column name UUID */
+    public static final String COLUMNNAME_UUID = "UUID";
+
+	/** Set Immutable Universally Unique Identifier.
+	  * Immutable Universally Unique Identifier
+	  */
+	public void setUUID (String UUID);
+
+	/** Get Immutable Universally Unique Identifier.
+	  * Immutable Universally Unique Identifier
+	  */
+	public String getUUID();
+}

--- a/src/patches/java/org/adempiere/core/domains/models/I_S_ServicePlan.java
+++ b/src/patches/java/org/adempiere/core/domains/models/I_S_ServicePlan.java
@@ -1,0 +1,329 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2017 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * or (at your option) any later version.                                     *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net                                                  *
+ * or https://github.com/adempiere/adempiere/blob/develop/license.html        *
+ *****************************************************************************/
+package org.adempiere.core.domains.models;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import org.compiere.model.MTable;
+import org.compiere.util.KeyNamePair;
+
+/** Generated Interface for S_ServicePlan
+ *  @author Adempiere (generated) 
+ *  @version Release 3.9.4
+ */
+public interface I_S_ServicePlan 
+{
+
+    /** TableName=S_ServicePlan */
+    public static final String Table_Name = "S_ServicePlan";
+
+    /** AD_Table_ID=55096 */
+    public static final int Table_ID = MTable.getTable_ID(Table_Name);
+
+    KeyNamePair Model = new KeyNamePair(Table_ID, Table_Name);
+
+    /** AccessLevel = 3 - Client - Org 
+     */
+    BigDecimal accessLevel = BigDecimal.valueOf(3);
+
+    /** Load Meta Data */
+
+    /** Column name AD_Client_ID */
+    public static final String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
+
+	/** Get Client.
+	  * Client/Tenant for this installation.
+	  */
+	public int getAD_Client_ID();
+
+    /** Column name AD_Org_ID */
+    public static final String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
+
+	/** Set Organization.
+	  * Organizational entity within client
+	  */
+	public void setAD_Org_ID (int AD_Org_ID);
+
+	/** Get Organization.
+	  * Organizational entity within client
+	  */
+	public int getAD_Org_ID();
+
+    /** Column name AD_User_ID */
+    public static final String COLUMNNAME_AD_User_ID = "AD_User_ID";
+
+	/** Set User/Contact.
+	  * User within the system - Internal or Business Partner Contact
+	  */
+	public void setAD_User_ID (int AD_User_ID);
+
+	/** Get User/Contact.
+	  * User within the system - Internal or Business Partner Contact
+	  */
+	public int getAD_User_ID();
+
+	public org.adempiere.core.domains.models.I_AD_User getAD_User() throws RuntimeException;
+
+    /** Column name C_BPartner_ID */
+    public static final String COLUMNNAME_C_BPartner_ID = "C_BPartner_ID";
+
+	/** Set Business Partner .
+	  * Identifies a Business Partner
+	  */
+	public void setC_BPartner_ID (int C_BPartner_ID);
+
+	/** Get Business Partner .
+	  * Identifies a Business Partner
+	  */
+	public int getC_BPartner_ID();
+
+	public org.adempiere.core.domains.models.I_C_BPartner getC_BPartner() throws RuntimeException;
+
+    /** Column name C_BPartner_Location_ID */
+    public static final String COLUMNNAME_C_BPartner_Location_ID = "C_BPartner_Location_ID";
+
+	/** Set Partner Location.
+	  * Identifies the (ship to) address for this Business Partner
+	  */
+	public void setC_BPartner_Location_ID (int C_BPartner_Location_ID);
+
+	/** Get Partner Location.
+	  * Identifies the (ship to) address for this Business Partner
+	  */
+	public int getC_BPartner_Location_ID();
+
+	public org.adempiere.core.domains.models.I_C_BPartner_Location getC_BPartner_Location() throws RuntimeException;
+
+    /** Column name Created */
+    public static final String COLUMNNAME_Created = "Created";
+
+	/** Get Created.
+	  * Date this record was created
+	  */
+	public Timestamp getCreated();
+
+    /** Column name CreatedBy */
+    public static final String COLUMNNAME_CreatedBy = "CreatedBy";
+
+	/** Get Created By.
+	  * User who created this records
+	  */
+	public int getCreatedBy();
+
+    /** Column name Description */
+    public static final String COLUMNNAME_Description = "Description";
+
+	/** Set Description.
+	  * Optional short description of the record
+	  */
+	public void setDescription (String Description);
+
+	/** Get Description.
+	  * Optional short description of the record
+	  */
+	public String getDescription();
+
+    /** Column name DocStatus */
+    public static final String COLUMNNAME_DocStatus = "DocStatus";
+
+	/** Set Document Status.
+	  * The current status of the document
+	  */
+	public void setDocStatus (String DocStatus);
+
+	/** Get Document Status.
+	  * The current status of the document
+	  */
+	public String getDocStatus();
+
+    /** Column name FrequencyType */
+    public static final String COLUMNNAME_FrequencyType = "FrequencyType";
+
+	/** Set Frequency Type.
+	  * Frequency of event
+	  */
+	public void setFrequencyType (String FrequencyType);
+
+	/** Get Frequency Type.
+	  * Frequency of event
+	  */
+	public String getFrequencyType();
+
+    /** Column name IsActive */
+    public static final String COLUMNNAME_IsActive = "IsActive";
+
+	/** Set Active.
+	  * The record is active in the system
+	  */
+	public void setIsActive (boolean IsActive);
+
+	/** Get Active.
+	  * The record is active in the system
+	  */
+	public boolean isActive();
+
+    /** Column name IsBillable */
+    public static final String COLUMNNAME_IsBillable = "IsBillable";
+
+	/** Set Billable.
+	  * Whether hours from this plan are billed to the client
+	  */
+	public void setIsBillable (boolean IsBillable);
+
+	/** Get Billable.
+	  * Whether hours from this plan are billed to the client
+	  */
+	public boolean isBillable();
+
+    /** Column name S_Contract_ID */
+    public static final String COLUMNNAME_S_Contract_ID = "S_Contract_ID";
+
+	/** Set Contract.
+	  * Contract
+	  */
+	public void setS_Contract_ID (int S_Contract_ID);
+
+	/** Get Contract.
+	  * Contract
+	  */
+	public int getS_Contract_ID();
+
+	public org.adempiere.core.domains.models.I_S_Contract getS_Contract() throws RuntimeException;
+
+    /** Column name S_ContractLine_ID */
+    public static final String COLUMNNAME_S_ContractLine_ID = "S_ContractLine_ID";
+
+	/** Set ContractLine.
+	  * ContractLine
+	  */
+	public void setS_ContractLine_ID (int S_ContractLine_ID);
+
+	/** Get ContractLine.
+	  * ContractLine
+	  */
+	public int getS_ContractLine_ID();
+
+	public org.adempiere.core.domains.models.I_S_ContractLine getS_ContractLine() throws RuntimeException;
+
+    /** Column name S_Resource_ID */
+    public static final String COLUMNNAME_S_Resource_ID = "S_Resource_ID";
+
+	/** Set Resource.
+	  * Resource
+	  */
+	public void setS_Resource_ID (int S_Resource_ID);
+
+	/** Get Resource.
+	  * Resource
+	  */
+	public int getS_Resource_ID();
+
+	public org.adempiere.core.domains.models.I_S_Resource getS_Resource() throws RuntimeException;
+
+    /** Column name S_ResourceType_ID */
+    public static final String COLUMNNAME_S_ResourceType_ID = "S_ResourceType_ID";
+
+	/** Set Resource Type	  */
+	public void setS_ResourceType_ID (int S_ResourceType_ID);
+
+	/** Get Resource Type	  */
+	public int getS_ResourceType_ID();
+
+	public org.adempiere.core.domains.models.I_S_ResourceType getS_ResourceType() throws RuntimeException;
+
+    /** Column name S_ServicePlan_ID */
+    public static final String COLUMNNAME_S_ServicePlan_ID = "S_ServicePlan_ID";
+
+	/** Set Service Plan ID.
+	  * Operational service plan
+	  */
+	public void setS_ServicePlan_ID (int S_ServicePlan_ID);
+
+	/** Get Service Plan ID.
+	  * Operational service plan
+	  */
+	public int getS_ServicePlan_ID();
+
+    /** Column name TotalWeeklyHours */
+    public static final String COLUMNNAME_TotalWeeklyHours = "TotalWeeklyHours";
+
+	/** Set Total Weekly Hours.
+	  * Sum of planned hours per week for this service plan
+	  */
+	public void setTotalWeeklyHours (BigDecimal TotalWeeklyHours);
+
+	/** Get Total Weekly Hours.
+	  * Sum of planned hours per week for this service plan
+	  */
+	public BigDecimal getTotalWeeklyHours();
+
+    /** Column name Updated */
+    public static final String COLUMNNAME_Updated = "Updated";
+
+	/** Get Updated.
+	  * Date this record was updated
+	  */
+	public Timestamp getUpdated();
+
+    /** Column name UpdatedBy */
+    public static final String COLUMNNAME_UpdatedBy = "UpdatedBy";
+
+	/** Get Updated By.
+	  * User who updated this records
+	  */
+	public int getUpdatedBy();
+
+    /** Column name UUID */
+    public static final String COLUMNNAME_UUID = "UUID";
+
+	/** Set Immutable Universally Unique Identifier.
+	  * Immutable Universally Unique Identifier
+	  */
+	public void setUUID (String UUID);
+
+	/** Get Immutable Universally Unique Identifier.
+	  * Immutable Universally Unique Identifier
+	  */
+	public String getUUID();
+
+    /** Column name ValidFrom */
+    public static final String COLUMNNAME_ValidFrom = "ValidFrom";
+
+	/** Set Valid from.
+	  * Valid from including this date (first day)
+	  */
+	public void setValidFrom (Timestamp ValidFrom);
+
+	/** Get Valid from.
+	  * Valid from including this date (first day)
+	  */
+	public Timestamp getValidFrom();
+
+    /** Column name ValidTo */
+    public static final String COLUMNNAME_ValidTo = "ValidTo";
+
+	/** Set Valid to.
+	  * Valid to including this date (last day)
+	  */
+	public void setValidTo (Timestamp ValidTo);
+
+	/** Get Valid to.
+	  * Valid to including this date (last day)
+	  */
+	public Timestamp getValidTo();
+}

--- a/src/patches/java/org/adempiere/core/domains/models/I_S_ServiceSchedule.java
+++ b/src/patches/java/org/adempiere/core/domains/models/I_S_ServiceSchedule.java
@@ -1,0 +1,290 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2017 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * or (at your option) any later version.                                     *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net                                                  *
+ * or https://github.com/adempiere/adempiere/blob/develop/license.html        *
+ *****************************************************************************/
+package org.adempiere.core.domains.models;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import org.compiere.model.MTable;
+import org.compiere.util.KeyNamePair;
+
+/** Generated Interface for S_ServiceSchedule
+ *  @author Adempiere (generated) 
+ *  @version Release 3.9.4
+ */
+public interface I_S_ServiceSchedule 
+{
+
+    /** TableName=S_ServiceSchedule */
+    public static final String Table_Name = "S_ServiceSchedule";
+
+    /** AD_Table_ID=55095 */
+    public static final int Table_ID = MTable.getTable_ID(Table_Name);
+
+    KeyNamePair Model = new KeyNamePair(Table_ID, Table_Name);
+
+    /** AccessLevel = 3 - Client - Org 
+     */
+    BigDecimal accessLevel = BigDecimal.valueOf(3);
+
+    /** Load Meta Data */
+
+    /** Column name AD_Client_ID */
+    public static final String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
+
+	/** Get Client.
+	  * Client/Tenant for this installation.
+	  */
+	public int getAD_Client_ID();
+
+    /** Column name AD_Org_ID */
+    public static final String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
+
+	/** Set Organization.
+	  * Organizational entity within client
+	  */
+	public void setAD_Org_ID (int AD_Org_ID);
+
+	/** Get Organization.
+	  * Organizational entity within client
+	  */
+	public int getAD_Org_ID();
+
+    /** Column name C_BPartner_ID */
+    public static final String COLUMNNAME_C_BPartner_ID = "C_BPartner_ID";
+
+	/** Set Business Partner .
+	  * Identifies a Business Partner
+	  */
+	public void setC_BPartner_ID (int C_BPartner_ID);
+
+	/** Get Business Partner .
+	  * Identifies a Business Partner
+	  */
+	public int getC_BPartner_ID();
+
+	public org.adempiere.core.domains.models.I_C_BPartner getC_BPartner() throws RuntimeException;
+
+    /** Column name C_BPartner_Location_ID */
+    public static final String COLUMNNAME_C_BPartner_Location_ID = "C_BPartner_Location_ID";
+
+	/** Set Partner Location.
+	  * Identifies the (ship to) address for this Business Partner
+	  */
+	public void setC_BPartner_Location_ID (int C_BPartner_Location_ID);
+
+	/** Get Partner Location.
+	  * Identifies the (ship to) address for this Business Partner
+	  */
+	public int getC_BPartner_Location_ID();
+
+	public org.adempiere.core.domains.models.I_C_BPartner_Location getC_BPartner_Location() throws RuntimeException;
+
+    /** Column name Created */
+    public static final String COLUMNNAME_Created = "Created";
+
+	/** Get Created.
+	  * Date this record was created
+	  */
+	public Timestamp getCreated();
+
+    /** Column name CreatedBy */
+    public static final String COLUMNNAME_CreatedBy = "CreatedBy";
+
+	/** Get Created By.
+	  * User who created this records
+	  */
+	public int getCreatedBy();
+
+    /** Column name DayOfWeek */
+    public static final String COLUMNNAME_DayOfWeek = "DayOfWeek";
+
+	/** Set Day of Week.
+	  * Day of the week: 1=Monday, 2=Tuesday, ..., 7=Sunday (ISO 8601)
+	  */
+	public void setDayOfWeek (String DayOfWeek);
+
+	/** Get Day of Week.
+	  * Day of the week: 1=Monday, 2=Tuesday, ..., 7=Sunday (ISO 8601)
+	  */
+	public String getDayOfWeek();
+
+    /** Column name Description */
+    public static final String COLUMNNAME_Description = "Description";
+
+	/** Set Description.
+	  * Optional short description of the record
+	  */
+	public void setDescription (String Description);
+
+	/** Get Description.
+	  * Optional short description of the record
+	  */
+	public String getDescription();
+
+    /** Column name IsActive */
+    public static final String COLUMNNAME_IsActive = "IsActive";
+
+	/** Set Active.
+	  * The record is active in the system
+	  */
+	public void setIsActive (boolean IsActive);
+
+	/** Get Active.
+	  * The record is active in the system
+	  */
+	public boolean isActive();
+
+    /** Column name PlannedHours */
+    public static final String COLUMNNAME_PlannedHours = "PlannedHours";
+
+	/** Set Planned Hours.
+	  * Planned duration in hours for this visit
+	  */
+	public void setPlannedHours (BigDecimal PlannedHours);
+
+	/** Get Planned Hours.
+	  * Planned duration in hours for this visit
+	  */
+	public BigDecimal getPlannedHours();
+
+    /** Column name S_ContractLine_ID */
+    public static final String COLUMNNAME_S_ContractLine_ID = "S_ContractLine_ID";
+
+	/** Set ContractLine.
+	  * ContractLine
+	  */
+	public void setS_ContractLine_ID (int S_ContractLine_ID);
+
+	/** Get ContractLine.
+	  * ContractLine
+	  */
+	public int getS_ContractLine_ID();
+
+	public org.adempiere.core.domains.models.I_S_ContractLine getS_ContractLine() throws RuntimeException;
+
+    /** Column name S_Resource_ID */
+    public static final String COLUMNNAME_S_Resource_ID = "S_Resource_ID";
+
+	/** Set Resource.
+	  * Resource
+	  */
+	public void setS_Resource_ID (int S_Resource_ID);
+
+	/** Get Resource.
+	  * Resource
+	  */
+	public int getS_Resource_ID();
+
+	public org.adempiere.core.domains.models.I_S_Resource getS_Resource() throws RuntimeException;
+
+    /** Column name S_ServicePlan_ID */
+    public static final String COLUMNNAME_S_ServicePlan_ID = "S_ServicePlan_ID";
+
+	/** Set Service Plan ID.
+	  * Operational service plan
+	  */
+	public void setS_ServicePlan_ID (int S_ServicePlan_ID);
+
+	/** Get Service Plan ID.
+	  * Operational service plan
+	  */
+	public int getS_ServicePlan_ID();
+
+	public org.adempiere.core.domains.models.I_S_ServicePlan getS_ServicePlan() throws RuntimeException;
+
+    /** Column name S_ServiceSchedule_ID */
+    public static final String COLUMNNAME_S_ServiceSchedule_ID = "S_ServiceSchedule_ID";
+
+	/** Set Service Schedule ID.
+	  * Weekly visit pattern for a service plan
+	  */
+	public void setS_ServiceSchedule_ID (int S_ServiceSchedule_ID);
+
+	/** Get Service Schedule ID.
+	  * Weekly visit pattern for a service plan
+	  */
+	public int getS_ServiceSchedule_ID();
+
+    /** Column name TimeFrom */
+    public static final String COLUMNNAME_TimeFrom = "TimeFrom";
+
+	/** Set Time (From).
+	  * Starting Time
+	  */
+	public void setTimeFrom (Timestamp TimeFrom);
+
+	/** Get Time (From).
+	  * Starting Time
+	  */
+	public Timestamp getTimeFrom();
+
+    /** Column name TimeTo */
+    public static final String COLUMNNAME_TimeTo = "TimeTo";
+
+	/** Set Time (To).
+	  * Ending Time
+	  */
+	public void setTimeTo (Timestamp TimeTo);
+
+	/** Get Time (To).
+	  * Ending Time
+	  */
+	public Timestamp getTimeTo();
+
+    /** Column name Updated */
+    public static final String COLUMNNAME_Updated = "Updated";
+
+	/** Get Updated.
+	  * Date this record was updated
+	  */
+	public Timestamp getUpdated();
+
+    /** Column name UpdatedBy */
+    public static final String COLUMNNAME_UpdatedBy = "UpdatedBy";
+
+	/** Get Updated By.
+	  * User who updated this records
+	  */
+	public int getUpdatedBy();
+
+    /** Column name UUID */
+    public static final String COLUMNNAME_UUID = "UUID";
+
+	/** Set Immutable Universally Unique Identifier.
+	  * Immutable Universally Unique Identifier
+	  */
+	public void setUUID (String UUID);
+
+	/** Get Immutable Universally Unique Identifier.
+	  * Immutable Universally Unique Identifier
+	  */
+	public String getUUID();
+
+    /** Column name WeekOfMonth */
+    public static final String COLUMNNAME_WeekOfMonth = "WeekOfMonth";
+
+	/** Set Week of Month.
+	  * Which week of the month (1-5). Used for biweekly and monthly frequency
+	  */
+	public void setWeekOfMonth (int WeekOfMonth);
+
+	/** Get Week of Month.
+	  * Which week of the month (1-5). Used for biweekly and monthly frequency
+	  */
+	public int getWeekOfMonth();
+}

--- a/src/patches/java/org/adempiere/core/domains/models/X_HR_AttendanceBatch.java
+++ b/src/patches/java/org/adempiere/core/domains/models/X_HR_AttendanceBatch.java
@@ -1,0 +1,640 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2017 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * or (at your option) any later version.                                     *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net                                                  *
+ * or https://github.com/adempiere/adempiere/blob/develop/license.html        *
+ *****************************************************************************/
+/** Generated Model - DO NOT CHANGE */
+package org.adempiere.core.domains.models;
+
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.util.Properties;
+import org.compiere.model.I_Persistent;
+import org.compiere.model.MTable;
+import org.compiere.model.PO;
+import org.compiere.model.POInfo;
+import org.compiere.util.KeyNamePair;
+
+/** Generated Model for HR_AttendanceBatch
+ *  @author Adempiere (generated) 
+ *  @version Release 3.9.4 - $Id$ */
+public class X_HR_AttendanceBatch extends PO implements I_HR_AttendanceBatch, I_Persistent 
+{
+
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 20260806L;
+
+    /** Standard Constructor */
+    public X_HR_AttendanceBatch (Properties ctx, int HR_AttendanceBatch_ID, String trxName)
+    {
+      super (ctx, HR_AttendanceBatch_ID, trxName);
+      /** if (HR_AttendanceBatch_ID == 0)
+        {
+			setC_BPartner_ID (0);
+			setC_DocType_ID (0);
+			setDateDoc (new Timestamp( System.currentTimeMillis() ));
+// @#Date@
+			setDocAction (null);
+// CO
+			setDocStatus (null);
+// DR
+			setDocumentNo (null);
+			setHR_AttendanceBatch_ID (0);
+			setIsApproved (false);
+// N
+			setProcessed (false);
+// N
+        } */
+    }
+
+    /** Load Constructor */
+    public X_HR_AttendanceBatch (Properties ctx, ResultSet rs, String trxName)
+    {
+      super (ctx, rs, trxName);
+    }
+
+    /** AccessLevel
+      * @return 3 - Client - Org 
+      */
+    protected int get_AccessLevel()
+    {
+      return accessLevel.intValue();
+    }
+
+    /** Load Meta Data */
+    protected POInfo initPO (Properties ctx)
+    {
+      POInfo poi = POInfo.getPOInfo (ctx, Table_ID, get_TrxName());
+      return poi;
+    }
+
+    public String toString()
+    {
+      StringBuffer sb = new StringBuffer ("X_HR_AttendanceBatch[")
+        .append(get_ID()).append("]");
+      return sb.toString();
+    }
+
+	public org.adempiere.core.domains.models.I_C_BPartner getC_BPartner() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_C_BPartner)MTable.get(getCtx(), org.adempiere.core.domains.models.I_C_BPartner.Table_Name)
+			.getPO(getC_BPartner_ID(), get_TrxName());	}
+
+	/** Set Business Partner .
+		@param C_BPartner_ID 
+		Identifies a Business Partner
+	  */
+	public void setC_BPartner_ID (int C_BPartner_ID)
+	{
+		if (C_BPartner_ID < 1) 
+			set_ValueNoCheck (COLUMNNAME_C_BPartner_ID, null);
+		else 
+			set_ValueNoCheck (COLUMNNAME_C_BPartner_ID, Integer.valueOf(C_BPartner_ID));
+	}
+
+	/** Get Business Partner .
+		@return Identifies a Business Partner
+	  */
+	public int getC_BPartner_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_C_BPartner_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public org.adempiere.core.domains.models.I_C_DocType getC_DocType() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_C_DocType)MTable.get(getCtx(), org.adempiere.core.domains.models.I_C_DocType.Table_Name)
+			.getPO(getC_DocType_ID(), get_TrxName());	}
+
+	/** Set Document Type.
+		@param C_DocType_ID 
+		Document type or rules
+	  */
+	public void setC_DocType_ID (int C_DocType_ID)
+	{
+		if (C_DocType_ID < 0) 
+			set_Value (COLUMNNAME_C_DocType_ID, null);
+		else 
+			set_Value (COLUMNNAME_C_DocType_ID, Integer.valueOf(C_DocType_ID));
+	}
+
+	/** Get Document Type.
+		@return Document type or rules
+	  */
+	public int getC_DocType_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_C_DocType_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** Set Document Date.
+		@param DateDoc 
+		Date of the Document
+	  */
+	public void setDateDoc (Timestamp DateDoc)
+	{
+		set_Value (COLUMNNAME_DateDoc, DateDoc);
+	}
+
+	/** Get Document Date.
+		@return Date of the Document
+	  */
+	public Timestamp getDateDoc () 
+	{
+		return (Timestamp)get_Value(COLUMNNAME_DateDoc);
+	}
+
+	/** Set Description.
+		@param Description 
+		Optional short description of the record
+	  */
+	public void setDescription (String Description)
+	{
+		set_Value (COLUMNNAME_Description, Description);
+	}
+
+	/** Get Description.
+		@return Optional short description of the record
+	  */
+	public String getDescription () 
+	{
+		return (String)get_Value(COLUMNNAME_Description);
+	}
+
+	/** DocAction AD_Reference_ID=135 */
+	public static final int DOCACTION_AD_Reference_ID=135;
+	/** Complete = CO */
+	public static final String DOCACTION_Complete = "CO";
+	/** Approve = AP */
+	public static final String DOCACTION_Approve = "AP";
+	/** Reject = RJ */
+	public static final String DOCACTION_Reject = "RJ";
+	/** Post = PO */
+	public static final String DOCACTION_Post = "PO";
+	/** Void = VO */
+	public static final String DOCACTION_Void = "VO";
+	/** Close = CL */
+	public static final String DOCACTION_Close = "CL";
+	/** Reverse - Correct = RC */
+	public static final String DOCACTION_Reverse_Correct = "RC";
+	/** Reverse - Accrual = RA */
+	public static final String DOCACTION_Reverse_Accrual = "RA";
+	/** Invalidate = IN */
+	public static final String DOCACTION_Invalidate = "IN";
+	/** Re-activate = RE */
+	public static final String DOCACTION_Re_Activate = "RE";
+	/** <None> = -- */
+	public static final String DOCACTION_None = "--";
+	/** Prepare = PR */
+	public static final String DOCACTION_Prepare = "PR";
+	/** Unlock = XL */
+	public static final String DOCACTION_Unlock = "XL";
+	/** Wait Complete = WC */
+	public static final String DOCACTION_WaitComplete = "WC";
+	/** Set Document Action.
+		@param DocAction 
+		The targeted status of the document
+	  */
+	public void setDocAction (String DocAction)
+	{
+
+		set_Value (COLUMNNAME_DocAction, DocAction);
+	}
+
+	/** Get Document Action.
+		@return The targeted status of the document
+	  */
+	public String getDocAction () 
+	{
+		return (String)get_Value(COLUMNNAME_DocAction);
+	}
+
+	/** DocStatus AD_Reference_ID=131 */
+	public static final int DOCSTATUS_AD_Reference_ID=131;
+	/** Drafted = DR */
+	public static final String DOCSTATUS_Drafted = "DR";
+	/** Completed = CO */
+	public static final String DOCSTATUS_Completed = "CO";
+	/** Approved = AP */
+	public static final String DOCSTATUS_Approved = "AP";
+	/** Not Approved = NA */
+	public static final String DOCSTATUS_NotApproved = "NA";
+	/** Voided = VO */
+	public static final String DOCSTATUS_Voided = "VO";
+	/** Invalid = IN */
+	public static final String DOCSTATUS_Invalid = "IN";
+	/** Reversed = RE */
+	public static final String DOCSTATUS_Reversed = "RE";
+	/** Closed = CL */
+	public static final String DOCSTATUS_Closed = "CL";
+	/** Unknown = ?? */
+	public static final String DOCSTATUS_Unknown = "??";
+	/** In Progress = IP */
+	public static final String DOCSTATUS_InProgress = "IP";
+	/** Waiting Payment = WP */
+	public static final String DOCSTATUS_WaitingPayment = "WP";
+	/** Waiting Confirmation = WC */
+	public static final String DOCSTATUS_WaitingConfirmation = "WC";
+	/** Set Document Status.
+		@param DocStatus 
+		The current status of the document
+	  */
+	public void setDocStatus (String DocStatus)
+	{
+
+		set_Value (COLUMNNAME_DocStatus, DocStatus);
+	}
+
+	/** Get Document Status.
+		@return The current status of the document
+	  */
+	public String getDocStatus () 
+	{
+		return (String)get_Value(COLUMNNAME_DocStatus);
+	}
+
+	/** Set Document No.
+		@param DocumentNo 
+		Document sequence number of the document
+	  */
+	public void setDocumentNo (String DocumentNo)
+	{
+		set_Value (COLUMNNAME_DocumentNo, DocumentNo);
+	}
+
+	/** Get Document No.
+		@return Document sequence number of the document
+	  */
+	public String getDocumentNo () 
+	{
+		return (String)get_Value(COLUMNNAME_DocumentNo);
+	}
+
+    /** Get Record ID/ColumnName
+        @return ID/ColumnName pair
+      */
+    public KeyNamePair getKeyNamePair() 
+    {
+        return new KeyNamePair(get_ID(), getDocumentNo());
+    }
+
+	/** Set Attendance Batch.
+		@param HR_AttendanceBatch_ID Attendance Batch	  */
+	public void setHR_AttendanceBatch_ID (int HR_AttendanceBatch_ID)
+	{
+		if (HR_AttendanceBatch_ID < 1) 
+			set_ValueNoCheck (COLUMNNAME_HR_AttendanceBatch_ID, null);
+		else 
+			set_ValueNoCheck (COLUMNNAME_HR_AttendanceBatch_ID, Integer.valueOf(HR_AttendanceBatch_ID));
+	}
+
+	/** Get Attendance Batch.
+		@return Attendance Batch	  */
+	public int getHR_AttendanceBatch_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_HR_AttendanceBatch_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public org.adempiere.core.domains.models.I_HR_Employee getHR_Employee() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_HR_Employee)MTable.get(getCtx(), org.adempiere.core.domains.models.I_HR_Employee.Table_Name)
+			.getPO(getHR_Employee_ID(), get_TrxName());	}
+
+	/** Set Payroll Employee.
+		@param HR_Employee_ID Payroll Employee	  */
+	public void setHR_Employee_ID (int HR_Employee_ID)
+	{
+		if (HR_Employee_ID < 1) 
+			set_ValueNoCheck (COLUMNNAME_HR_Employee_ID, null);
+		else 
+			set_ValueNoCheck (COLUMNNAME_HR_Employee_ID, Integer.valueOf(HR_Employee_ID));
+	}
+
+	/** Get Payroll Employee.
+		@return Payroll Employee	  */
+	public int getHR_Employee_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_HR_Employee_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public org.adempiere.core.domains.models.I_HR_ShiftSchedule getHR_ShiftSchedule() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_HR_ShiftSchedule)MTable.get(getCtx(), org.adempiere.core.domains.models.I_HR_ShiftSchedule.Table_Name)
+			.getPO(getHR_ShiftSchedule_ID(), get_TrxName());	}
+
+	/** Set Shift Schedule.
+		@param HR_ShiftSchedule_ID 
+		Shift Schedule
+	  */
+	public void setHR_ShiftSchedule_ID (int HR_ShiftSchedule_ID)
+	{
+		if (HR_ShiftSchedule_ID < 1) 
+			set_Value (COLUMNNAME_HR_ShiftSchedule_ID, null);
+		else 
+			set_Value (COLUMNNAME_HR_ShiftSchedule_ID, Integer.valueOf(HR_ShiftSchedule_ID));
+	}
+
+	/** Get Shift Schedule.
+		@return Shift Schedule
+	  */
+	public int getHR_ShiftSchedule_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_HR_ShiftSchedule_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public org.adempiere.core.domains.models.I_HR_WorkShift getHR_WorkShift() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_HR_WorkShift)MTable.get(getCtx(), org.adempiere.core.domains.models.I_HR_WorkShift.Table_Name)
+			.getPO(getHR_WorkShift_ID(), get_TrxName());	}
+
+	/** Set Work Shift.
+		@param HR_WorkShift_ID 
+		Work Shift
+	  */
+	public void setHR_WorkShift_ID (int HR_WorkShift_ID)
+	{
+		if (HR_WorkShift_ID < 1) 
+			set_Value (COLUMNNAME_HR_WorkShift_ID, null);
+		else 
+			set_Value (COLUMNNAME_HR_WorkShift_ID, Integer.valueOf(HR_WorkShift_ID));
+	}
+
+	/** Get Work Shift.
+		@return Work Shift
+	  */
+	public int getHR_WorkShift_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_HR_WorkShift_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** Set Approved.
+		@param IsApproved 
+		Indicates if this document requires approval
+	  */
+	public void setIsApproved (boolean IsApproved)
+	{
+		set_Value (COLUMNNAME_IsApproved, Boolean.valueOf(IsApproved));
+	}
+
+	/** Get Approved.
+		@return Indicates if this document requires approval
+	  */
+	public boolean isApproved () 
+	{
+		Object oo = get_Value(COLUMNNAME_IsApproved);
+		if (oo != null) 
+		{
+			 if (oo instanceof Boolean) 
+				 return ((Boolean)oo).booleanValue(); 
+			return "Y".equals(oo);
+		}
+		return false;
+	}
+
+	/** Set Attendance Generated.
+		@param IsAttendanceGenerated 
+		Attendance Generated automatically
+	  */
+	public void setIsAttendanceGenerated (boolean IsAttendanceGenerated)
+	{
+		set_Value (COLUMNNAME_IsAttendanceGenerated, Boolean.valueOf(IsAttendanceGenerated));
+	}
+
+	/** Get Attendance Generated.
+		@return Attendance Generated automatically
+	  */
+	public boolean isAttendanceGenerated () 
+	{
+		Object oo = get_Value(COLUMNNAME_IsAttendanceGenerated);
+		if (oo != null) 
+		{
+			 if (oo instanceof Boolean) 
+				 return ((Boolean)oo).booleanValue(); 
+			return "Y".equals(oo);
+		}
+		return false;
+	}
+
+	/** Set Leave.
+		@param IsLeave 
+		This document is generated from a leave
+	  */
+	public void setIsLeave (boolean IsLeave)
+	{
+		set_Value (COLUMNNAME_IsLeave, Boolean.valueOf(IsLeave));
+	}
+
+	/** Get Leave.
+		@return This document is generated from a leave
+	  */
+	public boolean isLeave () 
+	{
+		Object oo = get_Value(COLUMNNAME_IsLeave);
+		if (oo != null) 
+		{
+			 if (oo instanceof Boolean) 
+				 return ((Boolean)oo).booleanValue(); 
+			return "Y".equals(oo);
+		}
+		return false;
+	}
+
+	/** Set Processed.
+		@param Processed 
+		The document has been processed
+	  */
+	public void setProcessed (boolean Processed)
+	{
+		set_Value (COLUMNNAME_Processed, Boolean.valueOf(Processed));
+	}
+
+	/** Get Processed.
+		@return The document has been processed
+	  */
+	public boolean isProcessed () 
+	{
+		Object oo = get_Value(COLUMNNAME_Processed);
+		if (oo != null) 
+		{
+			 if (oo instanceof Boolean) 
+				 return ((Boolean)oo).booleanValue(); 
+			return "Y".equals(oo);
+		}
+		return false;
+	}
+
+	/** Set Process Now.
+		@param Processing Process Now	  */
+	public void setProcessing (boolean Processing)
+	{
+		set_Value (COLUMNNAME_Processing, Boolean.valueOf(Processing));
+	}
+
+	/** Get Process Now.
+		@return Process Now	  */
+	public boolean isProcessing () 
+	{
+		Object oo = get_Value(COLUMNNAME_Processing);
+		if (oo != null) 
+		{
+			 if (oo instanceof Boolean) 
+				 return ((Boolean)oo).booleanValue(); 
+			return "Y".equals(oo);
+		}
+		return false;
+	}
+
+	public org.adempiere.core.domains.models.I_S_Contract getS_Contract() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_S_Contract)MTable.get(getCtx(), org.adempiere.core.domains.models.I_S_Contract.Table_Name)
+			.getPO(getS_Contract_ID(), get_TrxName());	}
+
+	/** Set Contract.
+		@param S_Contract_ID 
+		Contract
+	  */
+	public void setS_Contract_ID (int S_Contract_ID)
+	{
+		if (S_Contract_ID < 1) 
+			set_Value (COLUMNNAME_S_Contract_ID, null);
+		else 
+			set_Value (COLUMNNAME_S_Contract_ID, Integer.valueOf(S_Contract_ID));
+	}
+
+	/** Get Contract.
+		@return Contract
+	  */
+	public int getS_Contract_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_S_Contract_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public org.adempiere.core.domains.models.I_S_ContractLine getS_ContractLine() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_S_ContractLine)MTable.get(getCtx(), org.adempiere.core.domains.models.I_S_ContractLine.Table_Name)
+			.getPO(getS_ContractLine_ID(), get_TrxName());	}
+
+	/** Set ContractLine.
+		@param S_ContractLine_ID 
+		ContractLine
+	  */
+	public void setS_ContractLine_ID (int S_ContractLine_ID)
+	{
+		if (S_ContractLine_ID < 1) 
+			set_Value (COLUMNNAME_S_ContractLine_ID, null);
+		else 
+			set_Value (COLUMNNAME_S_ContractLine_ID, Integer.valueOf(S_ContractLine_ID));
+	}
+
+	/** Get ContractLine.
+		@return ContractLine
+	  */
+	public int getS_ContractLine_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_S_ContractLine_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** Set Resource Assignment.
+		@param S_ResourceAssignment_ID 
+		Resource Assignment
+	  */
+	public void setS_ResourceAssignment_ID (int S_ResourceAssignment_ID)
+	{
+		if (S_ResourceAssignment_ID < 1) 
+			set_Value (COLUMNNAME_S_ResourceAssignment_ID, null);
+		else 
+			set_Value (COLUMNNAME_S_ResourceAssignment_ID, Integer.valueOf(S_ResourceAssignment_ID));
+	}
+
+	/** Get Resource Assignment.
+		@return Resource Assignment
+	  */
+	public int getS_ResourceAssignment_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_S_ResourceAssignment_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public org.adempiere.core.domains.models.I_S_ServiceSchedule getS_ServiceSchedule() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_S_ServiceSchedule)MTable.get(getCtx(), org.adempiere.core.domains.models.I_S_ServiceSchedule.Table_Name)
+			.getPO(getS_ServiceSchedule_ID(), get_TrxName());	}
+
+	/** Set Service Schedule ID.
+		@param S_ServiceSchedule_ID 
+		Weekly visit pattern for a service plan
+	  */
+	public void setS_ServiceSchedule_ID (int S_ServiceSchedule_ID)
+	{
+		if (S_ServiceSchedule_ID < 1) 
+			set_Value (COLUMNNAME_S_ServiceSchedule_ID, null);
+		else 
+			set_Value (COLUMNNAME_S_ServiceSchedule_ID, Integer.valueOf(S_ServiceSchedule_ID));
+	}
+
+	/** Get Service Schedule ID.
+		@return Weekly visit pattern for a service plan
+	  */
+	public int getS_ServiceSchedule_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_S_ServiceSchedule_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** Set Immutable Universally Unique Identifier.
+		@param UUID 
+		Immutable Universally Unique Identifier
+	  */
+	public void setUUID (String UUID)
+	{
+		set_Value (COLUMNNAME_UUID, UUID);
+	}
+
+	/** Get Immutable Universally Unique Identifier.
+		@return Immutable Universally Unique Identifier
+	  */
+	public String getUUID () 
+	{
+		return (String)get_Value(COLUMNNAME_UUID);
+	}
+}

--- a/src/patches/java/org/adempiere/core/domains/models/X_HR_AttendanceRecord.java
+++ b/src/patches/java/org/adempiere/core/domains/models/X_HR_AttendanceRecord.java
@@ -1,0 +1,463 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2017 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * or (at your option) any later version.                                     *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net                                                  *
+ * or https://github.com/adempiere/adempiere/blob/develop/license.html        *
+ *****************************************************************************/
+/** Generated Model - DO NOT CHANGE */
+package org.adempiere.core.domains.models;
+
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.util.Properties;
+import org.compiere.model.I_Persistent;
+import org.compiere.model.MTable;
+import org.compiere.model.PO;
+import org.compiere.model.POInfo;
+import org.compiere.util.Env;
+import org.compiere.util.KeyNamePair;
+
+/** Generated Model for HR_AttendanceRecord
+ *  @author Adempiere (generated) 
+ *  @version Release 3.9.4 - $Id$ */
+public class X_HR_AttendanceRecord extends PO implements I_HR_AttendanceRecord, I_Persistent 
+{
+
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 20260806L;
+
+    /** Standard Constructor */
+    public X_HR_AttendanceRecord (Properties ctx, int HR_AttendanceRecord_ID, String trxName)
+    {
+      super (ctx, HR_AttendanceRecord_ID, trxName);
+      /** if (HR_AttendanceRecord_ID == 0)
+        {
+			setAttendanceTime (new Timestamp( System.currentTimeMillis() ));
+			setHR_AttendanceBatch_ID (0);
+			setHR_AttendanceRecord_ID (0);
+			setIsOfflineMark (false);
+// N
+			setIsOutOfTime (false);
+// N
+			setIsOutOfZone (false);
+// N
+        } */
+    }
+
+    /** Load Constructor */
+    public X_HR_AttendanceRecord (Properties ctx, ResultSet rs, String trxName)
+    {
+      super (ctx, rs, trxName);
+    }
+
+    /** AccessLevel
+      * @return 3 - Client - Org 
+      */
+    protected int get_AccessLevel()
+    {
+      return accessLevel.intValue();
+    }
+
+    /** Load Meta Data */
+    protected POInfo initPO (Properties ctx)
+    {
+      POInfo poi = POInfo.getPOInfo (ctx, Table_ID, get_TrxName());
+      return poi;
+    }
+
+    public String toString()
+    {
+      StringBuffer sb = new StringBuffer ("X_HR_AttendanceRecord[")
+        .append(get_ID()).append("]");
+      return sb.toString();
+    }
+
+	/** Set Attendance Time.
+		@param AttendanceTime 
+		Attendance Time for Employee
+	  */
+	public void setAttendanceTime (Timestamp AttendanceTime)
+	{
+		set_Value (COLUMNNAME_AttendanceTime, AttendanceTime);
+	}
+
+	/** Get Attendance Time.
+		@return Attendance Time for Employee
+	  */
+	public Timestamp getAttendanceTime () 
+	{
+		return (Timestamp)get_Value(COLUMNNAME_AttendanceTime);
+	}
+
+    /** Get Record ID/ColumnName
+        @return ID/ColumnName pair
+      */
+    public KeyNamePair getKeyNamePair() 
+    {
+        return new KeyNamePair(get_ID(), String.valueOf(getAttendanceTime()));
+    }
+
+	/** Set Comments.
+		@param Comments 
+		Comments or additional information
+	  */
+	public void setComments (String Comments)
+	{
+		set_Value (COLUMNNAME_Comments, Comments);
+	}
+
+	/** Get Comments.
+		@return Comments or additional information
+	  */
+	public String getComments () 
+	{
+		return (String)get_Value(COLUMNNAME_Comments);
+	}
+
+	public org.adempiere.core.domains.models.I_C_Project getC_Project() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_C_Project)MTable.get(getCtx(), org.adempiere.core.domains.models.I_C_Project.Table_Name)
+			.getPO(getC_Project_ID(), get_TrxName());	}
+
+	/** Set Project.
+		@param C_Project_ID 
+		Financial Project
+	  */
+	public void setC_Project_ID (int C_Project_ID)
+	{
+		if (C_Project_ID < 1) 
+			set_Value (COLUMNNAME_C_Project_ID, null);
+		else 
+			set_Value (COLUMNNAME_C_Project_ID, Integer.valueOf(C_Project_ID));
+	}
+
+	/** Get Project.
+		@return Financial Project
+	  */
+	public int getC_Project_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_C_Project_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public org.adempiere.core.domains.models.I_HR_AttendanceBatch getHR_AttendanceBatch() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_HR_AttendanceBatch)MTable.get(getCtx(), org.adempiere.core.domains.models.I_HR_AttendanceBatch.Table_Name)
+			.getPO(getHR_AttendanceBatch_ID(), get_TrxName());	}
+
+	/** Set Attendance Batch.
+		@param HR_AttendanceBatch_ID Attendance Batch	  */
+	public void setHR_AttendanceBatch_ID (int HR_AttendanceBatch_ID)
+	{
+		if (HR_AttendanceBatch_ID < 1) 
+			set_ValueNoCheck (COLUMNNAME_HR_AttendanceBatch_ID, null);
+		else 
+			set_ValueNoCheck (COLUMNNAME_HR_AttendanceBatch_ID, Integer.valueOf(HR_AttendanceBatch_ID));
+	}
+
+	/** Get Attendance Batch.
+		@return Attendance Batch	  */
+	public int getHR_AttendanceBatch_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_HR_AttendanceBatch_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** Set Attendance Record.
+		@param HR_AttendanceRecord_ID 
+		Attendance Record
+	  */
+	public void setHR_AttendanceRecord_ID (int HR_AttendanceRecord_ID)
+	{
+		if (HR_AttendanceRecord_ID < 1) 
+			set_ValueNoCheck (COLUMNNAME_HR_AttendanceRecord_ID, null);
+		else 
+			set_ValueNoCheck (COLUMNNAME_HR_AttendanceRecord_ID, Integer.valueOf(HR_AttendanceRecord_ID));
+	}
+
+	/** Get Attendance Record.
+		@return Attendance Record
+	  */
+	public int getHR_AttendanceRecord_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_HR_AttendanceRecord_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** Set Offline Mark.
+		@param IsOfflineMark 
+		Attendance mark was made without internet connection and synced later
+	  */
+	public void setIsOfflineMark (boolean IsOfflineMark)
+	{
+		set_Value (COLUMNNAME_IsOfflineMark, Boolean.valueOf(IsOfflineMark));
+	}
+
+	/** Get Offline Mark.
+		@return Attendance mark was made without internet connection and synced later
+	  */
+	public boolean isOfflineMark () 
+	{
+		Object oo = get_Value(COLUMNNAME_IsOfflineMark);
+		if (oo != null) 
+		{
+			 if (oo instanceof Boolean) 
+				 return ((Boolean)oo).booleanValue(); 
+			return "Y".equals(oo);
+		}
+		return false;
+	}
+
+	/** Set Out of Time.
+		@param IsOutOfTime 
+		Attendance mark was made outside the time tolerance (10 minutes)
+	  */
+	public void setIsOutOfTime (boolean IsOutOfTime)
+	{
+		set_Value (COLUMNNAME_IsOutOfTime, Boolean.valueOf(IsOutOfTime));
+	}
+
+	/** Get Out of Time.
+		@return Attendance mark was made outside the time tolerance (10 minutes)
+	  */
+	public boolean isOutOfTime () 
+	{
+		Object oo = get_Value(COLUMNNAME_IsOutOfTime);
+		if (oo != null) 
+		{
+			 if (oo instanceof Boolean) 
+				 return ((Boolean)oo).booleanValue(); 
+			return "Y".equals(oo);
+		}
+		return false;
+	}
+
+	/** Set Out of Zone.
+		@param IsOutOfZone 
+		Attendance mark was made outside the geofence radius of the client location
+	  */
+	public void setIsOutOfZone (boolean IsOutOfZone)
+	{
+		set_Value (COLUMNNAME_IsOutOfZone, Boolean.valueOf(IsOutOfZone));
+	}
+
+	/** Get Out of Zone.
+		@return Attendance mark was made outside the geofence radius of the client location
+	  */
+	public boolean isOutOfZone () 
+	{
+		Object oo = get_Value(COLUMNNAME_IsOutOfZone);
+		if (oo != null) 
+		{
+			 if (oo instanceof Boolean) 
+				 return ((Boolean)oo).booleanValue(); 
+			return "Y".equals(oo);
+		}
+		return false;
+	}
+
+	/** Set Latitude.
+		@param Latitude 
+		Latitude is a geographic coordinate that specifies the north–south position of a point on the Earth's surface.
+	  */
+	public void setLatitude (BigDecimal Latitude)
+	{
+		set_Value (COLUMNNAME_Latitude, Latitude);
+	}
+
+	/** Get Latitude.
+		@return Latitude is a geographic coordinate that specifies the north–south position of a point on the Earth's surface.
+	  */
+	public BigDecimal getLatitude () 
+	{
+		BigDecimal bd = (BigDecimal)get_Value(COLUMNNAME_Latitude);
+		if (bd == null)
+			 return Env.ZERO;
+		return bd;
+	}
+
+	/** Set Longitude.
+		@param Longitude 
+		Longitude  is a geographic coordinate that specifies the east–west position of a point on the Earth's surface, or the surface of a celestial body
+	  */
+	public void setLongitude (BigDecimal Longitude)
+	{
+		set_Value (COLUMNNAME_Longitude, Longitude);
+	}
+
+	/** Get Longitude.
+		@return Longitude  is a geographic coordinate that specifies the east–west position of a point on the Earth's surface, or the surface of a celestial body
+	  */
+	public BigDecimal getLongitude () 
+	{
+		BigDecimal bd = (BigDecimal)get_Value(COLUMNNAME_Longitude);
+		if (bd == null)
+			 return Env.ZERO;
+		return bd;
+	}
+
+	/** Set Processed.
+		@param Processed 
+		The document has been processed
+	  */
+	public void setProcessed (boolean Processed)
+	{
+		set_Value (COLUMNNAME_Processed, Boolean.valueOf(Processed));
+	}
+
+	/** Get Processed.
+		@return The document has been processed
+	  */
+	public boolean isProcessed () 
+	{
+		Object oo = get_Value(COLUMNNAME_Processed);
+		if (oo != null) 
+		{
+			 if (oo instanceof Boolean) 
+				 return ((Boolean)oo).booleanValue(); 
+			return "Y".equals(oo);
+		}
+		return false;
+	}
+
+	public org.adempiere.core.domains.models.I_S_Contract getS_Contract() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_S_Contract)MTable.get(getCtx(), org.adempiere.core.domains.models.I_S_Contract.Table_Name)
+			.getPO(getS_Contract_ID(), get_TrxName());	}
+
+	/** Set Contract.
+		@param S_Contract_ID 
+		Contract
+	  */
+	public void setS_Contract_ID (int S_Contract_ID)
+	{
+		if (S_Contract_ID < 1) 
+			set_Value (COLUMNNAME_S_Contract_ID, null);
+		else 
+			set_Value (COLUMNNAME_S_Contract_ID, Integer.valueOf(S_Contract_ID));
+	}
+
+	/** Get Contract.
+		@return Contract
+	  */
+	public int getS_Contract_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_S_Contract_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public org.adempiere.core.domains.models.I_S_ContractLine getS_ContractLine() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_S_ContractLine)MTable.get(getCtx(), org.adempiere.core.domains.models.I_S_ContractLine.Table_Name)
+			.getPO(getS_ContractLine_ID(), get_TrxName());	}
+
+	/** Set ContractLine.
+		@param S_ContractLine_ID 
+		ContractLine
+	  */
+	public void setS_ContractLine_ID (int S_ContractLine_ID)
+	{
+		if (S_ContractLine_ID < 1) 
+			set_Value (COLUMNNAME_S_ContractLine_ID, null);
+		else 
+			set_Value (COLUMNNAME_S_ContractLine_ID, Integer.valueOf(S_ContractLine_ID));
+	}
+
+	/** Get ContractLine.
+		@return ContractLine
+	  */
+	public int getS_ContractLine_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_S_ContractLine_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** Set Sequence.
+		@param SeqNo 
+		Method of ordering records; lowest number comes first
+	  */
+	public void setSeqNo (int SeqNo)
+	{
+		set_Value (COLUMNNAME_SeqNo, Integer.valueOf(SeqNo));
+	}
+
+	/** Get Sequence.
+		@return Method of ordering records; lowest number comes first
+	  */
+	public int getSeqNo () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_SeqNo);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public org.adempiere.core.domains.models.I_S_ResourceAssignment getS_ResourceAssignment() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_S_ResourceAssignment)MTable.get(getCtx(), org.adempiere.core.domains.models.I_S_ResourceAssignment.Table_Name)
+			.getPO(getS_ResourceAssignment_ID(), get_TrxName());	}
+
+	/** Set Resource Assignment.
+		@param S_ResourceAssignment_ID 
+		Resource Assignment
+	  */
+	public void setS_ResourceAssignment_ID (int S_ResourceAssignment_ID)
+	{
+		if (S_ResourceAssignment_ID < 1) 
+			set_Value (COLUMNNAME_S_ResourceAssignment_ID, null);
+		else 
+			set_Value (COLUMNNAME_S_ResourceAssignment_ID, Integer.valueOf(S_ResourceAssignment_ID));
+	}
+
+	/** Get Resource Assignment.
+		@return Resource Assignment
+	  */
+	public int getS_ResourceAssignment_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_S_ResourceAssignment_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** Set Immutable Universally Unique Identifier.
+		@param UUID 
+		Immutable Universally Unique Identifier
+	  */
+	public void setUUID (String UUID)
+	{
+		set_Value (COLUMNNAME_UUID, UUID);
+	}
+
+	/** Get Immutable Universally Unique Identifier.
+		@return Immutable Universally Unique Identifier
+	  */
+	public String getUUID () 
+	{
+		return (String)get_Value(COLUMNNAME_UUID);
+	}
+}

--- a/src/patches/java/org/adempiere/core/domains/models/X_HR_Incidence.java
+++ b/src/patches/java/org/adempiere/core/domains/models/X_HR_Incidence.java
@@ -1,0 +1,753 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2017 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * or (at your option) any later version.                                     *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net                                                  *
+ * or https://github.com/adempiere/adempiere/blob/develop/license.html        *
+ *****************************************************************************/
+/** Generated Model - DO NOT CHANGE */
+package org.adempiere.core.domains.models;
+
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.util.Properties;
+import org.compiere.model.I_Persistent;
+import org.compiere.model.MTable;
+import org.compiere.model.PO;
+import org.compiere.model.POInfo;
+import org.compiere.util.Env;
+import org.compiere.util.KeyNamePair;
+
+/** Generated Model for HR_Incidence
+ *  @author Adempiere (generated) 
+ *  @version Release 3.9.4 - $Id$ */
+public class X_HR_Incidence extends PO implements I_HR_Incidence, I_Persistent 
+{
+
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 20260806L;
+
+    /** Standard Constructor */
+    public X_HR_Incidence (Properties ctx, int HR_Incidence_ID, String trxName)
+    {
+      super (ctx, HR_Incidence_ID, trxName);
+      /** if (HR_Incidence_ID == 0)
+        {
+			setC_BPartner_ID (0);
+			setC_DocType_ID (0);
+			setDateDoc (new Timestamp( System.currentTimeMillis() ));
+// @#Date@
+			setDocAction (null);
+// CO
+			setDocStatus (null);
+// DR
+			setDocumentNo (null);
+			setHR_Concept_ID (0);
+			setHR_Employee_ID (0);
+			setHR_Incidence_ID (0);
+			setIsApproved (false);
+// N
+			setProcessed (false);
+// N
+			setServiceDate (new Timestamp( System.currentTimeMillis() ));
+        } */
+    }
+
+    /** Load Constructor */
+    public X_HR_Incidence (Properties ctx, ResultSet rs, String trxName)
+    {
+      super (ctx, rs, trxName);
+    }
+
+    /** AccessLevel
+      * @return 3 - Client - Org 
+      */
+    protected int get_AccessLevel()
+    {
+      return accessLevel.intValue();
+    }
+
+    /** Load Meta Data */
+    protected POInfo initPO (Properties ctx)
+    {
+      POInfo poi = POInfo.getPOInfo (ctx, Table_ID, get_TrxName());
+      return poi;
+    }
+
+    public String toString()
+    {
+      StringBuffer sb = new StringBuffer ("X_HR_Incidence[")
+        .append(get_ID()).append("]");
+      return sb.toString();
+    }
+
+	/** Set Amount.
+		@param Amt 
+		Amount
+	  */
+	public void setAmt (BigDecimal Amt)
+	{
+		set_Value (COLUMNNAME_Amt, Amt);
+	}
+
+	/** Get Amount.
+		@return Amount
+	  */
+	public BigDecimal getAmt () 
+	{
+		BigDecimal bd = (BigDecimal)get_Value(COLUMNNAME_Amt);
+		if (bd == null)
+			 return Env.ZERO;
+		return bd;
+	}
+
+	public org.adempiere.core.domains.models.I_C_BPartner getC_BPartner() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_C_BPartner)MTable.get(getCtx(), org.adempiere.core.domains.models.I_C_BPartner.Table_Name)
+			.getPO(getC_BPartner_ID(), get_TrxName());	}
+
+	/** Set Business Partner .
+		@param C_BPartner_ID 
+		Identifies a Business Partner
+	  */
+	public void setC_BPartner_ID (int C_BPartner_ID)
+	{
+		if (C_BPartner_ID < 1) 
+			set_ValueNoCheck (COLUMNNAME_C_BPartner_ID, null);
+		else 
+			set_ValueNoCheck (COLUMNNAME_C_BPartner_ID, Integer.valueOf(C_BPartner_ID));
+	}
+
+	/** Get Business Partner .
+		@return Identifies a Business Partner
+	  */
+	public int getC_BPartner_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_C_BPartner_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public org.adempiere.core.domains.models.I_C_DocType getC_DocType() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_C_DocType)MTable.get(getCtx(), org.adempiere.core.domains.models.I_C_DocType.Table_Name)
+			.getPO(getC_DocType_ID(), get_TrxName());	}
+
+	/** Set Document Type.
+		@param C_DocType_ID 
+		Document type or rules
+	  */
+	public void setC_DocType_ID (int C_DocType_ID)
+	{
+		if (C_DocType_ID < 0) 
+			set_Value (COLUMNNAME_C_DocType_ID, null);
+		else 
+			set_Value (COLUMNNAME_C_DocType_ID, Integer.valueOf(C_DocType_ID));
+	}
+
+	/** Get Document Type.
+		@return Document type or rules
+	  */
+	public int getC_DocType_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_C_DocType_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public org.adempiere.core.domains.models.I_C_Project getC_Project() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_C_Project)MTable.get(getCtx(), org.adempiere.core.domains.models.I_C_Project.Table_Name)
+			.getPO(getC_Project_ID(), get_TrxName());	}
+
+	/** Set Project.
+		@param C_Project_ID 
+		Financial Project
+	  */
+	public void setC_Project_ID (int C_Project_ID)
+	{
+		if (C_Project_ID < 1) 
+			set_Value (COLUMNNAME_C_Project_ID, null);
+		else 
+			set_Value (COLUMNNAME_C_Project_ID, Integer.valueOf(C_Project_ID));
+	}
+
+	/** Get Project.
+		@return Financial Project
+	  */
+	public int getC_Project_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_C_Project_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** Set Document Date.
+		@param DateDoc 
+		Date of the Document
+	  */
+	public void setDateDoc (Timestamp DateDoc)
+	{
+		set_Value (COLUMNNAME_DateDoc, DateDoc);
+	}
+
+	/** Get Document Date.
+		@return Date of the Document
+	  */
+	public Timestamp getDateDoc () 
+	{
+		return (Timestamp)get_Value(COLUMNNAME_DateDoc);
+	}
+
+	/** Set Description.
+		@param Description 
+		Optional short description of the record
+	  */
+	public void setDescription (String Description)
+	{
+		set_Value (COLUMNNAME_Description, Description);
+	}
+
+	/** Get Description.
+		@return Optional short description of the record
+	  */
+	public String getDescription () 
+	{
+		return (String)get_Value(COLUMNNAME_Description);
+	}
+
+	/** DocAction AD_Reference_ID=135 */
+	public static final int DOCACTION_AD_Reference_ID=135;
+	/** Complete = CO */
+	public static final String DOCACTION_Complete = "CO";
+	/** Approve = AP */
+	public static final String DOCACTION_Approve = "AP";
+	/** Reject = RJ */
+	public static final String DOCACTION_Reject = "RJ";
+	/** Post = PO */
+	public static final String DOCACTION_Post = "PO";
+	/** Void = VO */
+	public static final String DOCACTION_Void = "VO";
+	/** Close = CL */
+	public static final String DOCACTION_Close = "CL";
+	/** Reverse - Correct = RC */
+	public static final String DOCACTION_Reverse_Correct = "RC";
+	/** Reverse - Accrual = RA */
+	public static final String DOCACTION_Reverse_Accrual = "RA";
+	/** Invalidate = IN */
+	public static final String DOCACTION_Invalidate = "IN";
+	/** Re-activate = RE */
+	public static final String DOCACTION_Re_Activate = "RE";
+	/** <None> = -- */
+	public static final String DOCACTION_None = "--";
+	/** Prepare = PR */
+	public static final String DOCACTION_Prepare = "PR";
+	/** Unlock = XL */
+	public static final String DOCACTION_Unlock = "XL";
+	/** Wait Complete = WC */
+	public static final String DOCACTION_WaitComplete = "WC";
+	/** Set Document Action.
+		@param DocAction 
+		The targeted status of the document
+	  */
+	public void setDocAction (String DocAction)
+	{
+
+		set_Value (COLUMNNAME_DocAction, DocAction);
+	}
+
+	/** Get Document Action.
+		@return The targeted status of the document
+	  */
+	public String getDocAction () 
+	{
+		return (String)get_Value(COLUMNNAME_DocAction);
+	}
+
+	/** DocStatus AD_Reference_ID=131 */
+	public static final int DOCSTATUS_AD_Reference_ID=131;
+	/** Drafted = DR */
+	public static final String DOCSTATUS_Drafted = "DR";
+	/** Completed = CO */
+	public static final String DOCSTATUS_Completed = "CO";
+	/** Approved = AP */
+	public static final String DOCSTATUS_Approved = "AP";
+	/** Not Approved = NA */
+	public static final String DOCSTATUS_NotApproved = "NA";
+	/** Voided = VO */
+	public static final String DOCSTATUS_Voided = "VO";
+	/** Invalid = IN */
+	public static final String DOCSTATUS_Invalid = "IN";
+	/** Reversed = RE */
+	public static final String DOCSTATUS_Reversed = "RE";
+	/** Closed = CL */
+	public static final String DOCSTATUS_Closed = "CL";
+	/** Unknown = ?? */
+	public static final String DOCSTATUS_Unknown = "??";
+	/** In Progress = IP */
+	public static final String DOCSTATUS_InProgress = "IP";
+	/** Waiting Payment = WP */
+	public static final String DOCSTATUS_WaitingPayment = "WP";
+	/** Waiting Confirmation = WC */
+	public static final String DOCSTATUS_WaitingConfirmation = "WC";
+	/** Set Document Status.
+		@param DocStatus 
+		The current status of the document
+	  */
+	public void setDocStatus (String DocStatus)
+	{
+
+		set_Value (COLUMNNAME_DocStatus, DocStatus);
+	}
+
+	/** Get Document Status.
+		@return The current status of the document
+	  */
+	public String getDocStatus () 
+	{
+		return (String)get_Value(COLUMNNAME_DocStatus);
+	}
+
+	/** Set Document No.
+		@param DocumentNo 
+		Document sequence number of the document
+	  */
+	public void setDocumentNo (String DocumentNo)
+	{
+		set_Value (COLUMNNAME_DocumentNo, DocumentNo);
+	}
+
+	/** Get Document No.
+		@return Document sequence number of the document
+	  */
+	public String getDocumentNo () 
+	{
+		return (String)get_Value(COLUMNNAME_DocumentNo);
+	}
+
+	/** Set Document Note.
+		@param DocumentNote 
+		Additional information for a Document
+	  */
+	public void setDocumentNote (String DocumentNote)
+	{
+		set_Value (COLUMNNAME_DocumentNote, DocumentNote);
+	}
+
+	/** Get Document Note.
+		@return Additional information for a Document
+	  */
+	public String getDocumentNote () 
+	{
+		return (String)get_Value(COLUMNNAME_DocumentNote);
+	}
+
+	public org.adempiere.core.domains.models.I_HR_AttendanceBatch getHR_AttendanceBatch() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_HR_AttendanceBatch)MTable.get(getCtx(), org.adempiere.core.domains.models.I_HR_AttendanceBatch.Table_Name)
+			.getPO(getHR_AttendanceBatch_ID(), get_TrxName());	}
+
+	/** Set Attendance Batch.
+		@param HR_AttendanceBatch_ID Attendance Batch	  */
+	public void setHR_AttendanceBatch_ID (int HR_AttendanceBatch_ID)
+	{
+		if (HR_AttendanceBatch_ID < 1) 
+			set_Value (COLUMNNAME_HR_AttendanceBatch_ID, null);
+		else 
+			set_Value (COLUMNNAME_HR_AttendanceBatch_ID, Integer.valueOf(HR_AttendanceBatch_ID));
+	}
+
+	/** Get Attendance Batch.
+		@return Attendance Batch	  */
+	public int getHR_AttendanceBatch_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_HR_AttendanceBatch_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public org.adempiere.core.domains.models.I_HR_Concept getHR_Concept() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_HR_Concept)MTable.get(getCtx(), org.adempiere.core.domains.models.I_HR_Concept.Table_Name)
+			.getPO(getHR_Concept_ID(), get_TrxName());	}
+
+	/** Set Global Payroll Concept.
+		@param HR_Concept_ID 
+		The Payroll Concept allows to define all the perception and deductions elements needed to define a payroll.
+	  */
+	public void setHR_Concept_ID (int HR_Concept_ID)
+	{
+		if (HR_Concept_ID < 1) 
+			set_Value (COLUMNNAME_HR_Concept_ID, null);
+		else 
+			set_Value (COLUMNNAME_HR_Concept_ID, Integer.valueOf(HR_Concept_ID));
+	}
+
+	/** Get Global Payroll Concept.
+		@return The Payroll Concept allows to define all the perception and deductions elements needed to define a payroll.
+	  */
+	public int getHR_Concept_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_HR_Concept_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+    /** Get Record ID/ColumnName
+        @return ID/ColumnName pair
+      */
+    public KeyNamePair getKeyNamePair() 
+    {
+        return new KeyNamePair(get_ID(), String.valueOf(getHR_Concept_ID()));
+    }
+
+	public org.adempiere.core.domains.models.I_HR_Employee getHR_Employee() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_HR_Employee)MTable.get(getCtx(), org.adempiere.core.domains.models.I_HR_Employee.Table_Name)
+			.getPO(getHR_Employee_ID(), get_TrxName());	}
+
+	/** Set Payroll Employee.
+		@param HR_Employee_ID Payroll Employee	  */
+	public void setHR_Employee_ID (int HR_Employee_ID)
+	{
+		if (HR_Employee_ID < 1) 
+			set_ValueNoCheck (COLUMNNAME_HR_Employee_ID, null);
+		else 
+			set_ValueNoCheck (COLUMNNAME_HR_Employee_ID, Integer.valueOf(HR_Employee_ID));
+	}
+
+	/** Get Payroll Employee.
+		@return Payroll Employee	  */
+	public int getHR_Employee_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_HR_Employee_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** Set Employee Incidence.
+		@param HR_Incidence_ID Employee Incidence	  */
+	public void setHR_Incidence_ID (int HR_Incidence_ID)
+	{
+		if (HR_Incidence_ID < 1) 
+			set_ValueNoCheck (COLUMNNAME_HR_Incidence_ID, null);
+		else 
+			set_ValueNoCheck (COLUMNNAME_HR_Incidence_ID, Integer.valueOf(HR_Incidence_ID));
+	}
+
+	/** Get Employee Incidence.
+		@return Employee Incidence	  */
+	public int getHR_Incidence_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_HR_Incidence_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public org.adempiere.core.domains.models.I_HR_ShiftIncidence getHR_ShiftIncidence() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_HR_ShiftIncidence)MTable.get(getCtx(), org.adempiere.core.domains.models.I_HR_ShiftIncidence.Table_Name)
+			.getPO(getHR_ShiftIncidence_ID(), get_TrxName());	}
+
+	/** Set Shift Incidence.
+		@param HR_ShiftIncidence_ID 
+		Shift Incidence Configuration
+	  */
+	public void setHR_ShiftIncidence_ID (int HR_ShiftIncidence_ID)
+	{
+		if (HR_ShiftIncidence_ID < 1) 
+			set_Value (COLUMNNAME_HR_ShiftIncidence_ID, null);
+		else 
+			set_Value (COLUMNNAME_HR_ShiftIncidence_ID, Integer.valueOf(HR_ShiftIncidence_ID));
+	}
+
+	/** Get Shift Incidence.
+		@return Shift Incidence Configuration
+	  */
+	public int getHR_ShiftIncidence_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_HR_ShiftIncidence_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** Set Approved.
+		@param IsApproved 
+		Indicates if this document requires approval
+	  */
+	public void setIsApproved (boolean IsApproved)
+	{
+		set_Value (COLUMNNAME_IsApproved, Boolean.valueOf(IsApproved));
+	}
+
+	/** Get Approved.
+		@return Indicates if this document requires approval
+	  */
+	public boolean isApproved () 
+	{
+		Object oo = get_Value(COLUMNNAME_IsApproved);
+		if (oo != null) 
+		{
+			 if (oo instanceof Boolean) 
+				 return ((Boolean)oo).booleanValue(); 
+			return "Y".equals(oo);
+		}
+		return false;
+	}
+
+	/** Set Manual.
+		@param IsManual 
+		This is a manual process
+	  */
+	public void setIsManual (boolean IsManual)
+	{
+		set_Value (COLUMNNAME_IsManual, Boolean.valueOf(IsManual));
+	}
+
+	/** Get Manual.
+		@return This is a manual process
+	  */
+	public boolean isManual () 
+	{
+		Object oo = get_Value(COLUMNNAME_IsManual);
+		if (oo != null) 
+		{
+			 if (oo instanceof Boolean) 
+				 return ((Boolean)oo).booleanValue(); 
+			return "Y".equals(oo);
+		}
+		return false;
+	}
+
+	/** Set Processed.
+		@param Processed 
+		The document has been processed
+	  */
+	public void setProcessed (boolean Processed)
+	{
+		set_Value (COLUMNNAME_Processed, Boolean.valueOf(Processed));
+	}
+
+	/** Get Processed.
+		@return The document has been processed
+	  */
+	public boolean isProcessed () 
+	{
+		Object oo = get_Value(COLUMNNAME_Processed);
+		if (oo != null) 
+		{
+			 if (oo instanceof Boolean) 
+				 return ((Boolean)oo).booleanValue(); 
+			return "Y".equals(oo);
+		}
+		return false;
+	}
+
+	/** Set Process Now.
+		@param Processing Process Now	  */
+	public void setProcessing (boolean Processing)
+	{
+		set_Value (COLUMNNAME_Processing, Boolean.valueOf(Processing));
+	}
+
+	/** Get Process Now.
+		@return Process Now	  */
+	public boolean isProcessing () 
+	{
+		Object oo = get_Value(COLUMNNAME_Processing);
+		if (oo != null) 
+		{
+			 if (oo instanceof Boolean) 
+				 return ((Boolean)oo).booleanValue(); 
+			return "Y".equals(oo);
+		}
+		return false;
+	}
+
+	/** Set Quantity.
+		@param Qty 
+		Quantity
+	  */
+	public void setQty (BigDecimal Qty)
+	{
+		set_Value (COLUMNNAME_Qty, Qty);
+	}
+
+	/** Get Quantity.
+		@return Quantity
+	  */
+	public BigDecimal getQty () 
+	{
+		BigDecimal bd = (BigDecimal)get_Value(COLUMNNAME_Qty);
+		if (bd == null)
+			 return Env.ZERO;
+		return bd;
+	}
+
+	public org.adempiere.core.domains.models.I_S_Contract getS_Contract() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_S_Contract)MTable.get(getCtx(), org.adempiere.core.domains.models.I_S_Contract.Table_Name)
+			.getPO(getS_Contract_ID(), get_TrxName());	}
+
+	/** Set Contract.
+		@param S_Contract_ID 
+		Contract
+	  */
+	public void setS_Contract_ID (int S_Contract_ID)
+	{
+		if (S_Contract_ID < 1) 
+			set_Value (COLUMNNAME_S_Contract_ID, null);
+		else 
+			set_Value (COLUMNNAME_S_Contract_ID, Integer.valueOf(S_Contract_ID));
+	}
+
+	/** Get Contract.
+		@return Contract
+	  */
+	public int getS_Contract_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_S_Contract_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public org.adempiere.core.domains.models.I_S_ContractLine getS_ContractLine() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_S_ContractLine)MTable.get(getCtx(), org.adempiere.core.domains.models.I_S_ContractLine.Table_Name)
+			.getPO(getS_ContractLine_ID(), get_TrxName());	}
+
+	/** Set ContractLine.
+		@param S_ContractLine_ID 
+		ContractLine
+	  */
+	public void setS_ContractLine_ID (int S_ContractLine_ID)
+	{
+		if (S_ContractLine_ID < 1) 
+			set_Value (COLUMNNAME_S_ContractLine_ID, null);
+		else 
+			set_Value (COLUMNNAME_S_ContractLine_ID, Integer.valueOf(S_ContractLine_ID));
+	}
+
+	/** Get ContractLine.
+		@return ContractLine
+	  */
+	public int getS_ContractLine_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_S_ContractLine_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** Set Service date.
+		@param ServiceDate 
+		Date service was provided
+	  */
+	public void setServiceDate (Timestamp ServiceDate)
+	{
+		set_Value (COLUMNNAME_ServiceDate, ServiceDate);
+	}
+
+	/** Get Service date.
+		@return Date service was provided
+	  */
+	public Timestamp getServiceDate () 
+	{
+		return (Timestamp)get_Value(COLUMNNAME_ServiceDate);
+	}
+
+	public org.adempiere.core.domains.models.I_S_TimeExpense getS_TimeExpense() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_S_TimeExpense)MTable.get(getCtx(), org.adempiere.core.domains.models.I_S_TimeExpense.Table_Name)
+			.getPO(getS_TimeExpense_ID(), get_TrxName());	}
+
+	/** Set Expense Report.
+		@param S_TimeExpense_ID 
+		Time and Expense Report
+	  */
+	public void setS_TimeExpense_ID (int S_TimeExpense_ID)
+	{
+		if (S_TimeExpense_ID < 1) 
+			set_Value (COLUMNNAME_S_TimeExpense_ID, null);
+		else 
+			set_Value (COLUMNNAME_S_TimeExpense_ID, Integer.valueOf(S_TimeExpense_ID));
+	}
+
+	/** Get Expense Report.
+		@return Time and Expense Report
+	  */
+	public int getS_TimeExpense_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_S_TimeExpense_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public org.adempiere.core.domains.models.I_S_TimeExpenseLine getS_TimeExpenseLine() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_S_TimeExpenseLine)MTable.get(getCtx(), org.adempiere.core.domains.models.I_S_TimeExpenseLine.Table_Name)
+			.getPO(getS_TimeExpenseLine_ID(), get_TrxName());	}
+
+	/** Set Expense Line.
+		@param S_TimeExpenseLine_ID 
+		Time and Expense Report Line
+	  */
+	public void setS_TimeExpenseLine_ID (int S_TimeExpenseLine_ID)
+	{
+		if (S_TimeExpenseLine_ID < 1) 
+			set_Value (COLUMNNAME_S_TimeExpenseLine_ID, null);
+		else 
+			set_Value (COLUMNNAME_S_TimeExpenseLine_ID, Integer.valueOf(S_TimeExpenseLine_ID));
+	}
+
+	/** Get Expense Line.
+		@return Time and Expense Report Line
+	  */
+	public int getS_TimeExpenseLine_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_S_TimeExpenseLine_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** Set Immutable Universally Unique Identifier.
+		@param UUID 
+		Immutable Universally Unique Identifier
+	  */
+	public void setUUID (String UUID)
+	{
+		set_Value (COLUMNNAME_UUID, UUID);
+	}
+
+	/** Get Immutable Universally Unique Identifier.
+		@return Immutable Universally Unique Identifier
+	  */
+	public String getUUID () 
+	{
+		return (String)get_Value(COLUMNNAME_UUID);
+	}
+}

--- a/src/patches/java/org/adempiere/core/domains/models/X_S_ResourceAssignment.java
+++ b/src/patches/java/org/adempiere/core/domains/models/X_S_ResourceAssignment.java
@@ -1,0 +1,855 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2017 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * or (at your option) any later version.                                     *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net                                                  *
+ * or https://github.com/adempiere/adempiere/blob/develop/license.html        *
+ *****************************************************************************/
+/** Generated Model - DO NOT CHANGE */
+package org.adempiere.core.domains.models;
+
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.util.Properties;
+import org.compiere.model.I_Persistent;
+import org.compiere.model.MTable;
+import org.compiere.model.PO;
+import org.compiere.model.POInfo;
+import org.compiere.util.Env;
+import org.compiere.util.KeyNamePair;
+
+/** Generated Model for S_ResourceAssignment
+ *  @author Adempiere (generated) 
+ *  @version Release 3.9.4 - $Id$ */
+public class X_S_ResourceAssignment extends PO implements I_S_ResourceAssignment, I_Persistent 
+{
+
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 20260806L;
+
+    /** Standard Constructor */
+    public X_S_ResourceAssignment (Properties ctx, int S_ResourceAssignment_ID, String trxName)
+    {
+      super (ctx, S_ResourceAssignment_ID, trxName);
+      /** if (S_ResourceAssignment_ID == 0)
+        {
+			setAssignDateFrom (new Timestamp( System.currentTimeMillis() ));
+			setIsConfirmed (false);
+			setIsManuallyModified (false);
+// N
+			setName (null);
+			setS_ResourceAssignment_ID (0);
+			setS_Resource_ID (0);
+        } */
+    }
+
+    /** Load Constructor */
+    public X_S_ResourceAssignment (Properties ctx, ResultSet rs, String trxName)
+    {
+      super (ctx, rs, trxName);
+    }
+
+    /** AccessLevel
+      * @return 1 - Org 
+      */
+    protected int get_AccessLevel()
+    {
+      return accessLevel.intValue();
+    }
+
+    /** Load Meta Data */
+    protected POInfo initPO (Properties ctx)
+    {
+      POInfo poi = POInfo.getPOInfo (ctx, Table_ID, get_TrxName());
+      return poi;
+    }
+
+    public String toString()
+    {
+      StringBuffer sb = new StringBuffer ("X_S_ResourceAssignment[")
+        .append(get_ID()).append("]");
+      return sb.toString();
+    }
+
+	/** Set Assign From.
+		@param AssignDateFrom 
+		Assign resource from
+	  */
+	public void setAssignDateFrom (Timestamp AssignDateFrom)
+	{
+		set_ValueNoCheck (COLUMNNAME_AssignDateFrom, AssignDateFrom);
+	}
+
+	/** Get Assign From.
+		@return Assign resource from
+	  */
+	public Timestamp getAssignDateFrom () 
+	{
+		return (Timestamp)get_Value(COLUMNNAME_AssignDateFrom);
+	}
+
+	/** Set Assign To.
+		@param AssignDateTo 
+		Assign resource until
+	  */
+	public void setAssignDateTo (Timestamp AssignDateTo)
+	{
+		set_ValueNoCheck (COLUMNNAME_AssignDateTo, AssignDateTo);
+	}
+
+	/** Get Assign To.
+		@return Assign resource until
+	  */
+	public Timestamp getAssignDateTo () 
+	{
+		return (Timestamp)get_Value(COLUMNNAME_AssignDateTo);
+	}
+
+	/** AssignmentSourceType AD_Reference_ID=54623 */
+	public static final int ASSIGNMENTSOURCETYPE_AD_Reference_ID=54623;
+	/** Plan = P */
+	public static final String ASSIGNMENTSOURCETYPE_Plan = "P";
+	/** Manual = M */
+	public static final String ASSIGNMENTSOURCETYPE_Manual = "M";
+	/** Substitution = S */
+	public static final String ASSIGNMENTSOURCETYPE_Substitution = "S";
+	/** Reassignment = R */
+	public static final String ASSIGNMENTSOURCETYPE_Reassignment = "R";
+	/** Set Assignment Source Type.
+		@param AssignmentSourceType 
+		How this assignment was originated: (P)lan, (M)anual, (S)ubstitution, (R)eassignment
+	  */
+	public void setAssignmentSourceType (String AssignmentSourceType)
+	{
+
+		set_Value (COLUMNNAME_AssignmentSourceType, AssignmentSourceType);
+	}
+
+	/** Get Assignment Source Type.
+		@return How this assignment was originated: (P)lan, (M)anual, (S)ubstitution, (R)eassignment
+	  */
+	public String getAssignmentSourceType () 
+	{
+		return (String)get_Value(COLUMNNAME_AssignmentSourceType);
+	}
+
+	/** AssignmentStatus AD_Reference_ID=54624 */
+	public static final int ASSIGNMENTSTATUS_AD_Reference_ID=54624;
+	/** Planned = PL */
+	public static final String ASSIGNMENTSTATUS_Planned = "PL";
+	/** To Coordinate = PC */
+	public static final String ASSIGNMENTSTATUS_ToCoordinate = "PC";
+	/** In Progress = IP */
+	public static final String ASSIGNMENTSTATUS_InProgress = "IP";
+	/** Confirmed = CO */
+	public static final String ASSIGNMENTSTATUS_Confirmed = "CO";
+	/** Pending Auth = PA */
+	public static final String ASSIGNMENTSTATUS_PendingAuth = "PA";
+	/** Approved = AP */
+	public static final String ASSIGNMENTSTATUS_Approved = "AP";
+	/** Cancelled = CA */
+	public static final String ASSIGNMENTSTATUS_Cancelled = "CA";
+	/** Not Attended = NA */
+	public static final String ASSIGNMENTSTATUS_NotAttended = "NA";
+	/** Set Assignment Status.
+		@param AssignmentStatus 
+		Operational status: PL(Planned), PC(ToCoordinate), IP(InProgress), CO(Confirmed), PA(PendingAuth), AP(Approved), CA(Cancelled), NA(NotAttended)
+	  */
+	public void setAssignmentStatus (String AssignmentStatus)
+	{
+
+		set_Value (COLUMNNAME_AssignmentStatus, AssignmentStatus);
+	}
+
+	/** Get Assignment Status.
+		@return Operational status: PL(Planned), PC(ToCoordinate), IP(InProgress), CO(Confirmed), PA(PendingAuth), AP(Approved), CA(Cancelled), NA(NotAttended)
+	  */
+	public String getAssignmentStatus () 
+	{
+		return (String)get_Value(COLUMNNAME_AssignmentStatus);
+	}
+
+	public I_C_Activity getC_Activity() throws RuntimeException
+    {
+		return (I_C_Activity)MTable.get(getCtx(), I_C_Activity.Table_Name)
+			.getPO(getC_Activity_ID(), get_TrxName());	}
+
+	/** Set Activity.
+		@param C_Activity_ID 
+		Business Activity
+	  */
+	public void setC_Activity_ID (int C_Activity_ID)
+	{
+		if (C_Activity_ID < 1) 
+			set_Value (COLUMNNAME_C_Activity_ID, null);
+		else 
+			set_Value (COLUMNNAME_C_Activity_ID, Integer.valueOf(C_Activity_ID));
+	}
+
+	/** Get Activity.
+		@return Business Activity
+	  */
+	public int getC_Activity_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_C_Activity_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public I_C_BPartner getC_BPartner() throws RuntimeException
+    {
+		return (I_C_BPartner)MTable.get(getCtx(), I_C_BPartner.Table_Name)
+			.getPO(getC_BPartner_ID(), get_TrxName());	}
+
+	/** Set Business Partner .
+		@param C_BPartner_ID 
+		Identifies a Business Partner
+	  */
+	public void setC_BPartner_ID (int C_BPartner_ID)
+	{
+		if (C_BPartner_ID < 1) 
+			set_Value (COLUMNNAME_C_BPartner_ID, null);
+		else 
+			set_Value (COLUMNNAME_C_BPartner_ID, Integer.valueOf(C_BPartner_ID));
+	}
+
+	/** Get Business Partner .
+		@return Identifies a Business Partner
+	  */
+	public int getC_BPartner_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_C_BPartner_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public I_C_BPartner_Location getC_BPartner_Location() throws RuntimeException
+    {
+		return (I_C_BPartner_Location)MTable.get(getCtx(), I_C_BPartner_Location.Table_Name)
+			.getPO(getC_BPartner_Location_ID(), get_TrxName());	}
+
+	/** Set Partner Location.
+		@param C_BPartner_Location_ID 
+		Identifies the (ship to) address for this Business Partner
+	  */
+	public void setC_BPartner_Location_ID (int C_BPartner_Location_ID)
+	{
+		if (C_BPartner_Location_ID < 1) 
+			set_Value (COLUMNNAME_C_BPartner_Location_ID, null);
+		else 
+			set_Value (COLUMNNAME_C_BPartner_Location_ID, Integer.valueOf(C_BPartner_Location_ID));
+	}
+
+	/** Get Partner Location.
+		@return Identifies the (ship to) address for this Business Partner
+	  */
+	public int getC_BPartner_Location_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_C_BPartner_Location_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public I_C_Campaign getC_Campaign() throws RuntimeException
+    {
+		return (I_C_Campaign)MTable.get(getCtx(), I_C_Campaign.Table_Name)
+			.getPO(getC_Campaign_ID(), get_TrxName());	}
+
+	/** Set Campaign.
+		@param C_Campaign_ID 
+		Marketing Campaign
+	  */
+	public void setC_Campaign_ID (int C_Campaign_ID)
+	{
+		if (C_Campaign_ID < 1) 
+			set_Value (COLUMNNAME_C_Campaign_ID, null);
+		else 
+			set_Value (COLUMNNAME_C_Campaign_ID, Integer.valueOf(C_Campaign_ID));
+	}
+
+	/** Get Campaign.
+		@return Marketing Campaign
+	  */
+	public int getC_Campaign_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_C_Campaign_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public I_C_Project getC_Project() throws RuntimeException
+    {
+		return (I_C_Project)MTable.get(getCtx(), I_C_Project.Table_Name)
+			.getPO(getC_Project_ID(), get_TrxName());	}
+
+	/** Set Project.
+		@param C_Project_ID 
+		Financial Project
+	  */
+	public void setC_Project_ID (int C_Project_ID)
+	{
+		if (C_Project_ID < 1) 
+			set_Value (COLUMNNAME_C_Project_ID, null);
+		else 
+			set_Value (COLUMNNAME_C_Project_ID, Integer.valueOf(C_Project_ID));
+	}
+
+	/** Get Project.
+		@return Financial Project
+	  */
+	public int getC_Project_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_C_Project_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** Set Description.
+		@param Description 
+		Optional short description of the record
+	  */
+	public void setDescription (String Description)
+	{
+		set_Value (COLUMNNAME_Description, Description);
+	}
+
+	/** Get Description.
+		@return Optional short description of the record
+	  */
+	public String getDescription () 
+	{
+		return (String)get_Value(COLUMNNAME_Description);
+	}
+
+	public org.adempiere.core.domains.models.I_HR_Leave getHR_Leave() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_HR_Leave)MTable.get(getCtx(), org.adempiere.core.domains.models.I_HR_Leave.Table_Name)
+			.getPO(getHR_Leave_ID(), get_TrxName());	}
+
+	/** Set Leave.
+		@param HR_Leave_ID 
+		The Leave Credit History of an Employee
+	  */
+	public void setHR_Leave_ID (int HR_Leave_ID)
+	{
+		if (HR_Leave_ID < 1) 
+			set_Value (COLUMNNAME_HR_Leave_ID, null);
+		else 
+			set_Value (COLUMNNAME_HR_Leave_ID, Integer.valueOf(HR_Leave_ID));
+	}
+
+	/** Get Leave.
+		@return The Leave Credit History of an Employee
+	  */
+	public int getHR_Leave_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_HR_Leave_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** Set Confirmed.
+		@param IsConfirmed 
+		Assignment is confirmed
+	  */
+	public void setIsConfirmed (boolean IsConfirmed)
+	{
+		set_ValueNoCheck (COLUMNNAME_IsConfirmed, Boolean.valueOf(IsConfirmed));
+	}
+
+	/** Get Confirmed.
+		@return Assignment is confirmed
+	  */
+	public boolean isConfirmed () 
+	{
+		Object oo = get_Value(COLUMNNAME_IsConfirmed);
+		if (oo != null) 
+		{
+			 if (oo instanceof Boolean) 
+				 return ((Boolean)oo).booleanValue(); 
+			return "Y".equals(oo);
+		}
+		return false;
+	}
+
+	/** Set Manually Modified.
+		@param IsManuallyModified 
+		When Y, this assignment is protected from automatic regeneration by plan changes
+	  */
+	public void setIsManuallyModified (boolean IsManuallyModified)
+	{
+		set_Value (COLUMNNAME_IsManuallyModified, Boolean.valueOf(IsManuallyModified));
+	}
+
+	/** Get Manually Modified.
+		@return When Y, this assignment is protected from automatic regeneration by plan changes
+	  */
+	public boolean isManuallyModified () 
+	{
+		Object oo = get_Value(COLUMNNAME_IsManuallyModified);
+		if (oo != null) 
+		{
+			 if (oo instanceof Boolean) 
+				 return ((Boolean)oo).booleanValue(); 
+			return "Y".equals(oo);
+		}
+		return false;
+	}
+
+	/** Set Name.
+		@param Name 
+		Alphanumeric identifier of the entity
+	  */
+	public void setName (String Name)
+	{
+		set_Value (COLUMNNAME_Name, Name);
+	}
+
+	/** Get Name.
+		@return Alphanumeric identifier of the entity
+	  */
+	public String getName () 
+	{
+		return (String)get_Value(COLUMNNAME_Name);
+	}
+
+	public org.adempiere.core.domains.models.I_S_Resource getPreviousResource() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_S_Resource)MTable.get(getCtx(), org.adempiere.core.domains.models.I_S_Resource.Table_Name)
+			.getPO(getPreviousResource_ID(), get_TrxName());	}
+
+	/** Set Previous Resource.
+		@param PreviousResource_ID 
+		Resource that was assigned before the last modification. Audit trail.
+	  */
+	public void setPreviousResource_ID (int PreviousResource_ID)
+	{
+		if (PreviousResource_ID < 1) 
+			set_Value (COLUMNNAME_PreviousResource_ID, null);
+		else 
+			set_Value (COLUMNNAME_PreviousResource_ID, Integer.valueOf(PreviousResource_ID));
+	}
+
+	/** Get Previous Resource.
+		@return Resource that was assigned before the last modification. Audit trail.
+	  */
+	public int getPreviousResource_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_PreviousResource_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** Set Quantity.
+		@param Qty 
+		Quantity
+	  */
+	public void setQty (BigDecimal Qty)
+	{
+		set_ValueNoCheck (COLUMNNAME_Qty, Qty);
+	}
+
+	/** Get Quantity.
+		@return Quantity
+	  */
+	public BigDecimal getQty () 
+	{
+		BigDecimal bd = (BigDecimal)get_Value(COLUMNNAME_Qty);
+		if (bd == null)
+			 return Env.ZERO;
+		return bd;
+	}
+
+	/** Set Replan Reason.
+		@param ReplanReason 
+		Free text reason entered by coordinator when replanning this assignment
+	  */
+	public void setReplanReason (String ReplanReason)
+	{
+		set_Value (COLUMNNAME_ReplanReason, ReplanReason);
+	}
+
+	/** Get Replan Reason.
+		@return Free text reason entered by coordinator when replanning this assignment
+	  */
+	public String getReplanReason () 
+	{
+		return (String)get_Value(COLUMNNAME_ReplanReason);
+	}
+
+	public I_R_Request getR_Request() throws RuntimeException
+	{
+		return (I_R_Request)MTable.get(getCtx(), I_R_Request.Table_Name)
+				.getPO(getR_Request_ID(), get_TrxName());	}
+
+	/** Set Request.
+		@param R_Request_ID
+		Request from a Business Partner or Prospect
+	  */
+	public void setR_Request_ID (int R_Request_ID)
+	{
+		if (R_Request_ID < 1)
+			set_Value (COLUMNNAME_R_Request_ID, null);
+		else
+			set_Value (COLUMNNAME_R_Request_ID, Integer.valueOf(R_Request_ID));
+	}
+
+	/** Get Request.
+		@return Request from a Business Partner or Prospect
+	  */
+	public int getR_Request_ID ()
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_R_Request_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public I_S_Contract getS_Contract() throws RuntimeException
+	{
+		return (I_S_Contract)MTable.get(getCtx(), I_S_Contract.Table_Name)
+				.getPO(getS_Contract_ID(), get_TrxName());	}
+
+	/** Set Contract.
+	 @param S_Contract_ID
+	 Contract
+	 */
+	public void setS_Contract_ID (int S_Contract_ID)
+	{
+		if (S_Contract_ID < 1)
+			set_Value (COLUMNNAME_S_Contract_ID, null);
+		else
+			set_Value (COLUMNNAME_S_Contract_ID, Integer.valueOf(S_Contract_ID));
+	}
+
+	/** Get Contract.
+	 @return Contract
+	 */
+	public int getS_Contract_ID ()
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_S_Contract_ID);
+		if (ii == null)
+			return 0;
+		return ii.intValue();
+	}
+
+	public org.adempiere.core.domains.models.I_S_ContractLine getS_ContractLine() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_S_ContractLine)MTable.get(getCtx(), org.adempiere.core.domains.models.I_S_ContractLine.Table_Name)
+			.getPO(getS_ContractLine_ID(), get_TrxName());	}
+
+	/** Set ContractLine.
+		@param S_ContractLine_ID 
+		ContractLine
+	  */
+	public void setS_ContractLine_ID (int S_ContractLine_ID)
+	{
+		if (S_ContractLine_ID < 1) 
+			set_Value (COLUMNNAME_S_ContractLine_ID, null);
+		else 
+			set_Value (COLUMNNAME_S_ContractLine_ID, Integer.valueOf(S_ContractLine_ID));
+	}
+
+	/** Get ContractLine.
+		@return ContractLine
+	  */
+	public int getS_ContractLine_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_S_ContractLine_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** Set Resource Assignment.
+		@param S_ResourceAssignment_ID 
+		Resource Assignment
+	  */
+	public void setS_ResourceAssignment_ID (int S_ResourceAssignment_ID)
+	{
+		if (S_ResourceAssignment_ID < 1) 
+			set_ValueNoCheck (COLUMNNAME_S_ResourceAssignment_ID, null);
+		else 
+			set_ValueNoCheck (COLUMNNAME_S_ResourceAssignment_ID, Integer.valueOf(S_ResourceAssignment_ID));
+	}
+
+	/** Get Resource Assignment.
+		@return Resource Assignment
+	  */
+	public int getS_ResourceAssignment_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_S_ResourceAssignment_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public org.adempiere.core.domains.models.I_S_Resource getS_Resource() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_S_Resource)MTable.get(getCtx(), org.adempiere.core.domains.models.I_S_Resource.Table_Name)
+			.getPO(getS_Resource_ID(), get_TrxName());	}
+
+	/** Set Resource.
+		@param S_Resource_ID 
+		Resource
+	  */
+	public void setS_Resource_ID (int S_Resource_ID)
+	{
+		if (S_Resource_ID < 1) 
+			set_ValueNoCheck (COLUMNNAME_S_Resource_ID, null);
+		else 
+			set_ValueNoCheck (COLUMNNAME_S_Resource_ID, Integer.valueOf(S_Resource_ID));
+	}
+
+	/** Get Resource.
+		@return Resource
+	  */
+	public int getS_Resource_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_S_Resource_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+    /** Get Record ID/ColumnName
+        @return ID/ColumnName pair
+      */
+    public KeyNamePair getKeyNamePair() 
+    {
+        return new KeyNamePair(get_ID(), String.valueOf(getS_Resource_ID()));
+    }
+
+	public org.adempiere.core.domains.models.I_S_Resource getS_Resource_Plan() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_S_Resource)MTable.get(getCtx(), org.adempiere.core.domains.models.I_S_Resource.Table_Name)
+			.getPO(getS_Resource_Plan_ID(), get_TrxName());	}
+
+	/** Set Plan Resource.
+		@param S_Resource_Plan_ID 
+		Original titular resource as defined in the service plan. NEVER modified after creation.
+	  */
+	public void setS_Resource_Plan_ID (int S_Resource_Plan_ID)
+	{
+		if (S_Resource_Plan_ID < 1) 
+			set_Value (COLUMNNAME_S_Resource_Plan_ID, null);
+		else 
+			set_Value (COLUMNNAME_S_Resource_Plan_ID, Integer.valueOf(S_Resource_Plan_ID));
+	}
+
+	/** Get Plan Resource.
+		@return Original titular resource as defined in the service plan. NEVER modified after creation.
+	  */
+	public int getS_Resource_Plan_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_S_Resource_Plan_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public org.adempiere.core.domains.models.I_S_ServicePlan getS_ServicePlan() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_S_ServicePlan)MTable.get(getCtx(), org.adempiere.core.domains.models.I_S_ServicePlan.Table_Name)
+			.getPO(getS_ServicePlan_ID(), get_TrxName());	}
+
+	/** Set Service Plan ID.
+		@param S_ServicePlan_ID 
+		Operational service plan
+	  */
+	public void setS_ServicePlan_ID (int S_ServicePlan_ID)
+	{
+		if (S_ServicePlan_ID < 1) 
+			set_Value (COLUMNNAME_S_ServicePlan_ID, null);
+		else 
+			set_Value (COLUMNNAME_S_ServicePlan_ID, Integer.valueOf(S_ServicePlan_ID));
+	}
+
+	/** Get Service Plan ID.
+		@return Operational service plan
+	  */
+	public int getS_ServicePlan_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_S_ServicePlan_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public org.adempiere.core.domains.models.I_S_ServiceSchedule getS_ServiceSchedule() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_S_ServiceSchedule)MTable.get(getCtx(), org.adempiere.core.domains.models.I_S_ServiceSchedule.Table_Name)
+			.getPO(getS_ServiceSchedule_ID(), get_TrxName());	}
+
+	/** Set Service Schedule ID.
+		@param S_ServiceSchedule_ID 
+		Weekly visit pattern for a service plan
+	  */
+	public void setS_ServiceSchedule_ID (int S_ServiceSchedule_ID)
+	{
+		if (S_ServiceSchedule_ID < 1) 
+			set_Value (COLUMNNAME_S_ServiceSchedule_ID, null);
+		else 
+			set_Value (COLUMNNAME_S_ServiceSchedule_ID, Integer.valueOf(S_ServiceSchedule_ID));
+	}
+
+	/** Get Service Schedule ID.
+		@return Weekly visit pattern for a service plan
+	  */
+	public int getS_ServiceSchedule_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_S_ServiceSchedule_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public I_C_ElementValue getUser1() throws RuntimeException
+    {
+		return (I_C_ElementValue)MTable.get(getCtx(), I_C_ElementValue.Table_Name)
+			.getPO(getUser1_ID(), get_TrxName());	}
+
+	/** Set User List 1.
+		@param User1_ID 
+		User defined list element #1
+	  */
+	public void setUser1_ID (int User1_ID)
+	{
+		if (User1_ID < 1) 
+			set_Value (COLUMNNAME_User1_ID, null);
+		else 
+			set_Value (COLUMNNAME_User1_ID, Integer.valueOf(User1_ID));
+	}
+
+	/** Get User List 1.
+		@return User defined list element #1
+	  */
+	public int getUser1_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_User1_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public I_C_ElementValue getUser2() throws RuntimeException
+    {
+		return (I_C_ElementValue)MTable.get(getCtx(), I_C_ElementValue.Table_Name)
+			.getPO(getUser2_ID(), get_TrxName());	}
+
+	/** Set User List 2.
+		@param User2_ID 
+		User defined list element #2
+	  */
+	public void setUser2_ID (int User2_ID)
+	{
+		if (User2_ID < 1) 
+			set_Value (COLUMNNAME_User2_ID, null);
+		else 
+			set_Value (COLUMNNAME_User2_ID, Integer.valueOf(User2_ID));
+	}
+
+	/** Get User List 2.
+		@return User defined list element #2
+	  */
+	public int getUser2_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_User2_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public I_C_ElementValue getUser3() throws RuntimeException
+    {
+		return (I_C_ElementValue)MTable.get(getCtx(), I_C_ElementValue.Table_Name)
+			.getPO(getUser3_ID(), get_TrxName());	}
+
+	/** Set User List 3.
+		@param User3_ID 
+		User defined list element #3
+	  */
+	public void setUser3_ID (int User3_ID)
+	{
+		if (User3_ID < 1) 
+			set_Value (COLUMNNAME_User3_ID, null);
+		else 
+			set_Value (COLUMNNAME_User3_ID, Integer.valueOf(User3_ID));
+	}
+
+	/** Get User List 3.
+		@return User defined list element #3
+	  */
+	public int getUser3_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_User3_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public I_C_ElementValue getUser4() throws RuntimeException
+    {
+		return (I_C_ElementValue)MTable.get(getCtx(), I_C_ElementValue.Table_Name)
+			.getPO(getUser4_ID(), get_TrxName());	}
+
+	/** Set User List 4.
+		@param User4_ID 
+		User defined list element #4
+	  */
+	public void setUser4_ID (int User4_ID)
+	{
+		if (User4_ID < 1) 
+			set_Value (COLUMNNAME_User4_ID, null);
+		else 
+			set_Value (COLUMNNAME_User4_ID, Integer.valueOf(User4_ID));
+	}
+
+	/** Get User List 4.
+		@return User defined list element #4
+	  */
+	public int getUser4_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_User4_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** Set Immutable Universally Unique Identifier.
+		@param UUID 
+		Immutable Universally Unique Identifier
+	  */
+	public void setUUID (String UUID)
+	{
+		set_Value (COLUMNNAME_UUID, UUID);
+	}
+
+	/** Get Immutable Universally Unique Identifier.
+		@return Immutable Universally Unique Identifier
+	  */
+	public String getUUID () 
+	{
+		return (String)get_Value(COLUMNNAME_UUID);
+	}
+}

--- a/src/patches/java/org/adempiere/core/domains/models/X_S_ServicePlan.java
+++ b/src/patches/java/org/adempiere/core/domains/models/X_S_ServicePlan.java
@@ -1,0 +1,487 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2017 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * or (at your option) any later version.                                     *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net                                                  *
+ * or https://github.com/adempiere/adempiere/blob/develop/license.html        *
+ *****************************************************************************/
+/** Generated Model - DO NOT CHANGE */
+package org.adempiere.core.domains.models;
+
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.util.Properties;
+import org.compiere.model.I_Persistent;
+import org.compiere.model.MTable;
+import org.compiere.model.PO;
+import org.compiere.model.POInfo;
+import org.compiere.util.Env;
+
+/** Generated Model for S_ServicePlan
+ *  @author Adempiere (generated) 
+ *  @version Release 3.9.4 - $Id$ */
+public class X_S_ServicePlan extends PO implements I_S_ServicePlan, I_Persistent 
+{
+
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 20260806L;
+
+    /** Standard Constructor */
+    public X_S_ServicePlan (Properties ctx, int S_ServicePlan_ID, String trxName)
+    {
+      super (ctx, S_ServicePlan_ID, trxName);
+      /** if (S_ServicePlan_ID == 0)
+        {
+			setDocStatus (null);
+// DR
+			setFrequencyType (null);
+// W
+			setIsBillable (true);
+// Y
+			setS_ServicePlan_ID (0);
+			setValidFrom (new Timestamp( System.currentTimeMillis() ));
+// @#Date@
+        } */
+    }
+
+    /** Load Constructor */
+    public X_S_ServicePlan (Properties ctx, ResultSet rs, String trxName)
+    {
+      super (ctx, rs, trxName);
+    }
+
+    /** AccessLevel
+      * @return 3 - Client - Org 
+      */
+    protected int get_AccessLevel()
+    {
+      return accessLevel.intValue();
+    }
+
+    /** Load Meta Data */
+    protected POInfo initPO (Properties ctx)
+    {
+      POInfo poi = POInfo.getPOInfo (ctx, Table_ID, get_TrxName());
+      return poi;
+    }
+
+    public String toString()
+    {
+      StringBuffer sb = new StringBuffer ("X_S_ServicePlan[")
+        .append(get_ID()).append("]");
+      return sb.toString();
+    }
+
+	public org.adempiere.core.domains.models.I_AD_User getAD_User() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_AD_User)MTable.get(getCtx(), org.adempiere.core.domains.models.I_AD_User.Table_Name)
+			.getPO(getAD_User_ID(), get_TrxName());	}
+
+	/** Set User/Contact.
+		@param AD_User_ID 
+		User within the system - Internal or Business Partner Contact
+	  */
+	public void setAD_User_ID (int AD_User_ID)
+	{
+		if (AD_User_ID < 1) 
+			set_Value (COLUMNNAME_AD_User_ID, null);
+		else 
+			set_Value (COLUMNNAME_AD_User_ID, Integer.valueOf(AD_User_ID));
+	}
+
+	/** Get User/Contact.
+		@return User within the system - Internal or Business Partner Contact
+	  */
+	public int getAD_User_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_AD_User_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public org.adempiere.core.domains.models.I_C_BPartner getC_BPartner() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_C_BPartner)MTable.get(getCtx(), org.adempiere.core.domains.models.I_C_BPartner.Table_Name)
+			.getPO(getC_BPartner_ID(), get_TrxName());	}
+
+	/** Set Business Partner .
+		@param C_BPartner_ID 
+		Identifies a Business Partner
+	  */
+	public void setC_BPartner_ID (int C_BPartner_ID)
+	{
+		if (C_BPartner_ID < 1) 
+			set_Value (COLUMNNAME_C_BPartner_ID, null);
+		else 
+			set_Value (COLUMNNAME_C_BPartner_ID, Integer.valueOf(C_BPartner_ID));
+	}
+
+	/** Get Business Partner .
+		@return Identifies a Business Partner
+	  */
+	public int getC_BPartner_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_C_BPartner_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public org.adempiere.core.domains.models.I_C_BPartner_Location getC_BPartner_Location() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_C_BPartner_Location)MTable.get(getCtx(), org.adempiere.core.domains.models.I_C_BPartner_Location.Table_Name)
+			.getPO(getC_BPartner_Location_ID(), get_TrxName());	}
+
+	/** Set Partner Location.
+		@param C_BPartner_Location_ID 
+		Identifies the (ship to) address for this Business Partner
+	  */
+	public void setC_BPartner_Location_ID (int C_BPartner_Location_ID)
+	{
+		if (C_BPartner_Location_ID < 1) 
+			set_Value (COLUMNNAME_C_BPartner_Location_ID, null);
+		else 
+			set_Value (COLUMNNAME_C_BPartner_Location_ID, Integer.valueOf(C_BPartner_Location_ID));
+	}
+
+	/** Get Partner Location.
+		@return Identifies the (ship to) address for this Business Partner
+	  */
+	public int getC_BPartner_Location_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_C_BPartner_Location_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** Set Description.
+		@param Description 
+		Optional short description of the record
+	  */
+	public void setDescription (String Description)
+	{
+		set_Value (COLUMNNAME_Description, Description);
+	}
+
+	/** Get Description.
+		@return Optional short description of the record
+	  */
+	public String getDescription () 
+	{
+		return (String)get_Value(COLUMNNAME_Description);
+	}
+
+	/** DocStatus AD_Reference_ID=131 */
+	public static final int DOCSTATUS_AD_Reference_ID=131;
+	/** Drafted = DR */
+	public static final String DOCSTATUS_Drafted = "DR";
+	/** Completed = CO */
+	public static final String DOCSTATUS_Completed = "CO";
+	/** Approved = AP */
+	public static final String DOCSTATUS_Approved = "AP";
+	/** Not Approved = NA */
+	public static final String DOCSTATUS_NotApproved = "NA";
+	/** Voided = VO */
+	public static final String DOCSTATUS_Voided = "VO";
+	/** Invalid = IN */
+	public static final String DOCSTATUS_Invalid = "IN";
+	/** Reversed = RE */
+	public static final String DOCSTATUS_Reversed = "RE";
+	/** Closed = CL */
+	public static final String DOCSTATUS_Closed = "CL";
+	/** Unknown = ?? */
+	public static final String DOCSTATUS_Unknown = "??";
+	/** In Progress = IP */
+	public static final String DOCSTATUS_InProgress = "IP";
+	/** Waiting Payment = WP */
+	public static final String DOCSTATUS_WaitingPayment = "WP";
+	/** Waiting Confirmation = WC */
+	public static final String DOCSTATUS_WaitingConfirmation = "WC";
+	/** Set Document Status.
+		@param DocStatus 
+		The current status of the document
+	  */
+	public void setDocStatus (String DocStatus)
+	{
+
+		set_Value (COLUMNNAME_DocStatus, DocStatus);
+	}
+
+	/** Get Document Status.
+		@return The current status of the document
+	  */
+	public String getDocStatus () 
+	{
+		return (String)get_Value(COLUMNNAME_DocStatus);
+	}
+
+	/** FrequencyType AD_Reference_ID=54622 */
+	public static final int FREQUENCYTYPE_AD_Reference_ID=54622;
+	/** Weekly = W */
+	public static final String FREQUENCYTYPE_Weekly = "W";
+	/** Biweekly = BW */
+	public static final String FREQUENCYTYPE_Biweekly = "BW";
+	/** Monthly = M */
+	public static final String FREQUENCYTYPE_Monthly = "M";
+	/** One-time = O */
+	public static final String FREQUENCYTYPE_One_Time = "O";
+	/** Set Frequency Type.
+		@param FrequencyType 
+		Frequency of event
+	  */
+	public void setFrequencyType (String FrequencyType)
+	{
+
+		set_Value (COLUMNNAME_FrequencyType, FrequencyType);
+	}
+
+	/** Get Frequency Type.
+		@return Frequency of event
+	  */
+	public String getFrequencyType () 
+	{
+		return (String)get_Value(COLUMNNAME_FrequencyType);
+	}
+
+	/** Set Billable.
+		@param IsBillable 
+		Whether hours from this plan are billed to the client
+	  */
+	public void setIsBillable (boolean IsBillable)
+	{
+		set_Value (COLUMNNAME_IsBillable, Boolean.valueOf(IsBillable));
+	}
+
+	/** Get Billable.
+		@return Whether hours from this plan are billed to the client
+	  */
+	public boolean isBillable () 
+	{
+		Object oo = get_Value(COLUMNNAME_IsBillable);
+		if (oo != null) 
+		{
+			 if (oo instanceof Boolean) 
+				 return ((Boolean)oo).booleanValue(); 
+			return "Y".equals(oo);
+		}
+		return false;
+	}
+
+	public org.adempiere.core.domains.models.I_S_Contract getS_Contract() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_S_Contract)MTable.get(getCtx(), org.adempiere.core.domains.models.I_S_Contract.Table_Name)
+			.getPO(getS_Contract_ID(), get_TrxName());	}
+
+	/** Set Contract.
+		@param S_Contract_ID 
+		Contract
+	  */
+	public void setS_Contract_ID (int S_Contract_ID)
+	{
+		if (S_Contract_ID < 1) 
+			set_Value (COLUMNNAME_S_Contract_ID, null);
+		else 
+			set_Value (COLUMNNAME_S_Contract_ID, Integer.valueOf(S_Contract_ID));
+	}
+
+	/** Get Contract.
+		@return Contract
+	  */
+	public int getS_Contract_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_S_Contract_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public org.adempiere.core.domains.models.I_S_ContractLine getS_ContractLine() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_S_ContractLine)MTable.get(getCtx(), org.adempiere.core.domains.models.I_S_ContractLine.Table_Name)
+			.getPO(getS_ContractLine_ID(), get_TrxName());	}
+
+	/** Set ContractLine.
+		@param S_ContractLine_ID 
+		ContractLine
+	  */
+	public void setS_ContractLine_ID (int S_ContractLine_ID)
+	{
+		if (S_ContractLine_ID < 1) 
+			set_Value (COLUMNNAME_S_ContractLine_ID, null);
+		else 
+			set_Value (COLUMNNAME_S_ContractLine_ID, Integer.valueOf(S_ContractLine_ID));
+	}
+
+	/** Get ContractLine.
+		@return ContractLine
+	  */
+	public int getS_ContractLine_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_S_ContractLine_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public org.adempiere.core.domains.models.I_S_Resource getS_Resource() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_S_Resource)MTable.get(getCtx(), org.adempiere.core.domains.models.I_S_Resource.Table_Name)
+			.getPO(getS_Resource_ID(), get_TrxName());	}
+
+	/** Set Resource.
+		@param S_Resource_ID 
+		Resource
+	  */
+	public void setS_Resource_ID (int S_Resource_ID)
+	{
+		if (S_Resource_ID < 1) 
+			set_Value (COLUMNNAME_S_Resource_ID, null);
+		else 
+			set_Value (COLUMNNAME_S_Resource_ID, Integer.valueOf(S_Resource_ID));
+	}
+
+	/** Get Resource.
+		@return Resource
+	  */
+	public int getS_Resource_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_S_Resource_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public org.adempiere.core.domains.models.I_S_ResourceType getS_ResourceType() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_S_ResourceType)MTable.get(getCtx(), org.adempiere.core.domains.models.I_S_ResourceType.Table_Name)
+			.getPO(getS_ResourceType_ID(), get_TrxName());	}
+
+	/** Set Resource Type.
+		@param S_ResourceType_ID Resource Type	  */
+	public void setS_ResourceType_ID (int S_ResourceType_ID)
+	{
+		if (S_ResourceType_ID < 1) 
+			set_Value (COLUMNNAME_S_ResourceType_ID, null);
+		else 
+			set_Value (COLUMNNAME_S_ResourceType_ID, Integer.valueOf(S_ResourceType_ID));
+	}
+
+	/** Get Resource Type.
+		@return Resource Type	  */
+	public int getS_ResourceType_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_S_ResourceType_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** Set Service Plan ID.
+		@param S_ServicePlan_ID 
+		Operational service plan
+	  */
+	public void setS_ServicePlan_ID (int S_ServicePlan_ID)
+	{
+		if (S_ServicePlan_ID < 1) 
+			set_ValueNoCheck (COLUMNNAME_S_ServicePlan_ID, null);
+		else 
+			set_ValueNoCheck (COLUMNNAME_S_ServicePlan_ID, Integer.valueOf(S_ServicePlan_ID));
+	}
+
+	/** Get Service Plan ID.
+		@return Operational service plan
+	  */
+	public int getS_ServicePlan_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_S_ServicePlan_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** Set Total Weekly Hours.
+		@param TotalWeeklyHours 
+		Sum of planned hours per week for this service plan
+	  */
+	public void setTotalWeeklyHours (BigDecimal TotalWeeklyHours)
+	{
+		set_Value (COLUMNNAME_TotalWeeklyHours, TotalWeeklyHours);
+	}
+
+	/** Get Total Weekly Hours.
+		@return Sum of planned hours per week for this service plan
+	  */
+	public BigDecimal getTotalWeeklyHours () 
+	{
+		BigDecimal bd = (BigDecimal)get_Value(COLUMNNAME_TotalWeeklyHours);
+		if (bd == null)
+			 return Env.ZERO;
+		return bd;
+	}
+
+	/** Set Immutable Universally Unique Identifier.
+		@param UUID 
+		Immutable Universally Unique Identifier
+	  */
+	public void setUUID (String UUID)
+	{
+		set_Value (COLUMNNAME_UUID, UUID);
+	}
+
+	/** Get Immutable Universally Unique Identifier.
+		@return Immutable Universally Unique Identifier
+	  */
+	public String getUUID () 
+	{
+		return (String)get_Value(COLUMNNAME_UUID);
+	}
+
+	/** Set Valid from.
+		@param ValidFrom 
+		Valid from including this date (first day)
+	  */
+	public void setValidFrom (Timestamp ValidFrom)
+	{
+		set_Value (COLUMNNAME_ValidFrom, ValidFrom);
+	}
+
+	/** Get Valid from.
+		@return Valid from including this date (first day)
+	  */
+	public Timestamp getValidFrom () 
+	{
+		return (Timestamp)get_Value(COLUMNNAME_ValidFrom);
+	}
+
+	/** Set Valid to.
+		@param ValidTo 
+		Valid to including this date (last day)
+	  */
+	public void setValidTo (Timestamp ValidTo)
+	{
+		set_Value (COLUMNNAME_ValidTo, ValidTo);
+	}
+
+	/** Get Valid to.
+		@return Valid to including this date (last day)
+	  */
+	public Timestamp getValidTo () 
+	{
+		return (Timestamp)get_Value(COLUMNNAME_ValidTo);
+	}
+}

--- a/src/patches/java/org/adempiere/core/domains/models/X_S_ServiceSchedule.java
+++ b/src/patches/java/org/adempiere/core/domains/models/X_S_ServiceSchedule.java
@@ -1,0 +1,389 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2017 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * or (at your option) any later version.                                     *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net                                                  *
+ * or https://github.com/adempiere/adempiere/blob/develop/license.html        *
+ *****************************************************************************/
+/** Generated Model - DO NOT CHANGE */
+package org.adempiere.core.domains.models;
+
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.util.Properties;
+import org.compiere.model.I_Persistent;
+import org.compiere.model.MTable;
+import org.compiere.model.PO;
+import org.compiere.model.POInfo;
+import org.compiere.util.Env;
+
+/** Generated Model for S_ServiceSchedule
+ *  @author Adempiere (generated) 
+ *  @version Release 3.9.4 - $Id$ */
+public class X_S_ServiceSchedule extends PO implements I_S_ServiceSchedule, I_Persistent 
+{
+
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 20260806L;
+
+    /** Standard Constructor */
+    public X_S_ServiceSchedule (Properties ctx, int S_ServiceSchedule_ID, String trxName)
+    {
+      super (ctx, S_ServiceSchedule_ID, trxName);
+      /** if (S_ServiceSchedule_ID == 0)
+        {
+			setDayOfWeek (null);
+			setPlannedHours (Env.ZERO);
+			setS_ServicePlan_ID (0);
+			setS_ServiceSchedule_ID (0);
+			setTimeFrom (new Timestamp( System.currentTimeMillis() ));
+			setTimeTo (new Timestamp( System.currentTimeMillis() ));
+        } */
+    }
+
+    /** Load Constructor */
+    public X_S_ServiceSchedule (Properties ctx, ResultSet rs, String trxName)
+    {
+      super (ctx, rs, trxName);
+    }
+
+    /** AccessLevel
+      * @return 3 - Client - Org 
+      */
+    protected int get_AccessLevel()
+    {
+      return accessLevel.intValue();
+    }
+
+    /** Load Meta Data */
+    protected POInfo initPO (Properties ctx)
+    {
+      POInfo poi = POInfo.getPOInfo (ctx, Table_ID, get_TrxName());
+      return poi;
+    }
+
+    public String toString()
+    {
+      StringBuffer sb = new StringBuffer ("X_S_ServiceSchedule[")
+        .append(get_ID()).append("]");
+      return sb.toString();
+    }
+
+	public org.adempiere.core.domains.models.I_C_BPartner getC_BPartner() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_C_BPartner)MTable.get(getCtx(), org.adempiere.core.domains.models.I_C_BPartner.Table_Name)
+			.getPO(getC_BPartner_ID(), get_TrxName());	}
+
+	/** Set Business Partner .
+		@param C_BPartner_ID 
+		Identifies a Business Partner
+	  */
+	public void setC_BPartner_ID (int C_BPartner_ID)
+	{
+		if (C_BPartner_ID < 1) 
+			set_Value (COLUMNNAME_C_BPartner_ID, null);
+		else 
+			set_Value (COLUMNNAME_C_BPartner_ID, Integer.valueOf(C_BPartner_ID));
+	}
+
+	/** Get Business Partner .
+		@return Identifies a Business Partner
+	  */
+	public int getC_BPartner_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_C_BPartner_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public org.adempiere.core.domains.models.I_C_BPartner_Location getC_BPartner_Location() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_C_BPartner_Location)MTable.get(getCtx(), org.adempiere.core.domains.models.I_C_BPartner_Location.Table_Name)
+			.getPO(getC_BPartner_Location_ID(), get_TrxName());	}
+
+	/** Set Partner Location.
+		@param C_BPartner_Location_ID 
+		Identifies the (ship to) address for this Business Partner
+	  */
+	public void setC_BPartner_Location_ID (int C_BPartner_Location_ID)
+	{
+		if (C_BPartner_Location_ID < 1) 
+			set_Value (COLUMNNAME_C_BPartner_Location_ID, null);
+		else 
+			set_Value (COLUMNNAME_C_BPartner_Location_ID, Integer.valueOf(C_BPartner_Location_ID));
+	}
+
+	/** Get Partner Location.
+		@return Identifies the (ship to) address for this Business Partner
+	  */
+	public int getC_BPartner_Location_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_C_BPartner_Location_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** DayOfWeek AD_Reference_ID=167 */
+	public static final int DAYOFWEEK_AD_Reference_ID=167;
+	/** Sunday = 7 */
+	public static final String DAYOFWEEK_Sunday = "7";
+	/** Monday = 1 */
+	public static final String DAYOFWEEK_Monday = "1";
+	/** Tuesday = 2 */
+	public static final String DAYOFWEEK_Tuesday = "2";
+	/** Wednesday = 3 */
+	public static final String DAYOFWEEK_Wednesday = "3";
+	/** Thursday = 4 */
+	public static final String DAYOFWEEK_Thursday = "4";
+	/** Friday = 5 */
+	public static final String DAYOFWEEK_Friday = "5";
+	/** Saturday = 6 */
+	public static final String DAYOFWEEK_Saturday = "6";
+	/** Set Day of Week.
+		@param DayOfWeek 
+		Day of the week: 1=Monday, 2=Tuesday, ..., 7=Sunday (ISO 8601)
+	  */
+	public void setDayOfWeek (String DayOfWeek)
+	{
+
+		set_Value (COLUMNNAME_DayOfWeek, DayOfWeek);
+	}
+
+	/** Get Day of Week.
+		@return Day of the week: 1=Monday, 2=Tuesday, ..., 7=Sunday (ISO 8601)
+	  */
+	public String getDayOfWeek () 
+	{
+		return (String)get_Value(COLUMNNAME_DayOfWeek);
+	}
+
+	/** Set Description.
+		@param Description 
+		Optional short description of the record
+	  */
+	public void setDescription (String Description)
+	{
+		set_Value (COLUMNNAME_Description, Description);
+	}
+
+	/** Get Description.
+		@return Optional short description of the record
+	  */
+	public String getDescription () 
+	{
+		return (String)get_Value(COLUMNNAME_Description);
+	}
+
+	/** Set Planned Hours.
+		@param PlannedHours 
+		Planned duration in hours for this visit
+	  */
+	public void setPlannedHours (BigDecimal PlannedHours)
+	{
+		set_Value (COLUMNNAME_PlannedHours, PlannedHours);
+	}
+
+	/** Get Planned Hours.
+		@return Planned duration in hours for this visit
+	  */
+	public BigDecimal getPlannedHours () 
+	{
+		BigDecimal bd = (BigDecimal)get_Value(COLUMNNAME_PlannedHours);
+		if (bd == null)
+			 return Env.ZERO;
+		return bd;
+	}
+
+	public org.adempiere.core.domains.models.I_S_ContractLine getS_ContractLine() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_S_ContractLine)MTable.get(getCtx(), org.adempiere.core.domains.models.I_S_ContractLine.Table_Name)
+			.getPO(getS_ContractLine_ID(), get_TrxName());	}
+
+	/** Set ContractLine.
+		@param S_ContractLine_ID 
+		ContractLine
+	  */
+	public void setS_ContractLine_ID (int S_ContractLine_ID)
+	{
+		if (S_ContractLine_ID < 1) 
+			set_Value (COLUMNNAME_S_ContractLine_ID, null);
+		else 
+			set_Value (COLUMNNAME_S_ContractLine_ID, Integer.valueOf(S_ContractLine_ID));
+	}
+
+	/** Get ContractLine.
+		@return ContractLine
+	  */
+	public int getS_ContractLine_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_S_ContractLine_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public org.adempiere.core.domains.models.I_S_Resource getS_Resource() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_S_Resource)MTable.get(getCtx(), org.adempiere.core.domains.models.I_S_Resource.Table_Name)
+			.getPO(getS_Resource_ID(), get_TrxName());	}
+
+	/** Set Resource.
+		@param S_Resource_ID 
+		Resource
+	  */
+	public void setS_Resource_ID (int S_Resource_ID)
+	{
+		if (S_Resource_ID < 1) 
+			set_Value (COLUMNNAME_S_Resource_ID, null);
+		else 
+			set_Value (COLUMNNAME_S_Resource_ID, Integer.valueOf(S_Resource_ID));
+	}
+
+	/** Get Resource.
+		@return Resource
+	  */
+	public int getS_Resource_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_S_Resource_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public org.adempiere.core.domains.models.I_S_ServicePlan getS_ServicePlan() throws RuntimeException
+    {
+		return (org.adempiere.core.domains.models.I_S_ServicePlan)MTable.get(getCtx(), org.adempiere.core.domains.models.I_S_ServicePlan.Table_Name)
+			.getPO(getS_ServicePlan_ID(), get_TrxName());	}
+
+	/** Set Service Plan ID.
+		@param S_ServicePlan_ID 
+		Operational service plan
+	  */
+	public void setS_ServicePlan_ID (int S_ServicePlan_ID)
+	{
+		if (S_ServicePlan_ID < 1) 
+			set_ValueNoCheck (COLUMNNAME_S_ServicePlan_ID, null);
+		else 
+			set_ValueNoCheck (COLUMNNAME_S_ServicePlan_ID, Integer.valueOf(S_ServicePlan_ID));
+	}
+
+	/** Get Service Plan ID.
+		@return Operational service plan
+	  */
+	public int getS_ServicePlan_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_S_ServicePlan_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** Set Service Schedule ID.
+		@param S_ServiceSchedule_ID 
+		Weekly visit pattern for a service plan
+	  */
+	public void setS_ServiceSchedule_ID (int S_ServiceSchedule_ID)
+	{
+		if (S_ServiceSchedule_ID < 1) 
+			set_ValueNoCheck (COLUMNNAME_S_ServiceSchedule_ID, null);
+		else 
+			set_ValueNoCheck (COLUMNNAME_S_ServiceSchedule_ID, Integer.valueOf(S_ServiceSchedule_ID));
+	}
+
+	/** Get Service Schedule ID.
+		@return Weekly visit pattern for a service plan
+	  */
+	public int getS_ServiceSchedule_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_S_ServiceSchedule_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** Set Time (From).
+		@param TimeFrom 
+		Starting Time
+	  */
+	public void setTimeFrom (Timestamp TimeFrom)
+	{
+		set_Value (COLUMNNAME_TimeFrom, TimeFrom);
+	}
+
+	/** Get Time (From).
+		@return Starting Time
+	  */
+	public Timestamp getTimeFrom () 
+	{
+		return (Timestamp)get_Value(COLUMNNAME_TimeFrom);
+	}
+
+	/** Set Time (To).
+		@param TimeTo 
+		Ending Time
+	  */
+	public void setTimeTo (Timestamp TimeTo)
+	{
+		set_Value (COLUMNNAME_TimeTo, TimeTo);
+	}
+
+	/** Get Time (To).
+		@return Ending Time
+	  */
+	public Timestamp getTimeTo () 
+	{
+		return (Timestamp)get_Value(COLUMNNAME_TimeTo);
+	}
+
+	/** Set Immutable Universally Unique Identifier.
+		@param UUID 
+		Immutable Universally Unique Identifier
+	  */
+	public void setUUID (String UUID)
+	{
+		set_Value (COLUMNNAME_UUID, UUID);
+	}
+
+	/** Get Immutable Universally Unique Identifier.
+		@return Immutable Universally Unique Identifier
+	  */
+	public String getUUID () 
+	{
+		return (String)get_Value(COLUMNNAME_UUID);
+	}
+
+	/** Set Week of Month.
+		@param WeekOfMonth 
+		Which week of the month (1-5). Used for biweekly and monthly frequency
+	  */
+	public void setWeekOfMonth (int WeekOfMonth)
+	{
+		set_Value (COLUMNNAME_WeekOfMonth, Integer.valueOf(WeekOfMonth));
+	}
+
+	/** Get Week of Month.
+		@return Which week of the month (1-5). Used for biweekly and monthly frequency
+	  */
+	public int getWeekOfMonth () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_WeekOfMonth);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+}


### PR DESCRIPTION
Adds the `S_ContractLine` column to the HR and service scheduling tables, reflected in their generated interface (`I_`) and model (`X_`) classes under `org.adempiere.core.domains.models`.

Updated classes (accessor for the new `S_ContractLine` column added to each):
- `HR_AttendanceBatch` (I_/X_)
- `HR_AttendanceRecord` (I_/X_)
- `HR_Incidence` (I_/X_)
- `S_ServicePlan` (I_/X_)
- `S_ServiceSchedule` (I_/X_)
- `S_ResourceAssignment` (I_/X_)
