### PR TITLE
feat: add organization auto-complete settings for attendance batch and incidence

### DIFF
--- a/src/patches/java/org/adempiere/core/domains/models/I_AD_OrgInfo.java
+++ b/src/patches/java/org/adempiere/core/domains/models/I_AD_OrgInfo.java
@@ -318,6 +318,24 @@ public interface I_AD_OrgInfo
 	/** Get Allows Overdraft Document	  */
 	public boolean isAllowOverdraftDocument();
 
+    /** Column name IsAutoCompleteAttendanceBatch */
+    public static final String COLUMNNAME_IsAutoCompleteAttendanceBatch = "IsAutoCompleteAttendanceBatch";
+
+	/** Set Auto Complete Attendance Batch	  */
+	public void setIsAutoCompleteAttendanceBatch (String IsAutoCompleteAttendanceBatch);
+
+	/** Get Auto Complete Attendance Batch	  */
+	public String getIsAutoCompleteAttendanceBatch();
+
+    /** Column name IsAutoCompleteIncidence */
+    public static final String COLUMNNAME_IsAutoCompleteIncidence = "IsAutoCompleteIncidence";
+
+	/** Set Auto Complete Incidence	  */
+	public void setIsAutoCompleteIncidence (String IsAutoCompleteIncidence);
+
+	/** Get Auto Complete Incidence	  */
+	public String getIsAutoCompleteIncidence();
+
     /** Column name IsRequiresToleranceApproval */
     public static final String COLUMNNAME_IsRequiresToleranceApproval = "IsRequiresToleranceApproval";
 

--- a/src/patches/java/org/adempiere/core/domains/models/X_AD_OrgInfo.java
+++ b/src/patches/java/org/adempiere/core/domains/models/X_AD_OrgInfo.java
@@ -491,6 +491,48 @@ public class X_AD_OrgInfo extends PO implements I_AD_OrgInfo, I_Persistent
 		return false;
 	}
 
+	/** IsAutoCompleteAttendanceBatch AD_Reference_ID=319 */
+	public static final int ISAUTOCOMPLETEATTENDANCEBATCH_AD_Reference_ID=319;
+	/** Yes = Y */
+	public static final String ISAUTOCOMPLETEATTENDANCEBATCH_Yes = "Y";
+	/** No = N */
+	public static final String ISAUTOCOMPLETEATTENDANCEBATCH_No = "N";
+	/** Set Auto Complete Attendance Batch.
+		@param IsAutoCompleteAttendanceBatch Auto Complete Attendance Batch	  */
+	public void setIsAutoCompleteAttendanceBatch (String IsAutoCompleteAttendanceBatch)
+	{
+
+		set_Value (COLUMNNAME_IsAutoCompleteAttendanceBatch, IsAutoCompleteAttendanceBatch);
+	}
+
+	/** Get Auto Complete Attendance Batch.
+		@return Auto Complete Attendance Batch	  */
+	public String getIsAutoCompleteAttendanceBatch ()
+	{
+		return (String)get_Value(COLUMNNAME_IsAutoCompleteAttendanceBatch);
+	}
+
+	/** IsAutoCompleteIncidence AD_Reference_ID=319 */
+	public static final int ISAUTOCOMPLETEINCIDENCE_AD_Reference_ID=319;
+	/** Yes = Y */
+	public static final String ISAUTOCOMPLETEINCIDENCE_Yes = "Y";
+	/** No = N */
+	public static final String ISAUTOCOMPLETEINCIDENCE_No = "N";
+	/** Set Auto Complete Incidence.
+		@param IsAutoCompleteIncidence Auto Complete Incidence	  */
+	public void setIsAutoCompleteIncidence (String IsAutoCompleteIncidence)
+	{
+
+		set_Value (COLUMNNAME_IsAutoCompleteIncidence, IsAutoCompleteIncidence);
+	}
+
+	/** Get Auto Complete Incidence.
+		@return Auto Complete Incidence	  */
+	public String getIsAutoCompleteIncidence ()
+	{
+		return (String)get_Value(COLUMNNAME_IsAutoCompleteIncidence);
+	}
+
 	/** IsRequiresToleranceApproval AD_Reference_ID=319 */
 	public static final int ISREQUIRESTOLERANCEAPPROVAL_AD_Reference_ID=319;
 	/** Yes = Y */

--- a/src/patches/java/org/spin/tar/model/MHRAttendanceBatch.java
+++ b/src/patches/java/org/spin/tar/model/MHRAttendanceBatch.java
@@ -22,6 +22,7 @@ import org.adempiere.core.domains.models.X_S_ServicePlan;
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.MBPartner;
 import org.compiere.model.MDocType;
+import org.compiere.model.MOrgInfo;
 import org.compiere.model.MPeriod;
 import org.compiere.model.MRule;
 import org.compiere.model.ModelValidationEngine;
@@ -791,10 +792,35 @@ public class MHRAttendanceBatch extends X_HR_AttendanceBatch implements DocActio
 		if(errorMessage.length() > 0) {
 			return errorMessage.toString();
 		}
+		completeIncidencesIfRequired();
 		//	default
 		return null;
 	}
-	
+
+	/**
+	 * Complete generated incidences when the organization is configured to create
+	 * them already completed (AD_OrgInfo.IsAutoCompleteIncidence = Y). When the
+	 * configuration is empty or N, the incidences keep their default draft status.
+	 */
+	private void completeIncidencesIfRequired() {
+		MOrgInfo orgInfo = MOrgInfo.get(getCtx(), getAD_Org_ID(), get_TrxName());
+		if(orgInfo == null
+				|| !"Y".equals(orgInfo.getIsAutoCompleteIncidence())) {
+			return;
+		}
+		int[] incidenceIds = new Query(getCtx(), MHRIncidence.Table_Name,
+				"HR_AttendanceBatch_ID = ? AND IsManual = 'N' AND DocStatus = ?", get_TrxName())
+			.setParameters(getHR_AttendanceBatch_ID(), DocAction.STATUS_Drafted)
+			.getIDs();
+		for(int incidenceId : incidenceIds) {
+			MHRIncidence incidence = new MHRIncidence(getCtx(), incidenceId, get_TrxName());
+			if(!incidence.processIt(DocAction.ACTION_Complete)) {
+				throw new AdempiereException("@ProcessRunError@ " + incidence.getProcessMsg());
+			}
+			incidence.saveEx();
+		}
+	}
+
 	/**
 	 * Get work shift for employee from:
 	 * - Shift Schedule for a Work Group


### PR DESCRIPTION
## Summary

Adds two organization-level settings on `AD_OrgInfo` (three-state Yes/No lists: empty, `Y`, `N`) and wires the incidence one into attendance batch processing.

## Changes

- **`X_AD_OrgInfo` / `I_AD_OrgInfo`**: add accessors for `IsAutoCompleteAttendanceBatch` and `IsAutoCompleteIncidence`, following the same Yes/No list reference used by the existing tolerance flags.
- **`MHRAttendanceBatch.processShiftIncidence`**: after the incidences are generated (only when the batch processed without errors), if the organization has `IsAutoCompleteIncidence = Y`, the drafted non-manual incidences of the batch are completed. When the setting is empty or `N`, incidences keep their current draft status — behavior is unchanged.

## Notes

- `IsAutoCompleteAttendanceBatch` is added to the model only; no processing logic consumes it yet.
- The columns are provided by the application dictionary; this change only adds the model accessors and the completion logic.
